### PR TITLE
Include modify_recipients

### DIFF
--- a/mapiproxy/libmapistore/backends/python/rest.py
+++ b/mapiproxy/libmapistore/backends/python/rest.py
@@ -224,7 +224,7 @@ class _RESTConn(object):
         """Delete an attachment given its ID
         :param uri: path to the attachment on remote
         """
-        r = self.so.delete('%s%s' % (self.base_url, uri))
+        self.so.delete('%s%s' % (self.base_url, uri))
         return mapistore.errors.MAPISTORE_SUCCESS
 
     def create_message(self, collection, parent_id, props):
@@ -283,7 +283,7 @@ class _Indexing(object):
     def add_uri_with_fmid(self, uri, fmid):
         mstore_uri = self.uri_rest_to_mstore(uri)
         # FIXME: check if uri already exists
-        self.ictx.add_fmid(fmid, uri)
+        self.ictx.add_fmid(fmid, mstore_uri)
         return mapistore.errors.MAPISTORE_SUCCESS
 
     def add_uri(self, uri):
@@ -583,13 +583,12 @@ class FolderObject(object):
 
     def get_child_count(self, table_type):
         logger.info('[PYTHON]: [%s] folder.fet_child_count with table_type = %d' % (BackendObject.name, table_type))
-        counter = { mapistore.FOLDER_TABLE: self._count_folders,
-                    mapistore.MESSAGE_TABLE: self._count_messages,
-                    mapistore.FAI_TABLE: self._count_zero,
-                    mapistore.RULE_TABLE: self._count_zero,
-                    mapistore.ATTACHMENT_TABLE: self._count_zero,
-                    mapistore.PERMISSIONS_TABLE: self._count_zero
-                }
+        counter = {mapistore.FOLDER_TABLE: self._count_folders,
+                   mapistore.MESSAGE_TABLE: self._count_messages,
+                   mapistore.FAI_TABLE: self._count_zero,
+                   mapistore.RULE_TABLE: self._count_zero,
+                   mapistore.ATTACHMENT_TABLE: self._count_zero,
+                   mapistore.PERMISSIONS_TABLE: self._count_zero}
         return counter[table_type]()
 
     def _count_folders(self):
@@ -646,7 +645,6 @@ class MessageObject(object):
 
     def get_message_data(self):
         logger.info('[PYTHON][%s][%s]: message.get_message_data' % (BackendObject.name, self.uri))
-        print self.properties
         return (self.recipients, self.properties)
 
     def _collection_from_messageClass(self, messageclass):

--- a/mapiproxy/servers/default/emsmdb/oxcmsg.c
+++ b/mapiproxy/servers/default/emsmdb/oxcmsg.c
@@ -871,6 +871,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopModifyRecipients(TALLOC_CTX *mem_ctx,
 	struct mapi_handles			*rec = NULL;
 	struct emsmdbp_object			*object;
 	enum MAPISTATUS				retval;
+	enum mapistore_error			ret;
 	uint32_t				handle;
 	void					*private_data;
 	bool					mapistore = false;
@@ -931,7 +932,11 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopModifyRecipients(TALLOC_CTX *mem_ctx,
 				goto end;
 			}
 		}
-		mapistore_message_modify_recipients(emsmdbp_ctx->mstore_ctx, contextID, object->backend_object, columns, mapi_req->u.mapi_ModifyRecipients.cValues, recipients);
+		ret = mapistore_message_modify_recipients(emsmdbp_ctx->mstore_ctx, contextID, object->backend_object, columns, mapi_req->u.mapi_ModifyRecipients.cValues, recipients);
+		if (ret != MAPISTORE_SUCCESS) {
+			DEBUG(5, ("Error modifying the recipients\n"));
+			mapi_repl->error_code = mapistore_error_to_mapi(ret);
+		}
 	}
 	else {
 		DEBUG(0, ("Not implement yet - shouldn't occur\n"));


### PR DESCRIPTION
* ` 54e7efd` includes small modifications in _rest.py_ that improve the semantics around `message_save` (e.g. folder permissions, restrictions, etc.). Message double-save is still not possible in OL.
* `6646bef` wraps in a method the way binary properties are encoded/decoded in order to push/retrieve them from/to the server
* `c52381e` includes various small fixes in _rest.py_
* `be58fac` implements the `RopModifyRecipients` operation in the REST API backend. The way recipients are pushed to the server (as a property) should be discussed. For instance, if we pass them as a property of the message dictionaries, maybe they could also be part of the message properties in _rest.py_ and not a separate attribute of message objects (in that case, `get_message_data` in _mapistore_python.c_ should change).
* `c5c34eb` modifies `emsmdbp_copy_message_recipients_mapistore` in _emsmdbp_object.c_: it used to modify the recipients only when the display name and the email address were not the first and second properties of the recipients. Now `modify_recipients` is independent of that condition (still dependent of `recipient_count > 0`).
* `54a22fe` modifies `get_message_data` in _mapistore_python.c_: It used to retrieve a fixed set of properties from the recipients. Now it includes all the properties in the recipients in the `mapistore_message` object. The method assumes that all the recipients have the same set of properties.