### PR TITLE
Remove default backend.

### DIFF
--- a/mapiproxy/libmapiproxy/openchangedb.c
+++ b/mapiproxy/libmapiproxy/openchangedb.c
@@ -48,10 +48,14 @@ _PUBLIC_ enum MAPISTATUS openchangedb_initialize(TALLOC_CTX *mem_ctx,
 	enum MAPISTATUS retval;
 	const char *openchangedb_backend = lpcfg_parm_string(lp_ctx, NULL, "mapiproxy",
 							     "openchangedb");
-	if (openchangedb_backend) {
+
+	if (openchangedb_backend == NULL) {
+		retval = MAPI_E_NOT_INITIALIZED;
+		DEBUG(0, ("No OpenChangeDB backend specified, please provision."));
+	} else if (strncmp(openchangedb_backend, "mysql:", strlen("mysql:")) == 0) {
 		DEBUG(0, ("Using MySQL backend for openchangedb: %s\n", openchangedb_backend));
 		retval = openchangedb_mysql_initialize(mem_ctx, lp_ctx, oc_ctx);
-	} else {
+	} else if (strncmp(openchangedb_backend, "ldb:", strlen("ldb:")) == 0) {
 		DEBUG(0, ("Using default backend for openchangedb\n"));
 		retval = openchangedb_ldb_initialize(mem_ctx,
 						     lpcfg_private_dir(lp_ctx),
@@ -112,7 +116,7 @@ _PUBLIC_ enum MAPISTATUS openchangedb_get_SystemFolderID(struct openchangedb_con
 	OPENCHANGE_RETVAL_IF(!oc_ctx, MAPI_E_NOT_INITIALIZED, NULL);
 	OPENCHANGE_RETVAL_IF(!recipient, MAPI_E_INVALID_PARAMETER, NULL);
 	OPENCHANGE_RETVAL_IF(!FolderId, MAPI_E_INVALID_PARAMETER, NULL);
-	
+
 	return oc_ctx->get_SystemFolderID(oc_ctx, recipient, SystemIdx, FolderId);
 }
 

--- a/mapiproxy/libmapiproxy/openchangedb.c
+++ b/mapiproxy/libmapiproxy/openchangedb.c
@@ -51,7 +51,7 @@ _PUBLIC_ enum MAPISTATUS openchangedb_initialize(TALLOC_CTX *mem_ctx,
 
 	if (openchangedb_backend == NULL) {
 		retval = MAPI_E_NOT_INITIALIZED;
-		DEBUG(0, ("No OpenChangeDB backend specified, please provision."));
+		DEBUG(0, ("No OpenChangeDB backend specified, please provision.\n"));
 	} else if (strncmp(openchangedb_backend, "mysql:", strlen("mysql:")) == 0) {
 		DEBUG(0, ("Using MySQL backend for openchangedb: %s\n", openchangedb_backend));
 		retval = openchangedb_mysql_initialize(mem_ctx, lp_ctx, oc_ctx);
@@ -60,6 +60,9 @@ _PUBLIC_ enum MAPISTATUS openchangedb_initialize(TALLOC_CTX *mem_ctx,
 		retval = openchangedb_ldb_initialize(mem_ctx,
 						     lpcfg_private_dir(lp_ctx),
 						     oc_ctx);
+	} else {
+		DEBUG(0, ("Unknown backend in URI %s\n", openchangedb_backend));
+		retval = MAPI_E_NOT_FOUND;
 	}
 
 	if (retval != MAPI_E_SUCCESS) {

--- a/python/openchange/provision.py
+++ b/python/openchange/provision.py
@@ -896,7 +896,7 @@ def registerasmain(setup_path, names, lp, creds, reporter=None):
 
 
 def openchangedb_deprovision(names, lp, mapistore=None):
-    """Removed the OpenChange database.
+    """Remove the OpenChange database.
 
     :param names: Provision names object
     :param lp: Loadparm context
@@ -905,16 +905,18 @@ def openchangedb_deprovision(names, lp, mapistore=None):
 
     print "Removing openchange db"
     uri = openchangedb_url(lp)
-    if uri.startswith('mysql'):
+    if uri.startswith('mysql:'):
         openchangedb = mailbox.OpenChangeDBWithMysqlBackend(uri)
-    else:
+    elif uri.startswith('ldb:'):
         openchangedb = mailbox.OpenChangeDB(uri)
+    else:
+        raise Exception("unknown backend in openchangedb URI %s" % uri)
     openchangedb.remove()
 
 
 def openchangedb_migrate(lp):
     uri = openchangedb_url(lp)
-    if uri.startswith('mysql'):
+    if uri.startswith('mysql:'):
         openchangedb = mailbox.OpenChangeDBWithMysqlBackend(uri)
         if openchangedb.migrate():
             print "Migration openchange db done"
@@ -928,14 +930,13 @@ def openchangedb_provision(names, lp, uri=None):
     :param names: Provision names object
     :param lp: Loadparm context
     :param uri: Openchangedb destination, by default will be a ldb file inside
-    private samba directory. You can specify a mysql connection string like
-    mysql://user:passwd@host/db_name to use openchangedb with mysql backend
+        private samba directory. You can specify a mysql connection string like
+        mysql://user:passwd@host/db_name to use openchangedb with mysql backend
     """
-
     print "Setting up openchange db"
-    if uri is None or len(uri) == 0 or uri.startswith('ldb'):  # LDB backend
+    if uri.startswith('ldb:'):  # LDB backend
         openchangedb = mailbox.OpenChangeDB(openchangedb_url(lp))
-    elif uri.startswith('mysql'):  # MySQL backend
+    elif uri.startswith('mysql:'):  # MySQL backend
         openchangedb = mailbox.OpenChangeDBWithMysqlBackend(uri, find_setup_dir())
     else:
         print "[!] error provisioning openchangedb: Unknown uri `%s`" % uri

--- a/python/openchange/provision.py
+++ b/python/openchange/provision.py
@@ -924,14 +924,14 @@ def openchangedb_migrate(lp):
         print "Only OpenchangeDB with MySQL as backend needs migration"
 
 
-def openchangedb_provision(names, lp, uri=None):
+def openchangedb_provision(names, lp, uri):
     """Create the OpenChange database.
 
     :param names: Provision names object
     :param lp: Loadparm context
-    :param uri: Openchangedb destination, by default will be a ldb file inside
-        private samba directory. You can specify a mysql connection string like
-        mysql://user:passwd@host/db_name to use openchangedb with mysql backend
+    :param uri: Openchangedb destination. You can specify a mysql connection
+        string like mysql://user:passwd@host/db_name to use openchangedb with
+        mysql backend or ldb: for LDB.
     """
     print "Setting up openchange db"
     if uri.startswith('ldb:'):  # LDB backend

--- a/python/openchange/tests/test_provision.py
+++ b/python/openchange/tests/test_provision.py
@@ -18,13 +18,11 @@
 #
 
 from samba import param
-from samba.credentials import Credentials
 from samba.tests import TestCaseInTempDir
-from samba.tests.samdb import SamDBTestCase
-from openchange.provision import (install_schemas, openchangedb_provision,
-    guess_names_from_smbconf, find_setup_dir)
+from openchange.provision import (
+    openchangedb_provision,
+    guess_names_from_smbconf)
 import os
-import shutil
 
 """
     FIXME: Not working, the issue is at SamDBTestCase code
@@ -50,6 +48,6 @@ class OpenChangeDBProvisionTestCase(TestCaseInTempDir):
         lp.load_default()
         lp.set("private dir", self.tempdir)
         names = guess_names_from_smbconf(lp, firstorg="bar", firstou="foo")
-        openchangedb_provision(names, lp)
+        openchangedb_provision(names, lp, "ldb://openchange.ldb")
         os.unlink(os.path.join(self.tempdir, "openchange.ldb"))
         os.unlink(os.path.join(self.tempdir, "sam.ldb"))

--- a/setup/openchange_provision
+++ b/setup/openchange_provision
@@ -46,7 +46,7 @@ parser.add_option("--standalone", action="store_true", help="Provisioning an sta
 parser.add_option("--additional", action="store_true", help="Provisioning an additional OpenChange server")
 parser.add_option("--primary-server", action="store_true", help="Set this OpenChange server as the primary server")
 parser.add_option("--openchangedb", action="store_true", help="Initialize OpenChange dispatcher database")
-parser.add_option("--openchangedb-uri", type="string", default="",
+parser.add_option("--openchangedb-uri", type="string", default="ldb://openchange.ldb",
                   help="openchange database destination, by default a ldb file (openchange.ldb) "
                        "inside samba private directory is used but you can use mysql as backend "
                        "specifying a connection string like mysql://user:passwd@host/db_name")


### PR DESCRIPTION
This means users will have to explicitly set *a* backend, whether it be ldb or mysql. 

I think this covers all code paths that deal with the default, but please let me know if there are others..