### PR TITLE
Encode ldap filters properly

### DIFF
--- a/mapiproxy/libmapiproxy/backends/openchangedb_ldb.c
+++ b/mapiproxy/libmapiproxy/backends/openchangedb_ldb.c
@@ -48,7 +48,7 @@ static enum MAPISTATUS get_SpecialFolderID(struct openchangedb_context *self,
 	mem_ctx = talloc_named(NULL, 0, "get_SpecialFolderID");
 
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
-			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", recipient);
+			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", ldb_binary_encode_string(mem_ctx, recipient));
 
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, mem_ctx);
 
@@ -98,7 +98,7 @@ static enum MAPISTATUS get_SystemFolderID(struct openchangedb_context *self,
 
 	/* Step 1. Search Mailbox Root DN */
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
-			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", recipient);
+			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", ldb_binary_encode_string(mem_ctx, recipient));
 
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, mem_ctx);
 
@@ -224,7 +224,7 @@ static enum MAPISTATUS get_MailboxGuid(struct openchangedb_context *self,
 
 	/* Step 1. Search Mailbox DN */
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
-			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", recipient);
+			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", ldb_binary_encode_string(mem_ctx, recipient));
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, mem_ctx);
 
 	/* Step 2. Retrieve MailboxGUID attribute's value */
@@ -253,7 +253,7 @@ static enum MAPISTATUS get_MailboxReplica(struct openchangedb_context *self,
 
 	/* Step 1. Search Mailbox DN */
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
-			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", recipient);
+			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", ldb_binary_encode_string(mem_ctx, recipient));
 
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, mem_ctx);
 
@@ -418,13 +418,15 @@ static enum MAPISTATUS get_fid(struct openchangedb_context *self,
 	mem_ctx = talloc_named(NULL, 0, "openchangedb_ldb get_fid");
 
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
-			 LDB_SCOPE_SUBTREE, attrs, "(MAPIStoreURI=%s)", mapistoreURL);
+			 LDB_SCOPE_SUBTREE, attrs, "(MAPIStoreURI=%s)",
+			 ldb_binary_encode_string(mem_ctx, mapistoreURL));
 	if (ret != LDB_SUCCESS || !res->count) {
 		len = strlen(mapistoreURL);
 		if (mapistoreURL[len-1] == '/') {
 			slashLessURL = talloc_strdup(mem_ctx, mapistoreURL);
 			slashLessURL[len-1] = 0;
-			ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx), LDB_SCOPE_SUBTREE, attrs, "(MAPIStoreURI=%s)", slashLessURL);
+			ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx), LDB_SCOPE_SUBTREE,
+					 attrs, "(MAPIStoreURI=%s)", ldb_binary_encode_string(mem_ctx, slashLessURL));
 		}
 		OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, mem_ctx);
 	}
@@ -453,7 +455,8 @@ static enum MAPISTATUS get_MAPIStoreURIs(struct openchangedb_context *self,
 
 	/* fetch mailbox DN */
 	ret = ldb_search(ldb_ctx, local_mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
-			 LDB_SCOPE_SUBTREE, attrs, "(&(cn=%s)(MailboxGUID=*))", username);
+			 LDB_SCOPE_SUBTREE, attrs, "(&(cn=%s)(MailboxGUID=*))",
+			 ldb_binary_encode_string(mem_ctx, username));
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, local_mem_ctx);
 
 	dnstr = talloc_strdup(local_mem_ctx, ldb_msg_find_attr_as_string(res->msgs[0], "distinguishedName", NULL));
@@ -509,7 +512,7 @@ static enum MAPISTATUS get_ReceiveFolder(TALLOC_CTX *parent_ctx,
 
 	/* Step 1. Find mailbox DN for the recipient */
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
-			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", recipient);
+			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", ldb_binary_encode_string(mem_ctx, recipient));
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, mem_ctx);
 
 	dnstr = talloc_strdup(mem_ctx, ldb_msg_find_attr_as_string(res->msgs[0], "distinguishedName", NULL));
@@ -884,7 +887,7 @@ static enum MAPISTATUS get_ReceiveFolderTable(TALLOC_CTX *mem_ctx,
 
 	/* Step 1. Find mailbox DN for the recipient */
 	ret = ldb_search(ldb_ctx, tmp_ctx, &res, ldb_get_default_basedn(ldb_ctx),
-			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", recipient);
+			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", ldb_binary_encode_string(tmp_ctx, recipient));
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, tmp_ctx);
 
 	dnstr = talloc_strdup(tmp_ctx, ldb_msg_find_attr_as_string(res->msgs[0], "distinguishedName", NULL));
@@ -1230,7 +1233,7 @@ static enum MAPISTATUS get_fid_by_name(struct openchangedb_context *self,
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
 			 LDB_SCOPE_SUBTREE, attrs,
 			 "(&(PidTagParentFolderId=%"PRIu64")(PidTagDisplayName=%s))",
-			 parent_fid, foldername);
+			 parent_fid, ldb_binary_encode_string(mem_ctx, foldername));
 
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS, MAPI_E_NOT_FOUND, mem_ctx);
 
