### PR TITLE
[libmapi++] Fix segfault when login() fails.

### DIFF
--- a/libmapi++/session.h
+++ b/libmapi++/session.h
@@ -133,11 +133,14 @@ class session {
 		{
 			if (m_message_store) {
 				delete m_message_store;
+				m_message_store = 0;
 			}
 			if (m_mapi_context) {
 				MAPIUninitialize(m_mapi_context);
+				m_mapi_context = 0;
 			}
 			talloc_free(m_memory_ctx);
+			m_memory_ctx = 0;
 		}
 };
 


### PR DESCRIPTION
A failed login calls uninitialize(), but so does the destructor.  A double-free causes a segfault, so always be sure to set freed pointers to 0.
