### PR TITLE
Include submit_message

### DIFF
--- a/mapiproxy/libmapistore/backends/python/rest.py
+++ b/mapiproxy/libmapistore/backends/python/rest.py
@@ -297,6 +297,31 @@ class _RESTConn(object):
                     headers=headers)
         return mapistore.errors.MAPISTORE_SUCCESS
 
+    def submit_message(self, props, recipients, serv_spool):
+        msg = props.copy()
+        rcps = [rcp.copy() for rcp in recipients]
+        # base64 PtypBinary properties
+        self._encode_object_b64(msg)
+        msg["PidTagSubject"] = msg["PidTagNormalizedSubject"]
+        # Add recipients
+        rcps = [rcp.copy() for rcp in recipients]
+        if len(rcps) > 0:
+            # We assume all the recipients have the same properties
+            rcp_keys = rcps[0].keys()
+            for key in rcp_keys:
+                if mapistore.isPtypBinary(key):
+                    for rcp in rcps:
+                        value = rcp[key]
+                        rcp[key] = base64.b64encode(value)
+        else:
+            return mapistore.errors.MAPISTORE_ERR_INVALID_DATA
+        msg['recipients'] = rcps
+        headers = {'Content-Type': 'application/json'}
+        submit_data = {'msg': msg, 'serv_spool': serv_spool}
+        self.so.post('%s/mails/submit/' % self.base_url,
+                     data=json.dumps(submit_data), headers=headers)
+        return mapistore.errors.MAPISTORE_SUCCESS
+
     def _dump_request(self, payload):
         print json.dumps(payload, indent=4)
 