@@ -1269,7 +1272,7 @@ static enum MAPISTATUS get_mid_by_subject(struct openchangedb_context *self,
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, base_dn,
 			 LDB_SCOPE_SUBTREE, attrs,
 			 "(&(PidTagParentFolderId=%"PRIu64")(PidTagNormalizedSubject=%s))",
-			 parent_fid, subject);
+			 parent_fid, ldb_binary_encode_string(mem_ctx, subject));
 
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS, MAPI_E_NOT_FOUND, mem_ctx);
 
@@ -1336,7 +1339,7 @@ static enum MAPISTATUS set_ReceiveFolder(struct openchangedb_context *self,
 
 	/* Step 1. Find mailbox DN for the recipient */
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
-			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", recipient);
+			 LDB_SCOPE_SUBTREE, attrs, "CN=%s", ldb_binary_encode_string(mem_ctx, recipient));
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, mem_ctx);
 
 	dnstr = talloc_strdup(mem_ctx, ldb_msg_find_attr_as_string(res->msgs[0], "distinguishedName", NULL));
@@ -1351,7 +1354,7 @@ static enum MAPISTATUS set_ReceiveFolder(struct openchangedb_context *self,
 
 	/* Step 2. Search for the MessageClass within user's mailbox */
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, dn, LDB_SCOPE_SUBTREE, attrs,
-			 "(PidTagMessageClass=%s)", MessageClass);
+			 "(PidTagMessageClass=%s)", ldb_binary_encode_string(mem_ctx, MessageClass));
 	DEBUG(5, ("openchangedb_ldb get_ReceiveFolder, res->count: %i\n", res->count));
 
 	/* We should never have more than one record with a specific MessageClass */
@@ -1426,7 +1429,8 @@ static enum MAPISTATUS get_fid_from_partial_uri(struct openchangedb_context *sel
 
 	/* Search mapistoreURI given partial URI */
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
-			 LDB_SCOPE_SUBTREE, attrs, "(MAPIStoreURI=%s)", partialURI);
+			 LDB_SCOPE_SUBTREE, attrs, "(MAPIStoreURI=%s)",
+			 ldb_binary_encode_string(mem_ctx, partialURI));
 
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, mem_ctx);
 	OPENCHANGE_RETVAL_IF(res->count > 1, MAPI_E_COLLISION, mem_ctx);
@@ -1459,7 +1463,8 @@ static enum MAPISTATUS get_users_from_partial_uri(TALLOC_CTX *parent_ctx,
 
 	/* Search mapistoreURI given partial URI */
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
-			 LDB_SCOPE_SUBTREE, attrs, "(&(MAPIStoreURI=%s)(mailboxDN=*))", partialURI);
+			 LDB_SCOPE_SUBTREE, attrs, "(&(MAPIStoreURI=%s)(mailboxDN=*))",
+			 ldb_binary_encode_string(mem_ctx, partialURI));
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, mem_ctx);
 	*count = res->count;
 	*MAPIStoreURI = talloc_array(parent_ctx, char *, *count);
@@ -1472,7 +1477,8 @@ static enum MAPISTATUS get_users_from_partial_uri(TALLOC_CTX *parent_ctx,
 		/* Retrieve the system user name */
 		mailboxDN = ldb_msg_find_attr_as_string(res->msgs[i], "mailboxDN", NULL);
 		dn = ldb_dn_new(mem_ctx, ldb_ctx, mailboxDN);
-		ret = ldb_search(ldb_ctx, mem_ctx, &mres, dn, LDB_SCOPE_SUBTREE, attrs, "(distinguishedName=%s)", mailboxDN);
+		ret = ldb_search(ldb_ctx, mem_ctx, &mres, dn, LDB_SCOPE_SUBTREE, attrs,
+				 "(distinguishedName=%s)", ldb_binary_encode_string(mem_ctx, mailboxDN));
 		/* This should NEVER happen */
 		OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, mem_ctx);
 		tmp = ldb_msg_find_attr_as_string(mres->msgs[0], "cn", NULL);
