### PR TITLE
removed requirement for boost and build libmapi++ with C++ 11 std

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # # Makefile for OpenChange
 # Written by Jelmer Vernooij <jelmer@openchange.org>, 2005.
 
+# C++11 support
+CXX11FLAGS=-std=c++0x
+
 ifneq ($(MAKECMDGOALS), samba)
 ifneq ($(MAKECMDGOALS), samba-git)
 include config.mk
@@ -119,11 +122,11 @@ re:: clean install
 
 .cpp.o:
 	@echo "Compiling $< with -fPIC"
-	@$(CXX) $(CXXFLAGS) $(QT4_CXXFLAGS) -fPIC -c $< -o $@
+	@$(CXX) $(CXX11FLAGS) $(CXXFLAGS) $(QT4_CXXFLAGS) -fPIC -c $< -o $@
 
 .cpp.po:
 	@echo "Compiling $< with -fPIC"
-	@$(CXX) $(CXXFLAGS) -fPIC -c $< -o $@
+	@$(CXX) $(CXX11FLAGS) $(CXXFLAGS) -fPIC -c $< -o $@
 
 #################################################################
 # IDL compilation rules
@@ -350,7 +353,7 @@ libmapipp.$(SHLIBEXT).$(PACKAGE_VERSION): 	\
 	libmapi++/src/session.po \
 	libmapi.$(SHLIBEXT).$(LIBMAPI_SO_VERSION)
 	@echo "Linking $@"
-	@$(CXX) $(DSOOPT) $(CXXFLAGS) $(LDFLAGS) -Wl,-soname,libmapipp.$(SHLIBEXT).$(LIBMAPIPP_SO_VERSION) -o $@ $^ $(LIBS) 
+	@$(CXX) $(DSOOPT) $(CXX11FLAGS) $(CXXFLAGS) $(LDFLAGS) -Wl,-soname,libmapipp.$(SHLIBEXT).$(LIBMAPIPP_SO_VERSION) -o $@ $^ $(LIBS) 
 
 libmapixx-installpc:
 	@echo "[*] install: libmapi++ pc files"
@@ -431,7 +434,7 @@ bin/libmapixx-test:	libmapi++/tests/test.cpp	\
 		libmapipp.$(SHLIBEXT).$(PACKAGE_VERSION) \
 		libmapi.$(SHLIBEXT).$(PACKAGE_VERSION)
 	@echo "Linking sample application $@"
-	@$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS) 
+	@$(CXX) $(CXX11FLAGS) $(CXXFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS) 
 
 clean:: libmapixx-test-clean
 
@@ -446,7 +449,7 @@ bin/libmapixx-attach: libmapi++/tests/attach_test.po	\
 		libmapipp.$(SHLIBEXT).$(PACKAGE_VERSION) \
 		libmapi.$(SHLIBEXT).$(PACKAGE_VERSION)
 	@echo "Linking sample application $@"
-	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS)
+	@$(CXX) $(CXX11FLAGS) $(CXXFLAGS) -o $@ $^ $(LIBS)
 
 clean:: libmapixx-attach-clean
 
@@ -456,7 +459,7 @@ bin/libmapixx-exception: libmapi++/tests/exception_test.cpp \
 		libmapipp.$(SHLIBEXT).$(PACKAGE_VERSION) \
 		libmapi.$(SHLIBEXT).$(PACKAGE_VERSION)
 	@echo "Linking exception test application $@"
-	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS)
+	@$(CXX) $(CXX11FLAGS) $(CXXFLAGS) -o $@ $^ $(LIBS)
 
 libmapixx-exception-clean:
 	rm -f bin/libmapixx-exception
@@ -476,7 +479,7 @@ bin/libmapixx-profiletest: libmapi++/tests/profile_test.po	\
 		libmapipp.$(SHLIBEXT).$(PACKAGE_VERSION) \
 		libmapi.$(SHLIBEXT).$(PACKAGE_VERSION)
 	@echo "Linking profile test application $@"
-	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS)
+	@$(CXX) $(CXX11FLAGS) $(CXXFLAGS) -o $@ $^ $(LIBS)
 
 clean:: libmapixx-profiletest-clean
 
@@ -497,7 +500,7 @@ libmapi++/examples/foldertree: libmapi++/examples/foldertree.cpp	\
 		libmapipp.$(SHLIBEXT).$(PACKAGE_VERSION) \
 		libmapi.$(SHLIBEXT).$(PACKAGE_VERSION)
 	@echo "Linking foldertree example application $@"
-	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS)
+	@$(CXX) $(CXX11FLAGS) $(CXXFLAGS) -o $@ $^ $(LIBS)
 
 clean:: libmapixx-foldertree-clean
 
@@ -505,7 +508,7 @@ libmapi++/examples/messages: libmapi++/examples/messages.cpp	\
 		libmapipp.$(SHLIBEXT).$(PACKAGE_VERSION) \
 		libmapi.$(SHLIBEXT).$(PACKAGE_VERSION)
 	@echo "Linking messages example application $@"
-	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS)
+	@$(CXX) $(CXX11FLAGS) $(CXXFLAGS) -o $@ $^ $(LIBS)
 
 clean:: libmapixx-messages-clean
 
