### PR TITLE
Set prev when splitting a range on deletion

### DIFF
--- a/libmapi/idset.c
+++ b/libmapi/idset.c
@@ -969,6 +969,7 @@ static void IDSET_ranges_remove_globcnt(struct idset *idset, uint64_t eid) {
 			new_range->high = range->high;
 			range->high = exchange_globcnt(work_eid - 1);
 			new_range->next = range->next;
+			new_range->prev = range;
 			range->next = new_range;
 			if (new_range->next == NULL) {
 				idset->ranges->prev = new_range;


### PR DESCRIPTION
If it was not set, then DLIST_REMOVE was crashing
as it was impossible to rebuild the proper list.
