### PR TITLE
Enhacements to crash mining tool V.II

### DIFF
--- a/script/bug-analysis/crash-digger.conf
+++ b/script/bug-analysis/crash-digger.conf
@@ -28,6 +28,14 @@ tracker = {
     # Reporter email custom field if available
     # The --notified argument is set there
     #'reporter_field': {'custom_field': 3},
+
+    # Support to reopen an issue if it is closed
+    # 'closed' indicates which status identifiers indicates we should reopen an issue
+    # 'reopened' indicates the status identifier to put the issue after reopening
+    # | closed_st_1 | -> | reopened |
+    # | closed_st_2 | ---------^
+    # 'status': {'closed': (3, 4),
+    #            'reopened': 1},
 }
 
 # Notifier settings when tracker is integrated

--- a/script/bug-analysis/oc-crash-digger
+++ b/script/bug-analysis/oc-crash-digger
@@ -115,7 +115,8 @@ class CrashDigger(object):
                                                          project=tracker_conf.get('project_id', None),
                                                          component_conf=tracker_conf.get('component_conf', {}),
                                                          custom_fields=tracker_conf.get('custom_fields', []),
-                                                         reporter_field=tracker_conf.get('reporter_field', None))
+                                                         reporter_field=tracker_conf.get('reporter_field', None),
+                                                         status=tracker_conf.get('status', {}))
                         except ImportError:
                             self.log("WARNING: python-redmine module is not installed")
                             # No redmine


### PR DESCRIPTION
- Do not try backup apport configuration when running with gdb
- Adding Package version and distro release version to duplicate note in tracker
- Reopen an issue when a duplicate is found.
  - Configurable via `crash-digger.conf`file
