### PR TITLE
Add dcesrv_mapiproxy:ndrdump parametric option to enable/disable ndrdump dump of EMSMDB/NSPI/RFR function

### DIFF
--- a/mapiproxy/dcesrv_mapiproxy.h
+++ b/mapiproxy/dcesrv_mapiproxy.h
@@ -53,6 +53,7 @@ struct dcesrv_mapiproxy_private {
 	char					*exchname;
 	bool					server_mode;
 	bool					connected;
+	bool					ndrdump;
 	struct cli_credentials			*credentials;
 };
 


### PR DESCRIPTION
The option is set to false by default.
