### PR TITLE
Provide REST server configuration from a conf file

### DIFF
--- a/python/mock/rest/api_server.py
+++ b/python/mock/rest/api_server.py
@@ -30,9 +30,10 @@ from flask.ctx import after_this_request
 from handler.kissHandler import ApiHandler
 from openchange import mapistore
 
+
 app = Flask(__name__)
-app.config.from_object(__name__)
-# app.config.from_pyfile()
+app.config.from_object('default_config')
+app.config.from_envvar('API_SERVER_SETTINGS', silent=True)
 
 
 @app.route('/', methods=['GET'])
@@ -399,5 +400,4 @@ def module_notes_create():
 
 
 if __name__ == '__main__':
-    app.debug = True
-    app.run(port=5001)
+    app.run(host=app.config['HOST'])

--- a/python/mock/rest/default_config.py
+++ b/python/mock/rest/default_config.py
@@ -1,0 +1,4 @@
+# Default configuration for the REST server
+DEBUG = True
+SERVER_NAME = 'localhost:5001'
+HOST = '127.0.0.1'


### PR DESCRIPTION
Following guidelines provided by Flask documentation:

http://flask.pocoo.org/docs/0.10/config/#configuring-from-files

API_SERVER_SETTINGS env var can point to a deployment settings file.
