### PR TITLE
mapistore: Bypass Embedded message creation for Tasks in Outlook

### DIFF
--- a/mapiproxy/libmapistore/mapistore_interface.c
+++ b/mapiproxy/libmapistore/mapistore_interface.c
@@ -1591,6 +1591,11 @@ _PUBLIC_ enum mapistore_error mapistore_message_attachment_create_embedded_messa
 	backend_ctx = mapistore_backend_lookup(mstore_ctx->context_list, context_id);
 	MAPISTORE_RETVAL_IF(!backend_ctx, MAPISTORE_ERR_INVALID_PARAMETER, NULL);
 
+	/*
+		FIXME: This is needs to be fixed in SOGo backend.
+		At the moment, we are just going to skip all
+		requests against Tasks folder
+	*/
 	if (strstr(backend_ctx->uri, "@tasks") != NULL) {
 		return MAPI_E_NOT_IMPLEMENTED;
 	}


### PR DESCRIPTION
Right now SOGo back end doesn't support embedded messages in
a Task, which leads to a nasty runtime Obj-C exception.
This effectively kills openchange process, so it is better
we just return MAPI_E_NOT_IMPLEMENTED for such objects and continue
to work instead of breaking badly.

This is a temporary fix for: issues => 7345
