### PR TITLE
[mapistore-python]: Allow NULL properties in recipients

### DIFF
--- a/mapiproxy/libmapistore/backends/python/rest.py
+++ b/mapiproxy/libmapistore/backends/python/rest.py
@@ -158,14 +158,9 @@ class _RESTConn(object):
         r = self.so.get('%s%s' % (self.base_url, msg_uri))
         msg = r.json()
         self._decode_object_b64(msg)
-        if "recipients" in msg and len(msg["recipients"]) > 0:
-            # We assume all the recipients have the same properties
-            rcp_keys = msg["recipients"][0].keys()
-            for key in rcp_keys:
-                if mapistore.isPtypBinary(key):
-                    for recipient in msg["recipients"]:
-                        value = recipient[key]
-                        recipient[key] = bytearray(base64.b64decode(str(value)))
+        if "recipients" in msg:
+            for recipient in msg["recipients"]:
+                self._decode_object_b64(recipient)
         return msg
 
     def get_message_count(self, uri):
@@ -186,14 +181,9 @@ class _RESTConn(object):
             msg['PidTagInstanceNum'] = 0
             msg['PidTagRowType'] = 1
             msg['PidTagDepth'] = 0
-            if "recipients" in msg and len(msg["recipients"]) > 0:
-                # We assume all the recipients have the same properties
-                rcp_keys = msg["recipients"][0].keys()
-                for key in rcp_keys:
-                    if mapistore.isPtypBinary(key):
-                        for recipient in msg["recipients"]:
-                            value = recipient[key]
-                            recipient[key] = bytearray(base64.b64decode(str(value)))
+            if "recipients" in msg:
+                for recipient in msg["recipients"]:
+                    self._decode_object_b64(recipient)
             newlist.append(msg)
         return newlist
 
@@ -274,15 +264,10 @@ class _RESTConn(object):
         self._encode_object_b64(msg)
         msg["PidTagSubject"] = msg["PidTagNormalizedSubject"]
         # Add recipients
