### PR TITLE
ncacn_http: Add option for HTTP auth scheme

### DIFF
--- a/libmapi/IProfAdmin.c
+++ b/libmapi/IProfAdmin.c
@@ -93,7 +93,7 @@ static enum MAPISTATUS ldb_load_profile(TALLOC_CTX *mem_ctx,
 	profile->roh_tls = ldb_msg_find_attr_as_bool(msg, "roh_tls", true);
 	profile->roh_rpc_proxy_port = ldb_msg_find_attr_as_int(msg, "roh_rpc_proxy_port", 443);
 	profile->roh_rpc_proxy_server = talloc_steal(profile, ldb_msg_find_attr_as_string(msg, "roh_rpc_proxy_server", NULL));
-
+	profile->roh_http_auth = talloc_steal(profile, ldb_msg_find_attr_as_string(msg, "roh_http_auth", "ntlm"));
 	talloc_free(res);
 
 	return MAPI_E_SUCCESS;

--- a/libmapi/mapi_profile.h
+++ b/libmapi/mapi_profile.h
@@ -59,6 +59,7 @@ struct mapi_profile
 	bool		roh_tls;
 	const char	*roh_rpc_proxy_server;
 	uint32_t	roh_rpc_proxy_port;
+    const char  *roh_http_auth;
 };
 
 typedef int (*mapi_profile_callback_t)(struct PropertyRowSet_r *, const void *);


### PR DESCRIPTION
New option in mapi_profile (--roh-http-auth) to specify the HTTP
authentication scheme to use. Choose between 'basic' and 'ntlm'.

Signed-off-by: Samuel Cabrero <scabrero@zentyal.com>