### PR TITLE
mapicode: Fix MAPI_STATUS_ERR() macro to check for errors

### DIFF
--- a/libmapi/mapicode.h
+++ b/libmapi/mapicode.h
@@ -89,7 +89,7 @@ typedef unsigned long	SCODE;
 #define	MAPI_STATUS_V(x) ((SCODE)x)
 
 #define	MAPI_STATUS_IS_OK(x) (MAPI_STATUS_V(x) == 0)
-#define	MAPI_STATUS_IS_ERR(x) ((MAPI_STATUS_V(x) & 0xc0000000) == 0xc0000000)
+#define	MAPI_STATUS_IS_ERR(x) ((MAPI_STATUS_V(x) & 0xc0000000) == 0x80000000)
 #define	MAPI_STATUS_EQUAL(x,y) (MAPI_STATUS_V(x) == MAPI_STATUS_V(y))
 
 #define	MAPI_STATUS_IS_OK_RETURN(x) do { \


### PR DESCRIPTION
Without this, MAPI_STATUS_ERR() is pretty useless