@@ -308,7 +333,7 @@ class _RESTConn(object):
         : param obj: Dictionary object
         """
         for key, value in obj.iteritems():
-            if mapistore.isPtypBinary(key):
+            if mapistore.isPtypBinary(key) or mapistore.isPtypServerId(key):
                 obj[key] = base64.b64encode(value)
 
     def _decode_object_b64(self, obj):
@@ -754,6 +779,22 @@ class MessageObject(object):
                 self.attachment_ids.append(att.att_id)
         self.cached_attachments = []
         return mapistore.errors.MAPISTORE_SUCCESS
+
+    def submit(self, serv_spool):
+        logger.info('[PYTHON][%s][%s]: message.submit' % (BackendObject.name,
+                    self.uri))
+        # Only E-mails can be submitted
+        collection = self._collection_from_messageClass(self.properties['PidTagMessageClass'])
+        if collection != "mails":
+            return mapistore.errors.MAPISTORE_ERR_INVALID_DATA
+        # FIXME: REST API shouldn't care about these properties
+        curr_time = float((datetime.now(tz=timezone('Europe/Madrid'))
+                           - timedelta(hours=1)).strftime("%s.%f"))
+        self.properties['PidTagClientSubmitTime'] = curr_time
+        # Submit the message to the server
+        conn = _RESTConn.get_instance()
+        return conn.submit_message(self.properties, self.recipients,
+                                   serv_spool)
 
     def create_attachment(self):
         logger.info('[PYTHON]: message.create_attachment()')

--- a/mapiproxy/libmapistore/backends/python/rest.py
+++ b/mapiproxy/libmapistore/backends/python/rest.py
@@ -259,7 +259,7 @@ class _RESTConn(object):
                     for rcp in rcps:
                         value = rcp[key]
                         rcp[key] = base64.b64encode(value)
-        msg["recipients"] = rcps
+            msg["recipients"] = rcps
         headers = {'Content-Type': 'application/json'}
         r = self.so.post('%s/%s/' % (self.base_url, collection),
                          data=json.dumps(msg), headers=headers)
@@ -292,7 +292,7 @@ class _RESTConn(object):
                     for rcp in rcps:
                         value = rcp[key]
                         rcp[key] = base64.b64encode(value)
-        msg["recipients"] = rcps
+            msg["recipients"] = rcps
         self.so.put('%s%s' % (self.base_url, uri), data=json.dumps(msg),
                     headers=headers)
         return mapistore.errors.MAPISTORE_SUCCESS

--- a/mapiproxy/libmapistore/backends/python/rest.py
+++ b/mapiproxy/libmapistore/backends/python/rest.py
@@ -707,8 +707,7 @@ class MessageObject(object):
         self.cached_attachments = []
         self.attachment_ids = att_ids
         self.next_aid = 0  # Provisional AID
-        logger.info('[PYTHON]:[%s] message.__init__(%s)' % (BackendObject.name,
-                    self.properties))
+        logger.info('[PYTHON]:[%s] message.__init__' % BackendObject.name)
 
     def get_properties(self, properties):
         logger.info('[PYTHON]:[%s][%s] message.get_properties()' % (BackendObject.name, self.uri))
@@ -838,7 +837,7 @@ class MessageObject(object):
 
 class AttachmentObject(object):
     def __init__(self, message, att=None, aid=None):
-        logger.info('[PYTHON]:[%s] attachment.__init__(%s)' % (BackendObject.name, att))
+        logger.info('[PYTHON]:[%s] attachment.__init__' % BackendObject.name)
         self.message = message
         self.properties = att
         self.att_id = aid

--- a/python/mock/rest/api_server.py
+++ b/python/mock/rest/api_server.py
@@ -378,6 +378,20 @@ def module_messages_get_attachments(msg_id):
 # Mail service
 ###############################################################################
 
+@app.route('/mails/submit/', methods=['POST'])
+def module_mail_submit():
+    """ Send mail to its recipients.
+        param data['msg']: the message properties
+        param data['serv_spool']: flag that indicates if the message needs
+            processing and by whom """
+    data = request.get_json()
+    # Read message data
+    msg = data['msg']
+    # Read processing flag (No processing required/by server/by client spooler
+    serv_spool = data['serv_spool']
+    return "", 202
+
+
 @app.route('/mails/', methods=['POST'])
 def module_mail_create():
     data = request.get_json()

--- a/python/mock/rest/api_server.py
+++ b/python/mock/rest/api_server.py
@@ -249,7 +249,7 @@ def module_folders_get_messages(folder_id):
 
 
 ###############################################################################
-# common message implementation
+# Common message implementation
 ###############################################################################
 
 def _message_create(handler, collection, data):
@@ -267,21 +267,6 @@ def _message_create(handler, collection, data):
     except KeyError, ke:
         abort(404, ke.message)
     return msg
-
-
-###############################################################################
-# Mail service
-###############################################################################
-
-@app.route('/mails/', methods=['POST'])
-def module_mail_create():
-    data = request.get_json()
-    handler = ApiHandler(user_id='any')
-    try:
-        msg = _message_create(handler, 'mails', data)
-    finally:
-        handler.close_context()
-    return jsonify(id=msg['id'])
 
 
 @app.route('/mails/<int:msg_id>/', methods=['GET'])
@@ -336,6 +321,7 @@ def module_mail_delete(msg_id):
         handler.close_context()
     return "", 204
 
+
 @app.route('/mails/<int:msg_id>/attachments', methods=['HEAD'])
 @app.route('/calendars/<int:msg_id>/attachments', methods=['HEAD'])
 @app.route('/tasks/<int:msg_id>/attachments', methods=['HEAD'])
@@ -358,6 +344,7 @@ def module_messages_head_attachments(msg_id):
         return response
 
     return jsonify()
+
 
 @app.route('/mails/<int:msg_id>/attachments', methods=['GET'])
 @app.route('/calendars/<int:msg_id>/attachments', methods=['GET'])
@@ -388,7 +375,22 @@ def module_messages_get_attachments(msg_id):
 
 
 ###############################################################################
-# Calendar
+# Mail service
+###############################################################################
+
+@app.route('/mails/', methods=['POST'])
+def module_mail_create():
+    data = request.get_json()
+    handler = ApiHandler(user_id='any')
+    try:
+        msg = _message_create(handler, 'mails', data)
+    finally:
+        handler.close_context()
+    return jsonify(id=msg['id'])
+
+
+###############################################################################
+# Calendar service
 ###############################################################################
 
 @app.route('/calendars/', methods=['POST'])
@@ -421,8 +423,6 @@ def module_tasks_create():
 # Contacts service
 ###############################################################################
 
-import pprint
-
 @app.route('/contacts/', methods=['POST'])
 def module_contacts_create():
     data = request.get_json()
@@ -452,6 +452,7 @@ def module_notes_create():
 ###############################################################################
 # Attachment
 ###############################################################################
+
 @app.route('/attachments/', methods=['POST'])
 def module_attachments_create():
     data = request.get_json()
@@ -470,6 +471,7 @@ def module_attachments_create():
         handler.close_context()
     return jsonify(id=att['id'])
 
+
 @app.route('/attachments/<int:att_id>/', methods=['GET'])
 def module_attachments_get(att_id):
     """Fetch single attachment by its ID"""
@@ -483,6 +485,7 @@ def module_attachments_get(att_id):
         handler.close_context()
     return jsonify(ret_val)
 
+
 @app.route('/attachments/<int:att_id>/', methods=['PUT'])
 def module_attachments_put(att_id):
     data = request.get_json()
@@ -494,6 +497,7 @@ def module_attachments_put(att_id):
     finally:
         handler.close_context()
     return "", 201
+
 
 @app.route('/attachments/<int:att_id>/', methods=['HEAD'])
 def module_attachments_head(att_id):


### PR DESCRIPTION
This PR implements the submit operation for E-mails in mapistore_python.c and rest.py. The latter doesn't check the return value of the server, which at this moment only takes the parameters (the message properties+recipients and the flag that indicates if any processing is needed).

The method doesn't check the permissions either, nor it modifies any properties apart from `PidTagClientSubmitTime`.