### PR TITLE
Add check option to openchange_provision

### DIFF
--- a/setup/openchange_provision
+++ b/setup/openchange_provision
@@ -52,6 +52,7 @@ parser.add_option("--openchangedb-uri", type="string", default="",
                        "specifying a connection string like mysql://user:passwd@host/db_name")
 parser.add_option("--deprovision", action="store_true", help="Uninstall the Exchange schema and objects from AD")
 parser.add_option("--migrate", action="store_true", help="Migrate MySQL schema of an existing OpenChange installation")
+parser.add_option("--check", action="store_true", help="Check whether the server can be provisioned")
 
 opts,args = parser.parse_args()
 if len(args) != 0:
@@ -72,7 +73,7 @@ def setup_path(*args):
 provisionnames = openchange.guess_names_from_smbconf(
     lp, creds, opts.firstorg, opts.firstou)
 
-if not opts.openchangedb:
+if not opts.openchangedb and not opts.check:
     if opts.deprovision:
         try:
             openchange.unregister(setup_path, provisionnames, lp, creds)
@@ -97,5 +98,7 @@ if not opts.openchangedb:
     else:
         parser.print_help()
         sys.exit(1)
+elif opts.check:
+    openchange.check_not_provisioned(provisionnames, lp, creds)
 else:
     openchange.openchangedb_provision(provisionnames, lp, opts.openchangedb_uri)


### PR DESCRIPTION
This option checks if the provision is possible. I added it because it is needed for Zentyal
server integration and I think it could be useful for more people.
If you do not find it useful, just clsoe the pull request and I will make a script
for Zentyal |server instead