### PR TITLE
Use a new variable called PORT and re-add HOST

### DIFF
--- a/python/mock/rest/api_server.py
+++ b/python/mock/rest/api_server.py
@@ -523,4 +523,4 @@ def module_attachment_delete(att_id):
 ###############################################################################
 
 if __name__ == '__main__':
-    app.run()
+    app.run(host=app.config.get('HOST', None), port=app.config.get('PORT', None))

--- a/python/mock/rest/default_config.py
+++ b/python/mock/rest/default_config.py
@@ -1,3 +1,3 @@
 # Default configuration for the REST server
 DEBUG = True
-SERVER_NAME = "127.0.0.1:5001"
+PORT = 5001


### PR DESCRIPTION
SERVER_NAME in this application is not required and it is mandatory
to make it work in a docker and non-docker scenario
