### PR TITLE
Fix boost detection on newer versions of boost.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -481,7 +481,8 @@ AC_CACHE_CHECK([for boost_thread$BOOST_LIB_SUFFIX library], [ov_cv_boost_thread]
 		ov_save_LIBS=$LIBS
 		LIBS="-lboost_thread$BOOST_LIB_SUFFIX -lboost_system$BOOST_LIB_SUFFIX $LIBS"
 		AC_LANG_PUSH([C++])
-		AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <boost/thread.hpp>]],
+		AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdint.h>
+						#include <boost/thread.hpp>]],
 						[[boost::thread t]])],
 				[ov_cv_boost_thread=yes])
 		AC_LANG_POP([C++])


### PR DESCRIPTION
Without this, there is an error running the configure test,
unable to find uintptr_t.
