### PR TITLE
Relational operators in Table implementation

### DIFF
--- a/mapiproxy/libmapistore/backends/python/rest.py
+++ b/mapiproxy/libmapistore/backends/python/rest.py
@@ -210,10 +210,8 @@ class _RESTConn(object):
         self._dump_response(r)
         msgs = r.json()
         newlist = []
-        for i,msg in enumerate(msgs):
-            for key,value in msg.iteritems():
-                if mapistore.isPtypBinary(key):
-                    msg[key] = bytearray(base64.b64decode(str(value)))
+        for msg in msgs:
+            self._decode_object_b64(msg)
             msg['PidTagInstID'] = msg['id']
             msg['PidTagInstanceNum'] = 0
             msg['PidTagRowType'] = 1


### PR DESCRIPTION
This PR implements different relational operations used in restrictions, such as `NotEqual`, `LessThan`, etc. It doesn't implement the DL membership operator. Comparisons are made in a Pythonic way and types are not checked.

The PR also includes a small corrections that uses the wrapping function for decoding data from the REST calls in FAI message retrieval.