### PR TITLE
Add travis configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ compiler:
   - clang
   - gcc
 install:
-  - sudo apt-add-repository ppa:jelmer/samba-backports
+  - sudo apt-add-repository -y ppa:jelmer/samba-backports
   - sudo apt-get update
   - sudo apt-get install -qq autoconf automake bison doxygen flex libboost-system-dev libboost-thread-dev libical-dev libldb-dev libmagic-dev libpopt-dev libsqlite3-dev libsubunit-dev libtalloc-dev libtevent-dev pkg-config python-all-dev python-samba samba-dev zlib1g-dev
 


### PR DESCRIPTION
This adds a configuration for travis, a continuous integration server for all projects on GitHub. I've verified that this works with current OpenChange. You can see the current results here: https://travis-ci.org/jelmer/openchange

When merging this, we'll also have to enable travis for the OpenChange repository. You should be able to do this from the travis-ci.org website (I can't since I don't have admin privileges).

Note that this currently only checks that openchange builds, it does not run "make test" yet since that is broken at the moment.