@@ -1660,7 +1666,8 @@ static enum MAPISTATUS get_message_count(struct openchangedb_context *self,
 	objectClass = (fai ? "faiMessage" : "systemMessage");
 	ret = ldb_search(ldb_ctx, mem_ctx, &res, ldb_get_default_basedn(ldb_ctx),
 			 LDB_SCOPE_SUBTREE, attrs,
-			 "(&(objectClass=%s)(PidTagParentFolderId=%"PRIu64"))", objectClass, fid);
+			 "(&(objectClass=%s)(PidTagParentFolderId=%"PRIu64"))",
+			 ldb_binary_encode_string(mem_ctx, objectClass), fid);
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS, MAPI_E_NOT_FOUND, mem_ctx);
 
 	*RowCount = res->count;

--- a/mapiproxy/servers/default/emsmdb/emsmdbp.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp.c
@@ -233,7 +233,8 @@ _PUBLIC_ bool emsmdbp_verify_user(struct dcesrv_call_state *dce_call,
 
 	ret = ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
 			 ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
-			 LDB_SCOPE_SUBTREE, recipient_attrs, "sAMAccountName=%s", username);
+			 LDB_SCOPE_SUBTREE, recipient_attrs, "sAMAccountName=%s",
+			 ldb_binary_encode_string(emsmdbp_ctx, username));
 
 	/* If the search failed */
 	if (ret != LDB_SUCCESS || !res->count) {
@@ -289,7 +290,7 @@ _PUBLIC_ bool emsmdbp_verify_userdn(struct dcesrv_call_state *dce_call,
 	ret = ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
 			 ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
 			 LDB_SCOPE_SUBTREE, recipient_attrs, "(legacyExchangeDN=%s)",
-			 legacyExchangeDN);
+			 ldb_binary_encode_string(emsmdbp_ctx, legacyExchangeDN));
 
 	/* If the search failed */
 	if (ret != LDB_SUCCESS || !res->count) {
@@ -357,7 +358,7 @@ _PUBLIC_ enum MAPISTATUS emsmdbp_resolve_recipient(TALLOC_CTX *mem_ctx,
 			 ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
 			 LDB_SCOPE_SUBTREE, recipient_attrs,
 			 "(&(objectClass=user)(sAMAccountName=*%s*)(!(objectClass=computer)))",
-			 recipient);
+			 ldb_binary_encode_string(mem_ctx, recipient));
 
 	/* If the search failed, build an external recipient: very basic for the moment */
 	if (ret != LDB_SUCCESS || !res->count) {
@@ -617,7 +618,8 @@ _PUBLIC_ enum MAPISTATUS emsmdbp_get_org_dn(struct emsmdbp_context *emsmdbp_ctx,
 	ret = ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
 			 ldb_get_config_basedn(emsmdbp_ctx->samdb_ctx),
                          LDB_SCOPE_SUBTREE, NULL,
-                         "(&(objectClass=msExchOrganizationContainer)(cn=%s))", org_name);
+                         "(&(objectClass=msExchOrganizationContainer)(cn=%s))",
+                         ldb_binary_encode_string(emsmdbp_ctx, org_name));
 	talloc_free(org_name);
 
 	/* If the search failed */

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -1124,7 +1124,7 @@ _PUBLIC_ struct emsmdbp_object *emsmdbp_object_mailbox_init(TALLOC_CTX *mem_ctx,
 		ret = ldb_search(emsmdbp_ctx->samdb_ctx, mem_ctx, &res,
 				 ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
 				 LDB_SCOPE_SUBTREE, recipient_attrs, "legacyExchangeDN=%s", 
-				 object->object.mailbox->owner_EssDN);
+				 ldb_binary_encode_string(mem_ctx, object->object.mailbox->owner_EssDN));
 		if (!ret && res->count == 1) {
 			accountName = ldb_msg_find_attr_as_string(res->msgs[0], "sAMAccountName", NULL);
 			if (accountName) {
@@ -1899,7 +1899,7 @@ static enum MAPISTATUS mapiserver_get_administrative_group_legacyexchangedn(TALL
 	ret = ldb_search(emsmdbp_ctx->samdb_ctx, emsmdbp_ctx, &res,
 			 basedn, LDB_SCOPE_SUBTREE, attrs,
 			 "(&(objectClass=msExchAdminGroup)(msExchDefaultAdminGroup=TRUE)(cn=%s))",
-			 group_name);
+			 ldb_binary_encode_string(mem_ctx, group_name));
 
 	/* If the search failed */
 	if (ret != LDB_SUCCESS) {

--- a/mapiproxy/servers/default/emsmdb/oxcmsg.c
+++ b/mapiproxy/servers/default/emsmdb/oxcmsg.c
@@ -65,7 +65,7 @@ static void oxcmsg_fill_RecipientRow(TALLOC_CTX *mem_ctx, struct emsmdbp_context
 			 ldb_get_default_basedn(emsmdbp_ctx->samdb_ctx),
 			 LDB_SCOPE_SUBTREE, recipient_attrs,
 			 "(&(objectClass=user)(sAMAccountName=*%s*)(!(objectClass=computer)))",
-			 recipient->username);
+			 ldb_binary_encode_string(mem_ctx, recipient->username));
 	/* If the search failed, build an external recipient: very basic for the moment */
 	if (ret != LDB_SUCCESS || !res->count) {
 		DEBUG(0, ("record not found for %s\n", recipient->username));

--- a/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
+++ b/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
@@ -1142,7 +1142,8 @@ static void dcesrv_NspiResolveNames(struct dcesrv_call_state *dce_call,
 		}
 		/* Build search filter */
 		for (j = 0; j < ARRAY_SIZE(search_attr); j++) {
-			char *attr_filter = talloc_asprintf(mem_ctx, "(%s=%s)", search_attr[j], paStr->Strings[i]);
+			char *attr_filter = talloc_asprintf(mem_ctx, "(%s=%s)", search_attr[j],
+							    ldb_binary_encode_string(mem_ctx, paStr->Strings[i]));
 			if (!attr_filter) {
 				retval = MAPI_E_NOT_ENOUGH_MEMORY;
 				goto error;
@@ -1287,7 +1288,8 @@ static void dcesrv_NspiResolveNamesW(struct dcesrv_call_state *dce_call,
 		}
 		/* Build search filter */
 		for (j = 0; j < ARRAY_SIZE(search_attr); j++) {
-			char *attr_filter = talloc_asprintf(mem_ctx, "(%s=%s)", search_attr[j], paWStr->Strings[i]);
+			char *attr_filter = talloc_asprintf(mem_ctx, "(%s=%s)", search_attr[j],
+							    ldb_binary_encode_string(mem_ctx, paWStr->Strings[i]));
 			if (!attr_filter) {
 				retval = MAPI_E_NOT_ENOUGH_MEMORY;
 				goto error;

--- a/mapiproxy/servers/default/nspi/emsabp.c
+++ b/mapiproxy/servers/default/nspi/emsabp.c
@@ -154,7 +154,7 @@ _PUBLIC_ enum MAPISTATUS emsabp_get_account_info(TALLOC_CTX *mem_ctx,
 	ret = ldb_search(emsabp_ctx->samdb_ctx, mem_ctx, &res,
 			 ldb_get_default_basedn(emsabp_ctx->samdb_ctx),
 			 LDB_SCOPE_SUBTREE, recipient_attrs, "sAMAccountName=%s",
-			 username);
+			 ldb_binary_encode_string(mem_ctx, username));
 	OPENCHANGE_RETVAL_IF((ret != LDB_SUCCESS || !res->count), MAPI_E_NOT_FOUND, NULL);
 
 	/* Check if more than one record was found */
@@ -1290,14 +1290,14 @@ _PUBLIC_ enum MAPISTATUS emsabp_search_legacyExchangeDN(struct emsabp_context *e
 	ret = ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res,
 			 ldb_get_config_basedn(emsabp_ctx->samdb_ctx), 
 			 LDB_SCOPE_SUBTREE, recipient_attrs, "(legacyExchangeDN=%s)",
-			 legacyDN);
+			 ldb_binary_encode_string(emsabp_ctx->mem_ctx, legacyDN));
 
 	if (ret != LDB_SUCCESS || res->count == 0) {
 		*pbUseConfPartition = false;
 		ret = ldb_search(emsabp_ctx->samdb_ctx, emsabp_ctx->mem_ctx, &res,
 				 ldb_get_default_basedn(emsabp_ctx->samdb_ctx),
 				 LDB_SCOPE_SUBTREE, recipient_attrs, "(legacyExchangeDN=%s)",
-				 legacyDN);
+				 ldb_binary_encode_string(emsabp_ctx->mem_ctx, legacyDN));
 	}
 	OPENCHANGE_RETVAL_IF(ret != LDB_SUCCESS || !res->count, MAPI_E_NOT_FOUND, NULL);
 


### PR DESCRIPTION
Ldap filters with chars in `*()\&|!"` are wrong and we have to encode it.
