### PR TITLE
Enable async notifications.

### DIFF
--- a/libmapi/IMSProvider.c
+++ b/libmapi/IMSProvider.c
@@ -304,6 +304,12 @@ enum MAPISTATUS Logon(struct mapi_session *session,
 			OPENCHANGE_RETVAL_IF(!NT_STATUS_IS_OK(status), MAPI_E_LOGON_FAILED, NULL);
 			mapistatus = emsmdb_async_connect(prov_ctx);
 			OPENCHANGE_RETVAL_IF(mapistatus, mapistatus, NULL);
+
+			session->notify_ctx = talloc_zero(prov_ctx->mem_ctx, struct mapi_notify_ctx);
+
+			session->notify_ctx->notifications = talloc_zero((TALLOC_CTX *)session->notify_ctx, struct notifications);
+			session->notify_ctx->notifications->prev = NULL;
+			session->notify_ctx->notifications->next = NULL;
 		}
 
 		break;
@@ -505,12 +511,6 @@ _PUBLIC_ enum MAPISTATUS RegisterAsyncNotification(struct mapi_session *session,
 
 	emsmdb = (struct emsmdb_context *)session->emsmdb->ctx;
 	
-	session->notify_ctx = talloc_zero(emsmdb->mem_ctx, struct mapi_notify_ctx);
-
-	session->notify_ctx->notifications = talloc_zero((TALLOC_CTX *)session->notify_ctx, struct notifications);
-	session->notify_ctx->notifications->prev = NULL;
-	session->notify_ctx->notifications->next = NULL;
-
 	mapistatus = emsmdb_async_waitex(emsmdb, 0, resultFlag);
 	OPENCHANGE_RETVAL_IF(mapistatus, mapistatus, NULL);
 

--- a/libmapi/async_emsmdb.c
+++ b/libmapi/async_emsmdb.c
@@ -60,8 +60,12 @@ enum MAPISTATUS emsmdb_async_waitex(struct emsmdb_context *emsmdb_ctx, uint32_t 
 	r.out.pulFlagsOut = flagsOut;
 	dcerpc_binding_handle_set_timeout(emsmdb_ctx->async_rpc_connection->binding_handle, 400);
 	status = dcerpc_EcDoAsyncWaitEx_r(emsmdb_ctx->async_rpc_connection->binding_handle, emsmdb_ctx->mem_ctx, &r);
+
+	/* If the call failed, map NT_STATUS to MAPISTATUS. r.out.result isn't valid unless status is OK */
+	OPENCHANGE_RETVAL_IF(NT_STATUS_EQUAL(status, NT_STATUS_IO_TIMEOUT), MAPI_E_TIMEOUT, NULL);
+	OPENCHANGE_RETVAL_IF(NT_STATUS_EQUAL(status, NT_STATUS_CONNECTION_DISCONNECTED), MAPI_E_END_OF_SESSION, NULL);
+	OPENCHANGE_RETVAL_IF(!NT_STATUS_IS_OK(status), NT_STATUS_V(status), NULL);
 	retval = r.out.result;
-	OPENCHANGE_RETVAL_IF(!NT_STATUS_IS_OK(status), retval, NULL);
 	OPENCHANGE_RETVAL_IF(retval, retval, NULL);
 
 	return MAPI_E_SUCCESS;

--- a/testprogs/test_asyncnotif.c
+++ b/testprogs/test_asyncnotif.c
@@ -46,7 +46,6 @@ struct poptOption popt_openchange_version[] = {
 #define POPT_OPENCHANGE_VERSION { NULL, 0, POPT_ARG_INCLUDE_TABLE, popt_openchange_version, 0, "Common openchange options:", NULL },
 #define DEFAULT_PROFDB  "%s/.openchange/profiles.ldb"
 
-#if 0
 static int callback(uint16_t NotificationType, void *NotificationData, void *private_data)
 {
 	struct HierarchyTableChange    	*htable;
@@ -177,7 +176,6 @@ static int callback(uint16_t NotificationType, void *NotificationData, void *pri
 
 	return 0;
 }
-#endif
 
 int main(int argc, const char *argv[])
 {
@@ -301,19 +299,21 @@ int main(int argc, const char *argv[])
 	retval = GetContentsTable(&obj_inbox, &obj_contentstable, 0, &count);
 	printf("mailbox contains %i messages\n", count);
 
-#if 0
-	ulEventMask = fnevNewMail|fnevObjectCreated|fnevObjectDeleted|fnevObjectModified|fnevObjectMoved|fnevObjectCopied|fnevSearchComplete|fnevTableModified|fnevStatusObjectModified;
-	retval = Subscribe(&obj_store, &ulConnection, ulEventMask, true, (mapi_notify_callback_t)callback, (void*) (&obj_store));
-        if (retval != MAPI_E_SUCCESS) {
+	uint32_t ulConnection;
+	uint16_t ulEventMask = fnevNewMail;
+	//uint16_t ulEventMask = fnevNewMail|fnevObjectCreated|fnevObjectDeleted|fnevObjectModified|fnevObjectMoved|fnevObjectCopied|fnevSearchComplete;
+	bool wholeStore = true;
+	retval = Subscribe(&obj_store, &ulConnection, ulEventMask, wholeStore, &callback, &obj_store);
+	if (retval != MAPI_E_SUCCESS) {
 		mapi_errstr("Subscribe", retval);
 		exit_code = 2;
 		goto cleanup;
 	}
-#endif
 
 	printf("about to start a long wait\n");
-	while ((retval = RegisterAsyncNotification(session, &notificationFlag)) == MAPI_E_SUCCESS) {
-		if (notificationFlag != 0x00000000) {
+	while ((retval = RegisterAsyncNotification(session, &notificationFlag)) == MAPI_E_SUCCESS ||
+	       retval == MAPI_E_TIMEOUT) {
+		if (retval == MAPI_E_SUCCESS && notificationFlag != 0x00000000) {
 			printf("Got a Notification: 0x%08x, woo hoo!\n", notificationFlag);
 			mapi_object_release(&obj_contentstable);
 			mapi_object_init(&obj_contentstable);
@@ -323,7 +323,7 @@ int main(int argc, const char *argv[])
 			printf("going around again, ^C to break out\n");
 		}
 	}
-        if (retval != MAPI_E_SUCCESS) {
+	if (retval != MAPI_E_SUCCESS) {
 		mapi_errstr("RegisterAsyncNotification", retval);
 		exit_code = 2;
 		goto cleanup;


### PR DESCRIPTION
To get notifications, we must first inform the server which ones we're interested in.  Subscribe() expects notify_ctx to be available, so we initialize it immediately after establishing an async connection.

When we do wait, the spec says the server should complete the ROP after 5minutes, but in practice this doesn't seem to be a hard limit.  If the server takes too long, then we'll timeout.  In that case we just issue a new request and continue waiting.

Tested against MS Exchange 2010.
