### PR TITLE
Fix potential crash in RAWIDSET_push_guid_glob

### DIFF
--- a/libmapi/idset.c
+++ b/libmapi/idset.c
@@ -1169,8 +1169,9 @@ _PUBLIC_ void RAWIDSET_push_eid(struct rawidset *rawidset, uint64_t eid)
 
 _PUBLIC_ void RAWIDSET_push_guid_glob(struct rawidset *rawidset, const struct GUID *guid, uint64_t globcnt)
 {
-	struct rawidset *glob_idset, *last_glob_idset;
-	static struct GUID *zero_guid = NULL;
+	struct rawidset		*glob_idset;
+	struct rawidset		*last_glob_idset = NULL;
+	static struct GUID	*zero_guid = NULL;
 
 	if (!rawidset) return;
 
@@ -1195,7 +1196,9 @@ _PUBLIC_ void RAWIDSET_push_guid_glob(struct rawidset *rawidset, const struct GU
 		glob_idset = RAWIDSET_find_by_GUID(rawidset, zero_guid, NULL);
 		if (!glob_idset) {
 			glob_idset = RAWIDSET_make(rawidset->mem_ctx, false, rawidset->single);
-			last_glob_idset->next = glob_idset;
+			if (last_glob_idset) {
+				last_glob_idset->next = glob_idset;
+			}
 		}
 		glob_idset->repl.guid = *guid;
 	}


### PR DESCRIPTION
Prevent RAWIDSET_push_guid_glob from crashing when last_glob_idset remains uninitialized after initial call to RAWIDSET_find_by_GUID.
