### PR TITLE
Fix message set properties from openchangedb

### DIFF
--- a/mapiproxy/libmapiproxy/backends/openchangedb_mysql.c
+++ b/mapiproxy/libmapiproxy/backends/openchangedb_mysql.c
@@ -3627,9 +3627,8 @@ static enum MAPISTATUS message_set_properties(TALLOC_CTX *parent_ctx,
 		tag = value->ulPropTag;
 		if (tag == PR_DEPTH || tag == PR_SOURCE_KEY ||
 		    tag == PR_PARENT_SOURCE_KEY || tag == PR_CHANGE_KEY) {
-			DEBUG(5, ("Ignored attempt to set handled property %.8x\n",
-				  tag));
-			break;
+			DEBUG(5, ("Ignored attempt to set handled property %.8x\n", tag));
+			continue;
 		}
 		attr = openchangedb_property_get_attribute(tag);
 		if (!attr) {

--- a/testsuite/libmapiproxy/openchangedb_logger.c
+++ b/testsuite/libmapiproxy/openchangedb_logger.c
@@ -625,8 +625,6 @@ static void ocdb_logger_setup(void)
 	enum MAPISTATUS mapi_status;
 	struct openchangedb_context *backend_ctx;
 
-	fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
-
 	mem_ctx = talloc_new(NULL);
 
 	mapi_status = mock_backend_init(mem_ctx, &backend_ctx);
@@ -646,7 +644,6 @@ static void ocdb_logger_setup(void)
 static void ocdb_logger_teardown(void)
 {
 	talloc_free(mem_ctx);
-	fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
 }
 
 


### PR DESCRIPTION
Now *set properties* works when setting a row with some of the *handled* properties