### PR TITLE
Fix minor leak when we cannot create a mapistore backend context

### DIFF
--- a/mapiproxy/libmapistore/mapistore_interface.c
+++ b/mapiproxy/libmapistore/mapistore_interface.c
@@ -221,6 +221,7 @@ _PUBLIC_ enum mapistore_error mapistore_add_context(struct mapistore_context *ms
 
 		retval = mapistore_backend_create_context(mstore_ctx, mstore_ctx->conn_info, ictx, namespace_start, backend_uri, fid, &backend_ctx);
 		if (retval != MAPISTORE_SUCCESS) {
+			talloc_free(mem_ctx);
 			return retval;
 		}
 


### PR DESCRIPTION
Valgrind report example:

```
457 (118 direct, 339 indirect) bytes in 1 blocks are definitely lost in loss record 9,447 of 11,560
  at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
  by 0x86EE3AC: talloc_vasprintf (in /usr/lib/x86_64-linux-gnu/libtalloc.so.2.1.0)
  by 0x86EED49: talloc_named (in /usr/lib/x86_64-linux-gnu/libtalloc.so.2.1.0)
  by 0x28DBBFDE: mapistore_add_context (mapistore_interface.c:204)
  by 0x288517CF: emsmdbp_object_open_folder (emsmdbp_object.c:439)
  by 0x28851FF6: emsmdbp_object_open_folder_by_fid (emsmdbp_object.c:628)
  by 0x28862D7C: EcDoRpc_RopOpenFolder (oxcfold.c:104)
```
