### PR TITLE
Fix #CR-633 in oxcfxics on folder change

### DIFF
--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -1746,7 +1746,7 @@ _PUBLIC_ void **emsmdbp_object_table_get_row_props(TALLOC_CTX *mem_ctx, struct e
 
 					local_data_pointers = emsmdbp_object_get_properties(data_pointers, emsmdbp_ctx, rowobject, &props, &local_retvals);
 					data_pointers[i] = local_data_pointers[0];
-					retvals[i] = local_retvals[0];
+					retval = local_retvals[0];
 				}
 					break;
 				case PidTagSourceKey:


### PR DESCRIPTION
Set retval while getting specific props from a openchange db table row.

The problem comes from the `retvals[i]` is overwritten in L1789 so we
have to store the `retval` in the local variable likewise other switch
functions does.
