### PR TITLE
user cleanup script

### DIFF
--- a/script/openchange_user_cleanup.py
+++ b/script/openchange_user_cleanup.py
@@ -182,7 +182,7 @@ class SOGoCleaner(object):
         c = conn.cursor()
         tablename = "sogo_cache_folder_%s" % self._as_css_id(username)
         if not self.dry_run:
-            c.execute("TRUNCATE TABLE %s" % tablename)
+            c.execute("DROP TABLE %s" % tablename)
         print " [SOGo MySQL] Table %s deleted" % tablename
 
     def _get_connection_url(self):


### PR DESCRIPTION
Script to cleanup things:
- Openchange: remove data from openchangedb and mapistore indexing databases.
- SOGo: remove user cache table
- Imap: remove a list of folders (Spam, Sync issues and folder with "(1)" pattern)-

You can call it ignoring some things (for instance --ignore=imap).

It also have a --users flag to retrieve all active users (users that had used outlook in the past at least once, it checks openchangedb for this).

```
Usage: openchange_user_cleanup.py [options] <username>

Options:
  -h, --help       show this help message and exit
  --users          List active openchange users
  --dry-run        Do not perform any action
  --ignore=IGNORE  Ignore to perform some cleaner actions. The ones that exist
                   are: openchange, sogo, imap
```