-        rcps = [rcp.copy() for rcp in recipients]
-        if len(rcps) > 0:
-            # We assume all the recipients have the same properties
-            rcp_keys = rcps[0].keys()
-            for key in rcp_keys:
-                if mapistore.isPtypBinary(key):
-                    for rcp in rcps:
-                        value = rcp[key]
-                        rcp[key] = base64.b64encode(value)
+        if len(recipients) > 0:
+            rcps = [rcp.copy() for rcp in recipients]
+            for rcp in rcps:
+                self._encode_object_b64(rcp)
             msg["recipients"] = rcps
         headers = {'Content-Type': 'application/json'}
         r = self.so.post('%s/%s/' % (self.base_url, collection),
@@ -306,16 +291,11 @@ class _RESTConn(object):
         msg = props.copy()
         headers = {'Content-Type': 'application/json'}
         self._encode_object_b64(msg)
-        rcps = [rcp.copy() for rcp in recipients]
         # Add recipients
-        if len(rcps) > 0:
-            # We assume all the recipients have the same properties
-            rcp_keys = rcps[0].keys()
-            for key in rcp_keys:
-                if mapistore.isPtypBinary(key):
-                    for rcp in rcps:
-                        value = rcp[key]
-                        rcp[key] = base64.b64encode(value)
+        if len(recipients) > 0:
+            rcps = [rcp.copy() for rcp in recipients]
+            for rcp in rcps:
+                self._encode_object_b64(rcp)
             msg["recipients"] = rcps
         self.so.put('%s%s' % (self.base_url, uri), data=json.dumps(msg),
                     headers=headers)
@@ -328,18 +308,12 @@ class _RESTConn(object):
         self._encode_object_b64(msg)
         msg["PidTagSubject"] = msg["PidTagNormalizedSubject"]
         # Add recipients
-        rcps = [rcp.copy() for rcp in recipients]
-        if len(rcps) > 0:
-            # We assume all the recipients have the same properties
-            rcp_keys = rcps[0].keys()
-            for key in rcp_keys:
-                if mapistore.isPtypBinary(key):
-                    for rcp in rcps:
-                        value = rcp[key]
-                        rcp[key] = base64.b64encode(value)
-        else:
+        if len(recipients) == 0:
             return mapistore.errors.MAPISTORE_ERR_INVALID_DATA
-        msg['recipients'] = rcps
+        rcps = [rcp.copy() for rcp in recipients]
+        for rcp in rcps:
+            self._encode_object_b64(rcp)
+        msg["recipients"] = rcps
         headers = {'Content-Type': 'application/json'}
         submit_data = {'msg': msg, 'serv_spool': serv_spool}
         self.so.post('%s/mails/submit/' % self.base_url,
@@ -773,7 +747,12 @@ class MessageObject(object):
 
     def get_message_data(self):
         logger.info('[PYTHON][%s][%s]: message.get_message_data' % (BackendObject.name, self.uri))
-        return (self.recipients, self.properties)
+        # Create a set with the union of the recipients' keys
+        recip_keys = set().union(*self.recipients)
+        # Transform the set into a list
+        recip_keys = list(recip_keys)
+        return {'recipients': self.recipients, 'recip_keys': recip_keys,
+                'properties': self.properties}
 
     def modify_recipients(self, recipients):
         logger.info('[PYTHON][%s][%s]: message.modify_recipients()' % (BackendObject.name, self.uri))
@@ -1072,8 +1051,8 @@ class TableObject(object):
         assert row_no < len(tmp_msg), "Index out of bounds of filtered data for message row=%s" % row_no
         message = tmp_msg[row_no]
 
-        (recipients, properties) = message.get_message_data()
-        return (self.columns, properties)
+        msg_data = message.get_message_data()
+        return (self.columns, msg_data['properties'])
 
     def _get_row_fai(self, row_no):
         assert row_no < len(self.parent.fai), "Index out of bounds for messages row=%s with len(self.parent.fai) = %d" % (row_no, len(self.parent.fai))
@@ -1087,8 +1066,8 @@ class TableObject(object):
         assert row_no < len(tmp_msg), "Index out of bounds of filtered data for message row=%s with len(tmp_msg) = %d" % (row_no, len(tmp_msg))
         message = tmp_msg[row_no]
 
-        (recipients, properties) = message.get_message_data()
-        return self.columns, properties
+        msg_data = message.get_message_data()
+        return self.columns, msg_data['properties']
 
     def _get_row_attachments(self, row_no):
         logger.info('[PYTHON]:[%s] table.get_attachment_row(%d)' % (BackendObject.name, row_no))

--- a/mapiproxy/libmapistore/backends/python/sample.py
+++ b/mapiproxy/libmapistore/backends/python/sample.py
@@ -813,8 +813,13 @@ class MessageObject(BackendObject):
 
     def get_message_data(self):
         print '[PYTHON]: %s message.get_message_data()' % (self.name)
+        # Create a set with the union of the recipients' keys
+        recip_keys = set().union(*self.basedict["recipients"])
+        # Transform the set into a list
+        recip_keys = list(recip_keys)
 
-        return (self.basedict["recipients"], self.basedict["properties"])
+        return {'recipients': self.recipients, 'recip_keys': recip_keys,
+                'properties': self.properties}
 
     def get_properties(self, properties):
         print '[PYTHON]: %s message.get_properties()' % (self.name)

--- a/mapiproxy/libmapistore/mapistore_python.c
+++ b/mapiproxy/libmapistore/mapistore_python.c
@@ -2629,15 +2629,15 @@ static enum mapistore_error mapistore_python_message_save(TALLOC_CTX *mem_ctx,
    \return MAPISTORE_SUCCESS on success, otherwise MAPISTORE error
  */
 static enum mapistore_error mapistore_python_message_submit(void *message_object,
-							  enum SubmitFlags flags)
+							    enum SubmitFlags flags)
 {
-	enum mapistore_error		    retval;
+	enum mapistore_error		retval;
 	struct mapistore_python_object	*pyobj;
-	PyObject                        *message;
-	PyObject			            *pres;
-    PyObject                        *serv_spool;
+	PyObject			*message;
+	PyObject			*pres;
+	PyObject                        *serv_spool;
 
-    DEBUG(5, ("[INFO] %s\n", __FUNCTION__));
+	DEBUG(5, ("[INFO] %s\n", __FUNCTION__));
 
 	/* Sanity checks */
 	MAPISTORE_RETVAL_IF(!message_object, MAPISTORE_ERR_INVALID_PARAMETER, NULL);
@@ -2653,22 +2653,21 @@ static enum mapistore_error mapistore_python_message_submit(void *message_object
 	MAPISTORE_RETVAL_IF(strcmp("MessageObject", message->ob_type->tp_name),
 			    MAPISTORE_ERR_CONTEXT_FAILED, NULL);
 
-    /* Read SubmitFlags */
+	/* Read SubmitFlags */
 	switch (flags) {
 		case None:
-            /* The message needs no preprocessing */
-            serv_spool = Py_None;
-            break;
+			/* The message needs no preprocessing */
+			serv_spool = Py_None;
+			break;
 		case PreProcess:
-            /* The message needs to be processed by the server */
-            serv_spool = Py_False;
-            break;
+			/* The message needs to be processed by the server */
+			serv_spool = Py_False;
+			break;
 		case NeedsSpooler:
-            /* The message needs to be processed by a client spooler */
-            serv_spool = Py_True;
-            break;
+			/* The message needs to be processed by a client spooler */
+			serv_spool = Py_True;
+			break;
 	}
-
 	/* Call submit function */
 	pres = PyObject_CallMethod(message, "submit", "O", serv_spool);
 	if (pres == NULL) {

--- a/mapiproxy/libmapistore/mapistore_python.c
+++ b/mapiproxy/libmapistore/mapistore_python.c
@@ -2352,7 +2352,7 @@ static enum mapistore_error mapistore_python_message_get_message_data(TALLOC_CTX
 			retval = MAPISTORE_ERR_CONTEXT_FAILED;
 			goto end;
 		}
-		if (PyDict_Contains(dict, key) == -1) {
+		if (PyDict_Contains(dict, key) == 0) {
 			DEBUG(0, ("[ERR][%s][%s]: Missing PidTagRecipientType property for recipient %d\n",
 				pyobj->name, __location__, i));
 			Py_DECREF(klist);

--- a/mapiproxy/libmapistore/mapistore_python.c
+++ b/mapiproxy/libmapistore/mapistore_python.c
@@ -2125,7 +2125,7 @@ static enum mapistore_error mapistore_python_message_get_message_data(TALLOC_CTX
 	PyObject			*pres;
 	PyObject			*rlist;
 	PyObject			*rdict;
-	PyObject			*klist;
+	PyObject			*rkeys;
 	PyObject			*dict;
 	PyObject			*ret;
 	PyObject			*key;
@@ -2161,18 +2161,18 @@ static enum mapistore_error mapistore_python_message_get_message_data(TALLOC_CTX
 		return MAPISTORE_ERR_CONTEXT_FAILED;
 	}
 
-	/* Ensure a tuple was returned */
-	if (PyTuple_Check(pres) == false) {
-		DEBUG(0, ("[ERR][%s][%s]: Tuple expected to be returned in get_message_data\n",
+	/* Ensure a dictionary was returned */
+	if (PyDict_Check(pres) == false) {
+		DEBUG(0, ("[ERR][%s][%s]: Dictionary expected to be returned in get_message_data\n",
 			pyobj->name, __location__));
 		Py_DECREF(pres);
 		return MAPISTORE_ERR_CONTEXT_FAILED;
 	}
 
-	/* Retrieve list of recipients (item 0 of the tuple) */
-	rlist = PyTuple_GetItem(pres, 0);
+	/* Retrieve list of recipients */
+	rlist = PyDict_GetItem(pres, PyString_FromString("recipients"));
 	if (rlist == NULL) {
-		DEBUG(0, ("[ERR][%s][%s]: PyTuple_GetItem failed ",
+		DEBUG(0, ("[ERR][%s][%s]: PyDict_GetItem failed ",
 			pyobj->name, __location__));
 		PyErr_Print();
 		Py_DECREF(pres);
@@ -2186,8 +2186,25 @@ static enum mapistore_error mapistore_python_message_get_message_data(TALLOC_CTX
 		return MAPISTORE_ERR_CONTEXT_FAILED;
 	}
 
-	/* Retrieve message properties (item 1 of the tuple) */
-	rdict = PyTuple_GetItem(pres, 1);
+	/* Retrieve recipient key lists union */
+	rkeys = PyDict_GetItem(pres, PyString_FromString("recip_keys"));
+	if (rkeys == NULL) {
+		DEBUG(0, ("[ERR][%s][%s]: PyTuple_GetItem failed ",
+			  pyobj->name, __location__));
+		PyErr_Print();
+		Py_DECREF(pres);
+		return MAPISTORE_ERR_CONTEXT_FAILED;
+	}
+
+	if (PyList_Check(rkeys) != true) {
+		DEBUG(0, ("[ERR][%s][%s]: list expected to be returned but got '%s'\n",
+			  pyobj->name, __location__, rkeys->ob_type->tp_name));
+		Py_DECREF(pres);
+		return MAPISTORE_ERR_CONTEXT_FAILED;
+	}
+
+	/* Retrieve message properties */
+	rdict = PyDict_GetItem(pres, PyString_FromString("properties"));
 	if (rdict == NULL) {
 		DEBUG(0, ("[ERR][%s][%s]: PyTuple_GetItem failed ",
 			pyobj->name, __location__));
@@ -2263,60 +2280,28 @@ static enum mapistore_error mapistore_python_message_get_message_data(TALLOC_CTX
 			goto end;
 		}
 
-		/* Extract the property tags from the first recipient */
-		/* TODO: This model assumes all the recipients have the same set of properties.
-		 * If this can't be ensured, compute the properties of every recipient and use
-		 * the union of all the sets. */
-		dict = PyList_GetItem(rlist, 0);
-		if (dict == NULL) {
-			DEBUG(0, ("[ERR][%s][%s]: PyList_GetItem failed ",
-				pyobj->name, __location__));
-			PyErr_Print();
-			retval = MAPISTORE_ERR_CONTEXT_FAILED;
-			goto end;
-		}
-
-		if (PyDict_Check(dict) != true) {
-			DEBUG(0, ("[ERR][%s][%s]: dict expected to be returned but got '%s'\n",
-				pyobj->name, __location__, dict->ob_type->tp_name));
-			retval = MAPISTORE_ERR_CONTEXT_FAILED;
-			goto end;
-		}
-
-		klist = PyDict_Keys(dict);
-		if (klist == NULL) {
-			DEBUG(0, ("[ERR][%s][%s]: PyDict_Keys failed ",
-				pyobj->name, __location__));
-			PyErr_Print();
-			retval = MAPISTORE_ERR_CONTEXT_FAILED;
-			goto end;
-		}
-
-		/* Transform the keys into tags */
-		prop_count = (uint32_t) PyList_Size(klist);
+		/* Transform the recipient keys into tags */
+		prop_count = (uint32_t) PyList_Size(rkeys);
 		msgdata->columns->cValues = prop_count;
 		msgdata->columns->aulPropTag = talloc_array(msgdata, enum MAPITAGS,
-							 prop_count);
+							    prop_count);
 		if (msgdata->columns->aulPropTag == NULL) {
-			Py_DECREF(klist);
 			retval = MAPISTORE_ERR_NO_MEMORY;
 			goto end;
 		}
 		for (j = 0; j < prop_count; j++) {
-			key = PyList_GetItem(klist, j);
+			key = PyList_GetItem(rkeys, j);
 			if (key == NULL) {
 				DEBUG(0, ("[ERR][%s][%s]: PyList_GetItem failed",
-					pyobj->name, __location__));
+					  pyobj->name, __location__));
 				PyErr_Print();
-				Py_DECREF(klist);
 				retval = MAPISTORE_ERR_CONTEXT_FAILED;
 				goto end;
 			}
 			retval = mapistore_python_proptag_from_pyobject(key, &proptag);
 			if (retval != MAPISTORE_SUCCESS) {
 				DEBUG(0, ("[ERR][%s][%s]: Non-string elements in property dictionary\n",
-					pyobj->name, __location__));
-				Py_DECREF(klist);
+					  pyobj->name, __location__));
 				goto end;
 			}
 			msgdata->columns->aulPropTag[j] = proptag;
@@ -2331,7 +2316,6 @@ static enum mapistore_error mapistore_python_message_get_message_data(TALLOC_CTX
 			DEBUG(0, ("[ERR][%s][%s]: PyList_GetItem failed ",
 				pyobj->name, __location__));
 			PyErr_Print();
-			Py_DECREF(klist);
 			retval = MAPISTORE_ERR_CONTEXT_FAILED;
 			goto end;
 		}
@@ -2339,7 +2323,6 @@ static enum mapistore_error mapistore_python_message_get_message_data(TALLOC_CTX
 		if (PyDict_Check(dict) != true) {
 			DEBUG(0, ("[ERR][%s][%s]: dict expected to be returned but got '%s'\n",
 				pyobj->name, __location__, dict->ob_type->tp_name));
-			Py_DECREF(klist);
 			retval = MAPISTORE_ERR_CONTEXT_FAILED;
 			goto end;
 		}
@@ -2348,14 +2331,12 @@ static enum mapistore_error mapistore_python_message_get_message_data(TALLOC_CTX
 		key = PyString_FromString("PidTagRecipientType");
 		if (key == NULL) {
 			PyErr_Print();
-			Py_DECREF(klist);
 			retval = MAPISTORE_ERR_CONTEXT_FAILED;
 			goto end;
 		}
 		if (PyDict_Contains(dict, key) == 0) {
 			DEBUG(0, ("[ERR][%s][%s]: Missing PidTagRecipientType property for recipient %d\n",
 				pyobj->name, __location__, i));
-			Py_DECREF(klist);
 			Py_DECREF(key);
 			retval = MAPISTORE_ERR_CONTEXT_FAILED;
 			goto end;
@@ -2365,7 +2346,6 @@ static enum mapistore_error mapistore_python_message_get_message_data(TALLOC_CTX
 		if (item == NULL) {
 			DEBUG(0, ("[ERR][%s][%s]: PyDict_GetItem failed\n", pyobj->name,
 				__location__));
-			Py_DECREF(klist);
 			retval = MAPISTORE_ERR_CONTEXT_FAILED;
 			goto end;
 		}
@@ -2374,7 +2354,6 @@ static enum mapistore_error mapistore_python_message_get_message_data(TALLOC_CTX
 		    (msgdata->recipients[i].type > MAPI_BCC)) {
 			DEBUG(0, ("[ERR][%s][%s]: Overflow error: %d\n",
 				pyobj->name, __location__, msgdata->recipients[i].type));
-			Py_DECREF(klist);
 			retval = MAPISTORE_ERR_CONTEXT_FAILED;
 			goto end;
 		}
@@ -2382,7 +2361,6 @@ static enum mapistore_error mapistore_python_message_get_message_data(TALLOC_CTX
 		/* Recipient properties */
 		msgdata->recipients[i].data = talloc_zero_array(msgdata, void *, msgdata->columns->cValues);
 		if (msgdata->recipients[i].data == NULL) {
-			Py_DECREF(klist);
 			retval = MAPISTORE_ERR_NO_MEMORY;
 			goto end;
 		}
@@ -2390,20 +2368,22 @@ static enum mapistore_error mapistore_python_message_get_message_data(TALLOC_CTX
 		for (j = 0; j < prop_count; j++) {
 			/* Go through the key list and retrieve the properties
 			 * of each recipient */
-			key = PyList_GetItem(klist, j);
+			key = PyList_GetItem(rkeys, j);
 			if (key == NULL) {
 				DEBUG(0, ("[ERR][%s][%s]: PyList_GetItem failed",
 					pyobj->name, __location__));
 				PyErr_Print();
-				Py_DECREF(klist);
 				retval = MAPISTORE_ERR_CONTEXT_FAILED;
 				goto end;
+			}
+			if (PyDict_Contains(dict, key) == 0) {
+				/* Silently allow empty properties */
+				continue;
 			}
 			item = PyDict_GetItem(dict, key);
 			if (item == NULL) {
 				DEBUG(0, ("[ERR][%s][%s]: PyDict_GetItem failed\n", pyobj->name,
 					__location__));
-				Py_DECREF(klist);
 				retval = MAPISTORE_ERR_CONTEXT_FAILED;
 				goto end;
 			}
@@ -2413,15 +2393,11 @@ static enum mapistore_error mapistore_python_message_get_message_data(TALLOC_CTX
 			if (retval != MAPISTORE_SUCCESS) {
 				DEBUG(0, ("[ERR][%s][%s]: Failed to retrieve property 0x%x\n",
 					pyobj->name, __location__, msgdata->columns->aulPropTag[j]));
-				Py_DECREF(klist);
 				goto end;
 			}
 		}
 	}
 
-	if (msgdata->recipients_count) {
-		Py_DECREF(klist);
-	}
 	Py_DECREF(pres);
 
 	*message_data = msgdata;

--- a/python/mock/rest/api_server.py
+++ b/python/mock/rest/api_server.py
@@ -424,16 +424,21 @@ def module_messages_get_attachments(msg_id):
 
 @app.route('/mails/submit/', methods=['POST'])
 def module_mail_submit():
-    """ Send mail to its recipients.
-        param data['msg']: the message properties
-        param data['serv_spool']: flag that indicates if the message needs
-            processing and by whom """
+    """ Send E-mail to its recipients. The json data contains the message
+    properties, including the recipients data, in the 'msg' field, and the
+    processing flag in the 'serv_spool' field. """
     data = request.get_json()
+    if data is None:
+        abort(422, "You must supply msg at least")
     # Read message data
-    msg = data['msg']
+    msg = data.get('msg', None)
+    if msg is None:
+        abort(422, "msg is a required parameter")
+    if 'recipients' not in msg:
+        abort(422, "recipients is a required field in msg")
     # Read processing flag (No processing required/by server/by client spooler
     serv_spool = data['serv_spool']
-    return "", 202
+    return "", 200
 
 
 @app.route('/mails/', methods=['POST'])


### PR DESCRIPTION
This PR allows the modify_recipients and get_message_data functions in mapistore_python.c to process recipients with properties that aren't set. Thus, recipients in the REST API backend don't necessarily have the same set of properties (which was assumed before), so the code has been modified consequently.