### PR TITLE
Return valid HTTP response when more data is needed

### DIFF
--- a/python/openchange/web/auth/NTLMAuthHandler.py
+++ b/python/openchange/web/auth/NTLMAuthHandler.py
@@ -664,7 +664,7 @@ class NTLMAuthHandler(object):
     def _in_progress_response(start_response, ntlm_data=None,
                               client_id=None, cookie_name=None):
         status = "401 %s" % httplib.responses[401]
-        content = "More data needed..."
+        content = "More data needed...\r\n"
         headers = [("Content-Type", "text/plain"),
                    ("Content-Length", "%d" % len(content))]
         if ntlm_data is None:


### PR DESCRIPTION
This was causing some 502 errors on Apache proxy when requesting oab.xml
