### PR TITLE
filter empty strings from ps -U 0

### DIFF
--- a/script/debugoc.py
+++ b/script/debugoc.py
@@ -69,7 +69,7 @@ def main():
 	for line in psbuffer.split('\n'):
 		if not 'samba' in line: continue
 		logger.info(line)
-		pid = line.split(' ')[0]
+		pid = filter(None, line.split(' '))[0]
 		fh = open('/proc/%s/maps' % pid, 'r')
 		try:
 			map = fh.read()


### PR DESCRIPTION
The script was not working for me without this fix:

```
>>> import subprocess
>>> ps = subprocess.Popen("ps -U 0", shell=True, stdout=subprocess.PIPE)
>>> parts = [line for line in ps.stdout.read().split('\n') if 'samba' in line]
>>> line = parts[0]
' 6411 pts/9    00:00:00 samba'
>>> line.split(' ')
['', '6411', 'pts/9', '', '', '', '00:00:00', 'samba']
>>> filter(None, _)
['6411', 'pts/9', '00:00:00', 'samba']
```
