### PR TITLE
Change configuration defaults for mapiproxy.

### DIFF
--- a/mapiproxy/dcesrv_mapiproxy.c
+++ b/mapiproxy/dcesrv_mapiproxy.c
@@ -605,7 +605,7 @@ static NTSTATUS mapiproxy_op_init_server(struct dcesrv_context *dce_ctx, const s
 {
 	NTSTATUS		ret;
 	struct dcesrv_interface	iface;
-	char     		**ifaces;
+	const char     		**ifaces;
 	uint32_t		i;
 	static bool		initialized = false;
 
@@ -619,7 +619,7 @@ static NTSTATUS mapiproxy_op_init_server(struct dcesrv_context *dce_ctx, const s
 	ret = mapiproxy_server_init(dce_ctx);
 	NT_STATUS_NOT_OK_RETURN(ret);
 
-	ifaces = str_list_make(dce_ctx, lpcfg_parm_string(dce_ctx->lp_ctx, NULL, "dcerpc_mapiproxy", "interfaces"), NULL);
+	ifaces = lpcfg_parm_string_list(dce_ctx, dce_ctx->lp_ctx, NULL, "dcerpc_mapiproxy", "interfaces", NULL);
 
 	for (i = 0; ifaces[i]; i++) {
 		/* Register the interface */

--- a/mapiproxy/libmapiproxy/dcesrv_mapiproxy_server.c
+++ b/mapiproxy/libmapiproxy/dcesrv_mapiproxy_server.c
@@ -179,7 +179,7 @@ static NTSTATUS mapiproxy_server_load(struct dcesrv_context *dce_ctx)
 								   NDR_EXCHANGE_DS_RFR_NAME, NULL };
 
 	/* Check server mode */
-	server_mode = lpcfg_parm_bool(dce_ctx->lp_ctx, NULL, "dcerpc_mapiproxy", "server", false);
+	server_mode = lpcfg_parm_bool(dce_ctx->lp_ctx, NULL, "dcerpc_mapiproxy", "server", true);
 	DEBUG(0, ("MAPIPROXY server mode %s\n", (server_mode == false) ? "disabled" : "enabled"));
 
 	if (server_mode == true) {


### PR DESCRIPTION
Change configuration defaults for mapiproxy to:
    
dcerpc_mapiproxy:server = true
dcerpc_mapiproxy:interfaces = exchange_emsmdb, exchange_nsp, exchange_ds_rfr
    
Users can still go back to the old defaults by explicitly setting:
dcerpc_mapiproxy:server = false
dcerpc_mapiproxy:interfaces =

This reduce the amount of changes users need to make to their configuration when setting up OpenChange.