### PR TITLE
util-mysql: remove mapistore dependecy

### DIFF
--- a/mapiproxy/libmapistore/backends/indexing_mysql.c
+++ b/mapiproxy/libmapistore/backends/indexing_mysql.c
@@ -474,6 +474,7 @@ _PUBLIC_ enum mapistore_error mapistore_indexing_mysql_init(struct mapistore_con
 	struct indexing_context	*ictx;
 	char			*schema_file;
 	MYSQL			*conn = NULL;
+	bool			schema_created;
 
 	/* Sanity checks */
 	MAPISTORE_RETVAL_IF(!mstore_ctx, MAPISTORE_ERR_NOT_INITIALIZED, NULL);
@@ -491,16 +492,18 @@ _PUBLIC_ enum mapistore_error mapistore_indexing_mysql_init(struct mapistore_con
 	MAPISTORE_RETVAL_IF(!ictx->data, MAPISTORE_ERR_NOT_INITIALIZED, ictx);
 
 	if (!table_exists(conn, INDEXING_TABLE)) {
-		enum mapistore_error schema_created;
 		DEBUG(3, ("Creating schema for indexing on mysql %s\n", connection_string));
 
 		schema_file = talloc_asprintf(ictx, "%s/%s", MAPISTORE_LDIF, INDEXING_SCHEMA_FILE);
 		MAPISTORE_RETVAL_IF(!schema_file, MAPISTORE_ERR_NO_MEMORY, NULL);
-		schema_created = create_schema(MYSQL(ictx), schema_file);
+		schema_created = create_schema(conn, schema_file);
 		talloc_free(schema_file);
 
-		MAPISTORE_RETVAL_IF(schema_created != MAPISTORE_SUCCESS,
-				    MAPISTORE_ERR_NOT_INITIALIZED, ictx);
+		if (!schema_created) {
+			DEBUG(1, ("Failed indexing schema creation, "
+				  "last mysql error was: `%s`\n", mysql_error(conn)));
+			MAPISTORE_RETVAL_ERR(MAPISTORE_ERR_NOT_INITIALIZED, ictx);
+		}
 	}
 
 	/* TODO: extract url from backend mapping, by the moment we use the username */

--- a/mapiproxy/libmapistore/mapistore_errors.h
+++ b/mapiproxy/libmapistore/mapistore_errors.h
@@ -42,6 +42,15 @@ do {					\
 	}				\
 } while (0);
 
+#define	MAPISTORE_RETVAL_ERR(e,c)	\
+do {					\
+	mapistore_set_errno(e);		\
+	if (c) {			\
+		talloc_free(c);		\
+	}				\
+	return (e);			\
+} while (0);
+
 #define	MAPISTORE_SANITY_CHECKS(x,c)						\
 MAPISTORE_RETVAL_IF(!x, MAPISTORE_ERR_NOT_INITIALIZED, c);			\
 MAPISTORE_RETVAL_IF(!x->processing_ctx, MAPISTORE_ERR_NOT_INITIALIZED, c);	\

--- a/mapiproxy/util/mysql.h
+++ b/mapiproxy/util/mysql.h
@@ -22,7 +22,6 @@
 #ifndef __MYSQL_H__
 #define __MYSQL_H__
 
-#include "mapiproxy/libmapistore/mapistore_errors.h"
 #include <mysql/mysql.h>
 #include <talloc.h>
 #include <stdbool.h>
@@ -40,7 +39,7 @@ enum MYSQLRESULT select_first_string(TALLOC_CTX *, MYSQL *, const char *, const 
 enum MYSQLRESULT select_first_uint(MYSQL *conn, const char *sql, uint64_t *n);
 
 bool table_exists(MYSQL *, char *);
-enum mapistore_error create_schema(MYSQL *, const char *);
+bool create_schema(MYSQL *, const char *);
 bool convert_string_to_ull(const char *, uint64_t *);
 
 MYSQL *create_connection(const char *, MYSQL **);


### PR DESCRIPTION
create_schema returns bool instead of mapistore_error.
Test adapted and moved to the proper test suite.

This change is needed to avoid dependecy of mapiproxy -> mapistore,
because util/mysql is used by both and mapistore already depends on
mapiproxy.
