### PR TITLE
Makefile: fix make mapistore test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -962,7 +962,8 @@ mapistore_test: bin/mapistore_test
 
 bin/mapistore_test: 	mapiproxy/libmapistore/tests/mapistore_test.o		\
 			mapiproxy/libmapistore.$(SHLIBEXT).$(PACKAGE_VERSION)	\
-			mapiproxy/libmapiproxy.$(SHLIBEXT).$(PACKAGE_VERSION)
+			mapiproxy/libmapiproxy.$(SHLIBEXT).$(PACKAGE_VERSION)	\
+			libmapi.$(SHLIBEXT).$(PACKAGE_VERSION)
 	@echo "Linking $@"
 	@$(CC) -o $@ $^ $(LDFLAGS) $(LIBS) -lpopt -L. libmapi.$(SHLIBEXT).$(PACKAGE_VERSION)
 


### PR DESCRIPTION
Following cookbook recipe we face this error while executing make:

```
vagrant@precise64:~/openchange$ make
Linking bin/mapistore_test
/usr/bin/ld: warning: libmapi.so.0, needed by mapiproxy/libmapistore.so.2.2, not found (try using -rpath or -rpath-link)
mapiproxy/libmapistore.so.2.2: undefined reference to `exchange_globcnt'
mapiproxy/libmapiproxy.so.2.2: undefined reference to `mapi_get_locale_from_lcid'
mapiproxy/libmapiproxy.so.2.2: undefined reference to `set_errno'
collect2: ld returned 1 exit status
```

http://tracker.openchange.org/boards/3/topics/306
