### PR TITLE
Enhance behaviour when receiving wrong GLOBCNT ranges

### DIFF
--- a/libmapi/libmapi.h
+++ b/libmapi/libmapi.h
@@ -548,6 +548,7 @@ bool			IDSET_includes_guid_glob(const struct idset *, struct GUID *, uint64_t);
 bool			IDSET_includes_eid(const struct idset *, uint64_t);
 void			IDSET_remove_rawidset(struct idset *, const struct rawidset *);
 void			IDSET_dump(const struct idset *, const char *);
+enum MAPISTATUS	IDSET_check_ranges(const struct idset *);
 void			ndr_push_idset(struct ndr_push *, struct idset *);
 
 struct globset_range *	GLOBSET_parse(TALLOC_CTX *, DATA_BLOB, uint32_t *, uint32_t *);

--- a/mapiproxy/servers/default/emsmdb/oxcfxics.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfxics.c
@@ -2741,6 +2741,12 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncUploadStateStreamEnd(TALLOC_CTX *mem_ctx
 	synccontext = synccontext_object->object.synccontext;
 	parsed_idset = IDSET_parse(synccontext, synccontext->state_stream.buffer, false);
 
+	retval = IDSET_check_ranges(parsed_idset);
+	if (retval != MAPI_E_SUCCESS) {
+		mapi_repl->error_code = retval;
+		goto reset;
+	}
+
 	switch (synccontext->state_property) {
 	case MetaTagIdsetGiven:
 		if (parsed_idset && parsed_idset->range_count == 0) {
@@ -2790,6 +2796,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncUploadStateStreamEnd(TALLOC_CTX *mem_ctx
 		talloc_free(old_idset);
 	}
 
+reset:
 	/* reset synccontext state */
 	if (synccontext->state_stream.buffer.length > 0) {
 		talloc_free(synccontext->state_stream.buffer.data);

--- a/mapiproxy/servers/default/emsmdb/oxcfxics.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfxics.c
@@ -2762,7 +2762,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncUploadStateStreamEnd(TALLOC_CTX *mem_ctx
 		retval = oxcfxics_check_cnset(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, parsed_idset, "cnset_seen");
 		if (retval != MAPI_E_SUCCESS) {
 			mapi_repl->error_code = retval;
-			goto end;
+			goto reset;
 		}
 		old_idset = synccontext->cnset_seen;
 		synccontext->cnset_seen = parsed_idset;
@@ -2774,7 +2774,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncUploadStateStreamEnd(TALLOC_CTX *mem_ctx
 		retval = oxcfxics_check_cnset(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, parsed_idset, "cnset_seen_fai");
 		if (retval != MAPI_E_SUCCESS) {
 			mapi_repl->error_code = retval;
-			goto end;
+			goto reset;
 		}
 		old_idset = synccontext->cnset_seen_fai;
 		synccontext->cnset_seen_fai = parsed_idset;
@@ -2786,7 +2786,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncUploadStateStreamEnd(TALLOC_CTX *mem_ctx
 		retval = oxcfxics_check_cnset(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, parsed_idset, "cnset_seen_read");
 		if (retval != MAPI_E_SUCCESS) {
 			mapi_repl->error_code = retval;
-			goto end;
+			goto reset;
 		}
 		old_idset = synccontext->cnset_read;
 		synccontext->cnset_read = parsed_idset;


### PR DESCRIPTION
Two fixes there as explained in the commit messages:

 * Do not crash on incorrect GLOBCNT range sent by client and send ecRpcFormat error value instead
 * Reset synccontext when the sent cn is greater than expected to continue managing state properties