@@ -1696,7 +1699,7 @@ libqtmapi.$(SHLIBEXT).$(PACKAGE_VERSION): 	\
 	qt/lib/foldermodel.o			\
 	qt/lib/messagesmodel.o
 	@echo "Linking $@"
-	@$(CXX) $(DSOOPT) $(CXXFLAGS) $(LDFLAGS) -Wl,-soname,libqtmapi.$(SHLIBEXT).$(LIBQTMAPI_SO_VERSION) -o $@ $^ $(LIBS)
+	@$(CXX) $(DSOOPT) $(CXX11FLAGS) $(CXXFLAGS) $(LDFLAGS) -Wl,-soname,libqtmapi.$(SHLIBEXT).$(LIBQTMAPI_SO_VERSION) -o $@ $^ $(LIBS)
 
 
 qt/demo/demoapp: qt/demo/demoapp.o 				\
@@ -1705,7 +1708,7 @@ qt/demo/demoapp: qt/demo/demoapp.o 				\
 	libmapipp.$(SHLIBEXT).$(PACKAGE_VERSION)	\
 	libqtmapi.$(SHLIBEXT).$(PACKAGE_VERSION)
 	@echo "Linking $@"
-	@$(CXX) $(CXXFLAGS) -o $@ $^ $(QT4_LIBS) $(LDFLAGS) $(LIBS)
+	@$(CXX) $(CXX11FLAGS) $(CXXFLAGS) -o $@ $^ $(QT4_LIBS) $(LDFLAGS) $(LIBS)
 	# we don't yet install this...
 	ln -sf libqtmapi.$(SHLIBEXT).$(PACKAGE_VERSION) libqtmapi.$(SHLIBEXT)
 	ln -sf libqtmapi.$(SHLIBEXT).$(PACKAGE_VERSION) libqtmapi.$(SHLIBEXT).$(LIBQTMAPI_SO_VERSION)

--- a/configure.ac
+++ b/configure.ac
@@ -469,33 +469,10 @@ AC_CACHE_CHECK([C++ compiler availability], [ac_cv_libmapixx_gxx_works],
 		AC_LANG_POP([C++])
 		])
 
-dnl ---------------------------------------------------------------------------
-dnl Check for boost-thread
-dnl ---------------------------------------------------------------------------
-
-AC_ARG_VAR([BOOST_LIB_SUFFIX], [Boost library name suffix])
-
-AC_CACHE_CHECK([for boost_thread$BOOST_LIB_SUFFIX library], [ov_cv_boost_thread],
-	       [
-	        ov_cv_boost_thread=no
-		ov_save_LIBS=$LIBS
-		LIBS="-lboost_thread$BOOST_LIB_SUFFIX -lboost_system$BOOST_LIB_SUFFIX $LIBS"
-		AC_LANG_PUSH([C++])
-		AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdint.h>
-						#include <boost/thread.hpp>]],
-						[[boost::thread t]])],
-				[ov_cv_boost_thread=yes])
-		AC_LANG_POP([C++])
-		LIBS=$ov_save_LIBS
-	       ])
-
-
 if test x"$ac_cv_libmapixx_gxx_works" = "xyes"; then
-   if test x"$ov_cv_boost_thread" = "xyes"; then
-      AC_PROG_CXX 
-      libmapixx=1
-      OC_RULE_ADD(libmapixx, LIBS)
-   fi
+   AC_PROG_CXX 
+   libmapixx=1
+   OC_RULE_ADD(libmapixx, LIBS)
 fi
 
 

--- a/libmapi++/folder.h
+++ b/libmapi++/folder.h
@@ -22,8 +22,8 @@
 #define LIBMAPIPP__FOLDER_H__
 
 #include <iostream> //for debugging
+#include <memory>
 #include <vector>
-#include <boost/shared_ptr.hpp>
 
 #include <libmapi++/clibmapi.h>
 #include <libmapi++/mapi_exception.h>
@@ -41,14 +41,14 @@ class folder : public object {
 		/**
 		 * Pointer to a message
 		*/
-		typedef boost::shared_ptr<message>		message_shared_ptr;
+		typedef std::shared_ptr<message>		message_shared_ptr;
 
 		typedef std::vector<message_shared_ptr >	message_container_type;
 
 		/**
 		 * Pointer to a %folder
 		*/
-		typedef boost::shared_ptr<folder>		folder_shared_ptr;
+		typedef std::shared_ptr<folder>		folder_shared_ptr;
 
 		/**
 		 * Hierarchy folders

--- a/libmapi++/message.h
+++ b/libmapi++/message.h
@@ -23,8 +23,8 @@
 #define LIBMAPIPP__MESSAGE_H__
 
 #include <iostream> //for debugging
+#include <memory>
 #include <vector>
-#include <boost/shared_ptr.hpp>
 
 #include <libmapi++/mapi_exception.h>
 #include <libmapi++/session.h>
@@ -44,7 +44,7 @@ class attachment;
  */
 class message : public object {
 	public:
-		typedef boost::shared_ptr<attachment>		attachment_shared_ptr;
+		typedef std::shared_ptr<attachment>		attachment_shared_ptr;
 		typedef std::vector<attachment_shared_ptr>	attachment_container_type;
 
 		/**


### PR DESCRIPTION
This pr removes the dependency on libboost by using C++ 11 features available in gcc for the last few years.
