### PR TITLE
Remove smb_panic calls, no need to crash

### DIFF
--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
@@ -28,6 +28,7 @@
 #include <sys/time.h>
 
 #include "mapiproxy/dcesrv_mapiproxy.h"
+#include "mapiproxy/libmapiproxy/fault_util.h"
 #include "mapiproxy/libmapiserver/libmapiserver.h"
 #include "dcesrv_exchange_emsmdb.h"
 
@@ -125,7 +126,7 @@ static enum MAPISTATUS dcesrv_EcDoConnect(struct dcesrv_call_state *dce_call,
 				   dcesrv_call_account_name(dce_call),
 				   openchange_db_ctx);
 	if (!emsmdbp_ctx) {
-		DEBUG(0, ("[exchange_emsmdb] EcDoConnect failed: unable to initialize emsmdbp context"));
+		OC_ABORT(false, ("[exchange_emsmdb] EcDoConnect failed: unable to initialize emsmdbp context"));
 		goto failure;
 	}
 
@@ -2011,7 +2012,7 @@ static NTSTATUS dcesrv_exchange_emsmdb_init(struct dcesrv_context *dce_ctx)
 	/* Open read/write context on OpenChange dispatcher database */
 	openchange_db_ctx = emsmdbp_openchangedb_init(dce_ctx->lp_ctx);
 	if (!openchange_db_ctx) {
-		DEBUG(0, ("[exchange_emsmdb] Unable to initialize openchangedb"));
+		OC_ABORT(false, ("[exchange_emsmdb] Unable to initialize openchangedb"));
 		return NT_STATUS_INTERNAL_ERROR;
 	}
 

--- a/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
+++ b/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
@@ -26,6 +26,7 @@
  */
 
 #include "mapiproxy/dcesrv_mapiproxy.h"
+#include "mapiproxy/libmapiproxy/fault_util.h"
 #include "dcesrv_exchange_nsp.h"
 
 static struct exchange_nsp_session	*nsp_session = NULL;
@@ -124,7 +125,7 @@ static void dcesrv_NspiBind(struct dcesrv_call_state *dce_call,
 	/* Step 1. Initialize the emsabp context */
 	emsabp_ctx = emsabp_init(dce_call->conn->dce_ctx->lp_ctx, emsabp_tdb_ctx);
 	if (!emsabp_ctx) {
-		DEBUG(0, ("[exchange_nsp] Unable to initialize emsabp context"));
+		OC_ABORT(false, ("[exchange_nsp] Unable to initialize emsabp context"));
 
 		wire_handle.handle_type = EXCHANGE_HANDLE_NSP;
 		wire_handle.uuid = GUID_zero();
@@ -1467,7 +1468,7 @@ static NTSTATUS dcesrv_exchange_nsp_init(struct dcesrv_context *dce_ctx)
 	/* Open a read-write pointer on the EMSABP TDB database */
 	emsabp_tdb_ctx = emsabp_tdb_init((TALLOC_CTX *)dce_ctx, dce_ctx->lp_ctx);
 	if (!emsabp_tdb_ctx) {
-		DEBUG(0, ("[exchange_nsp] Unable to initialize emsabp_tdb context"));
+		OC_ABORT(false, ("[exchange_nsp] Unable to initialize emsabp_tdb context"));
 		return NT_STATUS_INTERNAL_ERROR;
 	}
 

--- a/mapiproxy/servers/default/nspi/emsabp.c
+++ b/mapiproxy/servers/default/nspi/emsabp.c
@@ -28,6 +28,7 @@
 
 #define TEVENT_DEPRECATED
 #include "mapiproxy/dcesrv_mapiproxy.h"
+#include "mapiproxy/libmapiproxy/fault_util.h"
 #include "dcesrv_exchange_nsp.h"
 #include "ldb.h"
 
@@ -101,7 +102,7 @@ _PUBLIC_ struct emsabp_context *emsabp_init(struct loadparm_context *lp_ctx,
 	 * temporary MId used within EMSABP */
 	emsabp_ctx->ttdb_ctx = emsabp_tdb_init_tmp(emsabp_ctx->mem_ctx);
 	if (!emsabp_ctx->ttdb_ctx) {
-		DEBUG(0 , ("[nspi] Unable to create on-memory TDB database"));
+		OC_ABORT(false , ("[nspi] Unable to create on-memory TDB database"));
 		return NULL;
 	}
 


### PR DESCRIPTION
Normally we end in this scenario when mysql is down, instead of crashing much better to show an error (in this mysql scenario you can read in the log file the connection issue).
