### PR TITLE
Changes in provision code and schemas to allow provision when the Schema...

### DIFF
--- a/python/openchange/provision.py
+++ b/python/openchange/provision.py
@@ -27,7 +27,7 @@ import ldb
 from ldb import LdbError, SCOPE_SUBTREE, SCOPE_BASE
 from samba import read_and_sub_file
 from samba.auth import system_session
-from samba.provision import (setup_add_ldif, setup_modify_ldif)
+from samba.provision import setup_modify_ldif
 from samba.net import Net
 from samba.dcerpc import nbt
 from openchange.urlutils import openchangedb_url
@@ -147,8 +147,7 @@ def guess_names_from_smbconf(lp, creds=None, firstorg=None, firstou=None):
     names.hostname = hostname
     names.sitename = sitename
 
-    db = Ldb(url=get_ldb_url(lp, creds, names), session_info=system_session(),
-             credentials=creds, lp=lp)
+    db = get_local_samdb(names, lp, creds)
     exchangedn = 'CN=Microsoft Exchange,CN=Services,%s' % configdn
     if not firstorg:
         firstorg = db.searchone(
@@ -191,10 +190,6 @@ def provision_schema(sam_db, setup_path, names, reporter, ldif, msg, modify_mode
 
     try:
         reporter.reportNextStep(msg)
-        if modify_mode:
-            ldif_function = setup_modify_ldif
-        else:
-            ldif_function = setup_add_ldif
         ldif_params = {
             "FIRSTORG": names.firstorg,
             "FIRSTORGDN": names.firstorgdn,
@@ -207,12 +202,50 @@ def provision_schema(sam_db, setup_path, names, reporter, ldif, msg, modify_mode
             "NETBIOSNAME": names.netbiosname,
             "HOSTNAME": names.hostname
         }
-        ldif_function(sam_db, setup_path(ldif), ldif_params)
-        setup_modify_ldif(sam_db, setup_path("AD/oc_provision_schema_update.ldif"), ldif_params)
+        if modify_mode:
+            setup_modify_ldif(sam_db, setup_path(ldif), ldif_params)
+        else:
+            full_path = setup_path(ldif)
+            ldif_data = read_and_sub_file(full_path, ldif_params)
+            # schemaIDGUID can raise error if not match what is expected by schema master, if not present it will be automatically filled by the schema master
+            ldif_data = re.sub("^schemaIDGUID:", '#schemaIDGUID:', ldif_data, flags=re.M)
+
+            # we add elements one by one only to control better the exact position of the error
+            ldif_elements = re.split("\n\n+", ldif_data)
+            elements_to_add = []
+            for element in ldif_elements:
+                if not element:
+                    continue
+                # this match is to assure we have a legit element
+                match = re.search('^\s*dn:\s+(.*)$', element, flags=re.M)
+                if match:
+                    elements_to_add.append(element)
+
+            if elements_to_add:
+                for el in elements_to_add:
+                    try:
+                        sam_db.add_ldif(el, ['relax:0'])
+                    except Exception as ex:
+                        print 'Error: "' + str(ex) + '" when adding element:\n' + el + '\n'
+                        raise
+            else:
+                raise Exception('No elements to add found in ' + full_path)
     except:
         sam_db.transaction_cancel()
         raise
 
+    sam_db.transaction_commit()
+    force_schemas_update(sam_db, setup_path)
+
+
+def force_schemas_update(sam_db, setup_path):
+    sam_db.transaction_start()
+    try:
+        # update schema now
+        setup_modify_ldif(sam_db, setup_path('AD/update_now.ldif'), None)
+    except:
+        sam_db.transaction_cancel()
+        raise
     sam_db.transaction_commit()
 
 
@@ -243,10 +276,7 @@ def deprovision_schema(setup_path, names, lp, creds, reporter, ldif, msg, modify
     :param modify_mode: whether entries are added or modified
     """
 
-    session_info = system_session()
-    db = SamDB(url=get_ldb_url(lp, creds, names), session_info=session_info,
-               credentials=creds, lp=lp)
-
+    db = get_schema_master_samdb(names, lp, creds)
     db.transaction_start()
 
     try:
@@ -353,7 +383,7 @@ def install_schemas(setup_path, names, lp, creds, reporter):
     try:
         schemadn = str(names.schemadn)
         current = sam_db.search(expression="objectClass=classSchema", base=schemadn,
-                               scope=SCOPE_BASE)
+                                scope=SCOPE_BASE)
 
         schema_ldif = ""
         prefixmap_data = ""
@@ -374,27 +404,53 @@ def install_schemas(setup_path, names, lp, creds, reporter):
         print ("[!] error while provisioning the prefixMap: %s"
                % str(err))
 
-    try:
-        provision_schema(sam_db, setup_path, names, reporter, "AD/oc_provision_schema_attributes.ldif", "Add Exchange attributes to Samba schema")
-        provision_schema(sam_db, setup_path, names, reporter, "AD/oc_provision_schema_auxiliary_class.ldif", "Add Exchange auxiliary classes to Samba schema")
-        provision_schema(sam_db, setup_path, names, reporter, "AD/oc_provision_schema_objectCategory.ldif", "Add Exchange objectCategory to Samba schema")
-        provision_schema(sam_db, setup_path, names, reporter, "AD/oc_provision_schema_container.ldif", "Add Exchange containers to Samba schema")
-        provision_schema(sam_db, setup_path, names, reporter, "AD/oc_provision_schema_subcontainer.ldif", "Add Exchange *sub* containers to Samba schema")
-        provision_schema(sam_db, setup_path, names, reporter, "AD/oc_provision_schema_sub_CfgProtocol.ldif", "Add Exchange CfgProtocol subcontainers to Samba schema")
-        provision_schema(sam_db, setup_path, names, reporter, "AD/oc_provision_schema_sub_mailGateway.ldif", "Add Exchange mailGateway subcontainers to Samba schema")
-        provision_schema(sam_db, setup_path, names, reporter, "AD/oc_provision_schema.ldif", "Add Exchange classes to Samba schema")
-        modify_schema(sam_db, setup_path, names, reporter, "AD/oc_provision_schema_possSuperior.ldif", "Add possSuperior attributes to Exchange classes")
-        modify_schema(sam_db, setup_path, names, reporter, "AD/oc_provision_schema_modify.ldif", "Extend existing Samba classes and attributes")
-    except LdbError, ldb_error:
-        print ("[!] error while provisioning the Exchange"
-               " schema classes (%d): %s"
-               % ldb_error.args)
+    schemas = [{'path': 'AD/oc_provision_schema_attributes.ldif',
+                'description': 'Add Exchange attributes to Samba schema',
+                'modify_mode': False},
+               {'path': 'AD/oc_provision_schema_auxiliary_class.ldif',
+                'description': 'Add Exchange auxiliary classes to Samba schema',
+                'modify_mode': False},
+               {'path': 'AD/oc_provision_schema_objectCategory.ldif',
+                'description': 'Add Exchange objectCategory to Samba schema',
+                'modify_mode': False},
+               {'path': 'AD/oc_provision_schema_container.ldif',
+                'description': 'Add Exchange containers to Samba schema',
+                'modify_mode': False},
+               {'path': 'AD/oc_provision_schema_subcontainer.ldif',
+                'description': 'Add Exchange *sub* containers to Samba schema',
+                'modify_mode': False},
+               {'path': 'AD/oc_provision_schema_sub_CfgProtocol.ldif',
+                'description': 'Add Exchange CfgProtocol subcontainers to Samba schema',
+                'modify_mode': False},
+               {'path': 'AD/oc_provision_schema_sub_mailGateway.ldif',
+                'description': 'Add Exchange mailGateway subcontainers to Samba schema',
+                'modify_mode': False},
+               {'path': 'AD/oc_provision_schema.ldif',
+                'description': 'Add Exchange classes to Samba schema',
+                'modify_mode': False},
+
+               # modify schemas
+               {'path': 'AD/oc_provision_schema_possSuperior.ldif',
+                'description': 'Add possSuperior attributes to Exchange classes',
+                'modify_mode': True},
+               {'path': 'AD/oc_provision_schema_modify.ldif',
+                'description': 'Extend existing Samba classes and attributes',
+                'modify_mode': True}]
+    for schema in schemas:
+        try:
+            provision_schema(sam_db, setup_path, names, reporter, schema['path'], schema['description'], schema['modify_mode'])
+        except LdbError, ldb_error:
+            print ("[!] error while provisioning the Exchange"
+                   " schema classes (%d): %s"
+                   % ldb_error.args)
+            raise
 
     try:
         provision_schema(sam_db, setup_path, names, reporter, "AD/oc_provision_configuration.ldif", "Generic Exchange configuration objects")
     except LdbError, ldb_error:
         print ("[!] error while provisioning the Exchange configuration"
                " objects (%d): %s" % ldb_error.args)
+        raise
 
 
 def provision_organization(setup_path, names, lp, creds, reporter=None):
@@ -409,9 +465,15 @@ def provision_organization(setup_path, names, lp, creds, reporter=None):
     if reporter is None:
         reporter = TextProgressReporter()
 
+    sam_db = get_schema_master_samdb(names, lp, creds)
     try:
-        sam_db = get_schema_master_samdb(names, lp, creds)
         provision_schema(sam_db, setup_path, names, reporter, "AD/oc_provision_configuration_org.ldif", "Exchange Organization objects")
+    except LdbError, ldb_error:
+            print ("[!] error while provisioning the Exchange organization objects"
+                   " objects (%d): %s" % ldb_error.args)
+            return False
+
+    try:
         modify_schema(sam_db, setup_path, names, reporter, "AD/oc_provision_configuration_finalize.ldif", "Update generic Exchange configuration objects")
     except LdbError, ldb_error:
         print ("[!] error while provisioning the Exchange organization"
@@ -467,17 +529,26 @@ def get_dns_owner(db, ntds_owner):
 
 
 def get_schema_master_samdb(names, lp, creds):
-    samdb_url = get_ldb_url(lp, creds, names)
-    session_info = system_session()
-    db = SamDB(samdb_url, session_info=session_info,
-               credentials=creds, lp=lp)
-    ntds_owner = get_schema_master(db)
-    dns_owner  = get_dns_owner(db, ntds_owner)
+    local_db = get_local_samdb(names, lp, creds)
+    ntds_owner = get_schema_master(local_db)
+    dns_owner = get_dns_owner(local_db, ntds_owner)
+    fqdn = names.hostname + '.' + names.dnsdomain
+    if dns_owner == fqdn:
+        return local_db
 
     owner_samdb_url = 'ldap://' + dns_owner
+    session_info = system_session()
     sam_db = SamDB(url=owner_samdb_url, session_info=session_info,
                    credentials=creds, lp=lp)
     return sam_db
+
+
+def get_local_samdb(names, lp, creds):
+    samdb_url = get_ldb_url(lp, creds, names)
+    session_info = system_session()
+    local_db = SamDB(samdb_url, session_info=session_info,
+                     credentials=creds, lp=lp)
+    return local_db
 
 
 def newuser(names, lp, creds, username=None, mail=None):
@@ -490,8 +561,7 @@ def newuser(names, lp, creds, username=None, mail=None):
     :param mail: The user email address. If not specified, it will be set
                  to <samAccountName>@<dnsdomain>
     """
-    db = Ldb(url=get_ldb_url(lp, creds, names), session_info=system_session(),
-             credentials=creds, lp=lp)
+    db = get_local_samdb(names, lp, creds)
     user_dn = get_user_dn(db, "CN=Users,%s" % names.domaindn, username)
     if user_dn:
         if mail:
@@ -589,10 +659,7 @@ def checkusage(names, lp, creds):
     :param creds: Credentials Context
     """
 
-    session_info = system_session()
-
-    samdb = SamDB(url=get_ldb_url(lp, creds, names), session_info=session_info,
-                  credentials=creds, lp=lp)
+    samdb = get_local_samdb(names, lp, creds)
 
     try:
         config_dn = samdb.get_config_basedn()
@@ -637,12 +704,11 @@ def checkusage(names, lp, creds):
         mailboxes_handled = 0
         for user_mailbox in mailboxes:
             if (user_mailbox['homeMDB'][0] == our_mailbox_store and
-                user_mailbox['msExchUserAccountControl'][0] != '2'):
+                  user_mailbox['msExchUserAccountControl'][0] != '2'):
                 mailboxes_handled += 1
 
         if mailboxes_handled > 0:
-            server_uses.append(
-                "handling %d mailboxes" % mailboxes_handled)
+            server_uses.append("handling %d mailboxes" % mailboxes_handled)
 
         return server_uses
     except LdbError, ldb_error:
@@ -668,6 +734,9 @@ def provision(setup_path, names, lp, creds, reporter=None):
 
     if reporter is None:
         reporter = TextProgressReporter()
+
+    # check not already provisioned
+    check_not_provisioned(names, lp, creds)
 
     # Install OpenChange-specific schemas
     install_schemas(setup_path, names, lp, creds, reporter)
@@ -878,3 +947,21 @@ def find_setup_dir():
     if os.path.isdir(ret):
         return os.path.abspath(ret)
     raise Exception("Unable to find setup directory.")
+
+
+def check_not_provisioned(names, lp, creds):
+    """
+    Check if the server is not already provisioned.
+    For now only checking there are not exchange organizations created.
+    """
+    sam_db = get_schema_master_samdb(names, lp, creds)
+    basedn = 'CN=Services,' + sam_db.get_config_basedn().get_linearized()
+    ret = sam_db.search(
+        attrs=['name'],
+        base=basedn,
+        expression='(objectclass=msExchOrganizationContainer)',
+        scope=ldb.SCOPE_SUBTREE)
+    if len(ret) > 0:
+        firstorg = ret[0]['name'][0]
+        raise Exception(
+            'There is already, at least, one provisioned organization: %(name)s' % {'name': firstorg})

--- a/setup/AD/oc_provision_schema_attributes.ldif
+++ b/setup/AD/oc_provision_schema_attributes.ldif
@@ -256,6 +256,35 @@ isMemberOfPartialAttributeSet: FALSE
 objectCategory: CN=Attribute-Schema,${SCHEMADN}
 
 
+#
+# ms-Exch-Address-List-Service-Link	 
+# A link from the address list service to the Exchange server it
+# should be running on.
+#
+dn: CN=ms-Exch-Address-List-Service-Link,${SCHEMADN}
+objectClass: top
+objectClass: attributeSchema
+cn: ms-Exch-Address-List-Service-Link
+distinguishedName: CN=ms-Exch-Address-List-Service-Link,${SCHEMADN}
+attributeID: 1.2.840.113556.1.4.7000.102.75
+attributeSyntax: 2.5.5.1
+isSingleValued: TRUE
+linkID: 1016
+showInAdvancedViewOnly: TRUE
+adminDisplayName: ms-Exch-Address-List-Service-Link
+oMObjectClass:: KwwCh3McAIVK
+adminDescription: ms-Exch-Address-List-Service-Link
+oMSyntax: 127
+searchFlags: 0
+lDAPDisplayName: msExchAddressListServiceLink
+name: ms-Exch-Address-List-Service-Link
+schemaIDGUID: 9b6e9584-b093-11d2-aa06-00c04f8eedd8
+isMemberOfPartialAttributeSet: FALSE
+objectCategory: CN=Attribute-Schema,${SCHEMADN}
+
+
+
+
 
 #
 # ms-Exch-Address-List-Service-BL   
@@ -281,35 +310,6 @@ lDAPDisplayName: msExchAddressListServiceBL
 name: ms-Exch-Address-List-Service-BL
 schemaIDGUID: 8a407b6e-b09e-11d2-aa06-00c04f8eedd8
 systemFlags: 1
-isMemberOfPartialAttributeSet: FALSE
-objectCategory: CN=Attribute-Schema,${SCHEMADN}
-
-
-
-
-#
-# ms-Exch-Address-List-Service-Link	 
-# A link from the address list service to the Exchange server it
-# should be running on.
-#
-dn: CN=ms-Exch-Address-List-Service-Link,${SCHEMADN}
-objectClass: top
-objectClass: attributeSchema
-cn: ms-Exch-Address-List-Service-Link
-distinguishedName: CN=ms-Exch-Address-List-Service-Link,${SCHEMADN}
-attributeID: 1.2.840.113556.1.4.7000.102.75
-attributeSyntax: 2.5.5.1
-isSingleValued: TRUE
-linkID: 1016
-showInAdvancedViewOnly: TRUE
-adminDisplayName: ms-Exch-Address-List-Service-Link
-oMObjectClass:: KwwCh3McAIVK
-adminDescription: ms-Exch-Address-List-Service-Link
-oMSyntax: 127
-searchFlags: 0
-lDAPDisplayName: msExchAddressListServiceLink
-name: ms-Exch-Address-List-Service-Link
-schemaIDGUID: 9b6e9584-b093-11d2-aa06-00c04f8eedd8
 isMemberOfPartialAttributeSet: FALSE
 objectCategory: CN=Attribute-Schema,${SCHEMADN}
 
@@ -1002,6 +1002,32 @@ objectCategory: CN=Attribute-Schema,${SCHEMADN}
 
 
 #
+# ms-Exch-Responsible-Local-DXA	
+#
+dn: CN=ms-Exch-Responsible-Local-DXA,${SCHEMADN}
+objectClass: top
+objectClass: attributeSchema
+cn: ms-Exch-Responsible-Local-DXA
+distinguishedName: CN=ms-Exch-Responsible-Local-DXA,${SCHEMADN}
+attributeID: 1.2.840.113556.1.2.298
+attributeSyntax: 2.5.5.1
+isSingleValued: TRUE
+mAPIID: 33059
+linkID: 122
+showInAdvancedViewOnly: TRUE
+adminDisplayName: ms-Exch-Responsible-Local-DXA
+oMObjectClass:: KwwCh3McAIVK
+adminDescription: ms-Exch-Responsible-Local-DXA
+oMSyntax: 127
+searchFlags: 0
+lDAPDisplayName: responsibleLocalDXA
+name: ms-Exch-Responsible-Local-DXA
+schemaIDGUID: a8df7462-c5ea-11d1-bbcb-0080c76670c0
+isMemberOfPartialAttributeSet: FALSE
+objectCategory: CN=Attribute-Schema,${SCHEMADN}
+
+
+#
 # ms-Exch-Assoc-Remote-DXA
 #
 dn: CN=ms-Exch-Assoc-Remote-DXA,${SCHEMADN}
@@ -1541,6 +1567,33 @@ objectCategory: CN=Attribute-Schema,${SCHEMADN}
 
 
 
+#
+# ms-Exch-Source-Bridgehead-Servers-DN		  
+# Pointers to SMTP virtual servers of servers in bridgehead on the
+# local side of Exchange Connector.
+#
+dn: CN=ms-Exch-Source-Bridgehead-Servers-DN,${SCHEMADN}
+objectClass: top
+objectClass: attributeSchema
+cn: ms-Exch-Source-Bridgehead-Servers-DN
+distinguishedName: CN=ms-Exch-Source-Bridgehead-Servers-DN,${SCHEMADN}
+attributeID: 1.2.840.113556.1.4.7000.102.12511
+attributeSyntax: 2.5.5.1
+isSingleValued: FALSE
+linkID: 1002
+showInAdvancedViewOnly: TRUE
+adminDisplayName: ms-Exch-Source-Bridgehead-Servers-DN
+oMObjectClass:: KwwCh3McAIVK
+adminDescription: ms-Exch-Source-Bridgehead-Servers-DN
+oMSyntax: 127
+searchFlags: 0
+lDAPDisplayName: msExchSourceBridgeheadServersDN
+name: ms-Exch-Source-Bridgehead-Servers-DN
+schemaIDGUID: 206f4094-b099-11d2-aa06-00c04f8eedd8
+isMemberOfPartialAttributeSet: FALSE
+objectCategory: CN=Attribute-Schema,${SCHEMADN}
+
+
 
 #
 # ms-Exch-Bridgeheaded-Local-Connectors-DN-BL	
@@ -1569,6 +1622,34 @@ systemFlags: 1
 isMemberOfPartialAttributeSet: FALSE
 objectCategory: CN=Attribute-Schema,${SCHEMADN}
 
+
+
+
+#
+# ms-Exch-Target-Bridgehead-Servers-DN	
+# Pointers to bridgehead SMTP virtual servers in the connector target
+# routing group (RG).
+#
+dn: CN=ms-Exch-Target-Bridgehead-Servers-DN,${SCHEMADN}
+objectClass: top
+objectClass: attributeSchema
+cn: ms-Exch-Target-Bridgehead-Servers-DN
+distinguishedName: CN=ms-Exch-Target-Bridgehead-Servers-DN,${SCHEMADN}
+attributeID: 1.2.840.113556.1.4.7000.102.12514
+attributeSyntax: 2.5.5.1
+isSingleValued: FALSE
+linkID: 1004
+showInAdvancedViewOnly: TRUE
+adminDisplayName: ms-Exch-Target-Bridgehead-Servers-DN
+oMObjectClass:: KwwCh3McAIVK
+adminDescription: ms-Exch-Target-Bridgehead-Servers-DN
+oMSyntax: 127
+searchFlags: 0
+lDAPDisplayName: msExchTargetBridgeheadServersDN
+name: ms-Exch-Target-Bridgehead-Servers-DN
+schemaIDGUID: 20da8a66-b099-11d2-aa06-00c04f8eedd8
+isMemberOfPartialAttributeSet: FALSE
+objectCategory: CN=Attribute-Schema,${SCHEMADN}
 
 
 
@@ -3330,6 +3411,33 @@ schemaIDGUID: 9af29b3c-b093-11d2-aa06-00c04f8eedd8
 isMemberOfPartialAttributeSet: FALSE
 objectCategory: CN=Attribute-Schema,${SCHEMADN}
 
+
+
+#
+# ms-Exch-Home-Sync-Service  
+# Link to the Active Directory Connector (ADC) for this connection
+# agreement.
+#
+dn: CN=ms-Exch-Home-Sync-Service,${SCHEMADN}
+objectClass: top
+objectClass: attributeSchema
+cn: ms-Exch-Home-Sync-Service
+distinguishedName: CN=ms-Exch-Home-Sync-Service,${SCHEMADN}
+attributeID: 1.2.840.113556.1.4.7000.102.36
+attributeSyntax: 2.5.5.1
+isSingleValued: TRUE
+linkID: 146
+showInAdvancedViewOnly: TRUE
+adminDisplayName: ms-Exch-Home-Sync-Service
+oMObjectClass:: KwwCh3McAIVK
+adminDescription: ms-Exch-Home-Sync-Service
+oMSyntax: 127
+searchFlags: 0
+lDAPDisplayName: msExchHomeSyncService
+name: ms-Exch-Home-Sync-Service
+schemaIDGUID: a2a3f1a0-b093-11d2-aa06-00c04f8eedd8
+isMemberOfPartialAttributeSet: FALSE
+objectCategory: CN=Attribute-Schema,${SCHEMADN}
 
 
 
@@ -8143,6 +8251,32 @@ objectCategory: CN=Attribute-Schema,${SCHEMADN}
 
 
 
+
+#
+# ms-Exch-Export-Containers-Linked 
+#
+dn: CN=ms-Exch-Export-Containers-Linked,${SCHEMADN}
+objectClass: top
+objectClass: attributeSchema
+cn: ms-Exch-Export-Containers-Linked
+distinguishedName: CN=ms-Exch-Export-Containers-Linked,${SCHEMADN}
+attributeID: 1.2.840.113556.1.4.7000.102.1026
+attributeSyntax: 2.5.5.1
+isSingleValued: FALSE
+linkID: 1028
+showInAdvancedViewOnly: TRUE
+adminDisplayName: ms-Exch-Export-Containers-Linked
+oMObjectClass:: KwwCh3McAIVK
+adminDescription: ms-Exch-Export-Containers-Linked
+oMSyntax: 127
+searchFlags: 0
+lDAPDisplayName: msExchExportContainersLinked
+name: ms-Exch-Export-Containers-Linked
+schemaIDGUID: 3b7ea364-1d4d-11d3-aa5e-00c04f8eedd8
+isMemberOfPartialAttributeSet: FALSE
+objectCategory: CN=Attribute-Schema,${SCHEMADN}
+
+
 #
 # ms-Exch-Export-Containers-BL	  
 #
@@ -8168,32 +8302,6 @@ systemFlags: 1
 isMemberOfPartialAttributeSet: FALSE
 objectCategory: CN=Attribute-Schema,${SCHEMADN}
 
-
-
-
-#
-# ms-Exch-Export-Containers-Linked 
-#
-dn: CN=ms-Exch-Export-Containers-Linked,${SCHEMADN}
-objectClass: top
-objectClass: attributeSchema
-cn: ms-Exch-Export-Containers-Linked
-distinguishedName: CN=ms-Exch-Export-Containers-Linked,${SCHEMADN}
-attributeID: 1.2.840.113556.1.4.7000.102.1026
-attributeSyntax: 2.5.5.1
-isSingleValued: FALSE
-linkID: 1028
-showInAdvancedViewOnly: TRUE
-adminDisplayName: ms-Exch-Export-Containers-Linked
-oMObjectClass:: KwwCh3McAIVK
-adminDescription: ms-Exch-Export-Containers-Linked
-oMSyntax: 127
-searchFlags: 0
-lDAPDisplayName: msExchExportContainersLinked
-name: ms-Exch-Export-Containers-Linked
-schemaIDGUID: 3b7ea364-1d4d-11d3-aa5e-00c04f8eedd8
-isMemberOfPartialAttributeSet: FALSE
-objectCategory: CN=Attribute-Schema,${SCHEMADN}
 
 
 
@@ -9475,6 +9583,32 @@ objectCategory: CN=Attribute-Schema,${SCHEMADN}
 
 
 
+#
+# ms-Exch-Routing-Group-Members-DN 
+# Pointers to virtual servers of servers in a Exchange Routing Group.
+#
+dn: CN=ms-Exch-Routing-Group-Members-DN,${SCHEMADN}
+objectClass: top
+objectClass: attributeSchema
+cn: ms-Exch-Routing-Group-Members-DN
+distinguishedName: CN=ms-Exch-Routing-Group-Members-DN,${SCHEMADN}
+attributeID: 1.2.840.113556.1.4.7000.102.12506
+attributeSyntax: 2.5.5.1
+isSingleValued: FALSE
+linkID: 1000
+showInAdvancedViewOnly: TRUE
+adminDisplayName: ms-Exch-Routing-Group-Members-DN
+oMObjectClass:: KwwCh3McAIVK
+adminDescription: ms-Exch-Routing-Group-Members-DN
+oMSyntax: 127
+searchFlags: 1
+lDAPDisplayName: msExchRoutingGroupMembersDN
+name: ms-Exch-Routing-Group-Members-DN
+schemaIDGUID: 1ff9ed9a-b098-11d2-aa06-00c04f8eedd8
+isMemberOfPartialAttributeSet: FALSE
+objectCategory: CN=Attribute-Schema,${SCHEMADN}
+
+
 
 #
 # ms-Exch-Home-Routing-Group-DN-BL	 
@@ -9528,33 +9662,6 @@ attributeSecurityGUID: e48d0154-bcf8-11d1-8702-00c04fb96050
 isMemberOfPartialAttributeSet: TRUE
 objectCategory: CN=Attribute-Schema,${SCHEMADN}
 
-
-
-#
-# ms-Exch-Home-Sync-Service  
-# Link to the Active Directory Connector (ADC) for this connection
-# agreement.
-#
-dn: CN=ms-Exch-Home-Sync-Service,${SCHEMADN}
-objectClass: top
-objectClass: attributeSchema
-cn: ms-Exch-Home-Sync-Service
-distinguishedName: CN=ms-Exch-Home-Sync-Service,${SCHEMADN}
-attributeID: 1.2.840.113556.1.4.7000.102.36
-attributeSyntax: 2.5.5.1
-isSingleValued: TRUE
-linkID: 146
-showInAdvancedViewOnly: TRUE
-adminDisplayName: ms-Exch-Home-Sync-Service
-oMObjectClass:: KwwCh3McAIVK
-adminDescription: ms-Exch-Home-Sync-Service
-oMSyntax: 127
-searchFlags: 0
-lDAPDisplayName: msExchHomeSyncService
-name: ms-Exch-Home-Sync-Service
-schemaIDGUID: a2a3f1a0-b093-11d2-aa06-00c04f8eedd8
-isMemberOfPartialAttributeSet: FALSE
-objectCategory: CN=Attribute-Schema,${SCHEMADN}
 
 
 
@@ -17309,33 +17416,6 @@ objectCategory: CN=Attribute-Schema,${SCHEMADN}
 
 
 #
-# ms-Exch-Responsible-Local-DXA	
-#
-dn: CN=ms-Exch-Responsible-Local-DXA,${SCHEMADN}
-objectClass: top
-objectClass: attributeSchema
-cn: ms-Exch-Responsible-Local-DXA
-distinguishedName: CN=ms-Exch-Responsible-Local-DXA,${SCHEMADN}
-attributeID: 1.2.840.113556.1.2.298
-attributeSyntax: 2.5.5.1
-isSingleValued: TRUE
-mAPIID: 33059
-linkID: 122
-showInAdvancedViewOnly: TRUE
-adminDisplayName: ms-Exch-Responsible-Local-DXA
-oMObjectClass:: KwwCh3McAIVK
-adminDescription: ms-Exch-Responsible-Local-DXA
-oMSyntax: 127
-searchFlags: 0
-lDAPDisplayName: responsibleLocalDXA
-name: ms-Exch-Responsible-Local-DXA
-schemaIDGUID: a8df7462-c5ea-11d1-bbcb-0080c76670c0
-isMemberOfPartialAttributeSet: FALSE
-objectCategory: CN=Attribute-Schema,${SCHEMADN}
-
-
-
-#
 # ms-Exch-Responsible-MTA-Server    
 #
 dn: CN=ms-Exch-Responsible-MTA-Server,${SCHEMADN}
@@ -17723,32 +17803,6 @@ systemFlags: 1
 isMemberOfPartialAttributeSet: FALSE
 objectCategory: CN=Attribute-Schema,${SCHEMADN}
 
-
-
-#
-# ms-Exch-Routing-Group-Members-DN 
-# Pointers to virtual servers of servers in a Exchange Routing Group.
-#
-dn: CN=ms-Exch-Routing-Group-Members-DN,${SCHEMADN}
-objectClass: top
-objectClass: attributeSchema
-cn: ms-Exch-Routing-Group-Members-DN
-distinguishedName: CN=ms-Exch-Routing-Group-Members-DN,${SCHEMADN}
-attributeID: 1.2.840.113556.1.4.7000.102.12506
-attributeSyntax: 2.5.5.1
-isSingleValued: FALSE
-linkID: 1000
-showInAdvancedViewOnly: TRUE
-adminDisplayName: ms-Exch-Routing-Group-Members-DN
-oMObjectClass:: KwwCh3McAIVK
-adminDescription: ms-Exch-Routing-Group-Members-DN
-oMSyntax: 127
-searchFlags: 1
-lDAPDisplayName: msExchRoutingGroupMembersDN
-name: ms-Exch-Routing-Group-Members-DN
-schemaIDGUID: 1ff9ed9a-b098-11d2-aa06-00c04f8eedd8
-isMemberOfPartialAttributeSet: FALSE
-objectCategory: CN=Attribute-Schema,${SCHEMADN}
 
 
 
@@ -21808,33 +21862,6 @@ objectCategory: CN=Attribute-Schema,${SCHEMADN}
 
 
 
-#
-# ms-Exch-Source-Bridgehead-Servers-DN		  
-# Pointers to SMTP virtual servers of servers in bridgehead on the
-# local side of Exchange Connector.
-#
-dn: CN=ms-Exch-Source-Bridgehead-Servers-DN,${SCHEMADN}
-objectClass: top
-objectClass: attributeSchema
-cn: ms-Exch-Source-Bridgehead-Servers-DN
-distinguishedName: CN=ms-Exch-Source-Bridgehead-Servers-DN,${SCHEMADN}
-attributeID: 1.2.840.113556.1.4.7000.102.12511
-attributeSyntax: 2.5.5.1
-isSingleValued: FALSE
-linkID: 1002
-showInAdvancedViewOnly: TRUE
-adminDisplayName: ms-Exch-Source-Bridgehead-Servers-DN
-oMObjectClass:: KwwCh3McAIVK
-adminDescription: ms-Exch-Source-Bridgehead-Servers-DN
-oMSyntax: 127
-searchFlags: 0
-lDAPDisplayName: msExchSourceBridgeheadServersDN
-name: ms-Exch-Source-Bridgehead-Servers-DN
-schemaIDGUID: 206f4094-b099-11d2-aa06-00c04f8eedd8
-isMemberOfPartialAttributeSet: FALSE
-objectCategory: CN=Attribute-Schema,${SCHEMADN}
-
-
 
 #
 # ms-Exch-Space-Last-Computed	    
@@ -22135,34 +22162,6 @@ attributeSecurityGUID: e48d0154-bcf8-11d1-8702-00c04fb96050
 isMemberOfPartialAttributeSet: TRUE
 objectCategory: CN=Attribute-Schema,${SCHEMADN}
 
-
-
-
-#
-# ms-Exch-Target-Bridgehead-Servers-DN	
-# Pointers to bridgehead SMTP virtual servers in the connector target
-# routing group (RG).
-#
-dn: CN=ms-Exch-Target-Bridgehead-Servers-DN,${SCHEMADN}
-objectClass: top
-objectClass: attributeSchema
-cn: ms-Exch-Target-Bridgehead-Servers-DN
-distinguishedName: CN=ms-Exch-Target-Bridgehead-Servers-DN,${SCHEMADN}
-attributeID: 1.2.840.113556.1.4.7000.102.12514
-attributeSyntax: 2.5.5.1
-isSingleValued: FALSE
-linkID: 1004
-showInAdvancedViewOnly: TRUE
-adminDisplayName: ms-Exch-Target-Bridgehead-Servers-DN
-oMObjectClass:: KwwCh3McAIVK
-adminDescription: ms-Exch-Target-Bridgehead-Servers-DN
-oMSyntax: 127
-searchFlags: 0
-lDAPDisplayName: msExchTargetBridgeheadServersDN
-name: ms-Exch-Target-Bridgehead-Servers-DN
-schemaIDGUID: 20da8a66-b099-11d2-aa06-00c04f8eedd8
-isMemberOfPartialAttributeSet: FALSE
-objectCategory: CN=Attribute-Schema,${SCHEMADN}
 
 
 
@@ -23798,3 +23797,21 @@ name: ms-Exch-XMIT-Timeout-Urgent
 schemaIDGUID: 1482fed4-b098-11d2-aa06-00c04f8eedd8
 isMemberOfPartialAttributeSet: FALSE
 objectCategory: CN=Attribute-Schema,${SCHEMADN}
+
+
+#
+# Legacy-Exchange-DN
+# 
+cn: Legacy-Exchange-DN
+ldapDisplayName: legacyExchangeDN
+attributeId: 1.2.840.113556.1.4.655
+attributeSyntax: 2.5.5.4
+omSyntax: 20
+isSingleValued: TRUE
+schemaIdGuid: 28630ebc-41d5-11d1-a9c1-0000f80367c1
+systemOnly: FALSE
+searchFlags:fPRESERVEONDELETE| fANR | fATTINDEX
+attributeSecurityGuid: e48d0154-bcf8-11d1-8702-00c04fb96050
+isMemberOfPartialAttributeSet: TRUE
+systemFlags: FLAG_SCHEMA_BASE_OBJECT
+schemaFlagsEx: FLAG_ATTR_IS_CRITICAL

--- a/setup/AD/update_now.ldif
+++ b/setup/AD/update_now.ldif
@@ -1,0 +1,4 @@
+dn:
+changetype: modify
+replace: schemaupdatenow
+schemaupdatenow: 1


### PR DESCRIPTION
... Master is a windows without exchange installed

Changes in schemas:
- reorder to avoid problems with linkID
- added Legacy-Exchange-DN, not used in openchange but needed to ad correctly the schemas to windows
- do not use schemaIDGUID. (not removed from the schemas themselves but removed by code before sending them)
