### PR TITLE
Fix returned value from `emsmdbp_object_open_folder_by_fid`

### DIFF
--- a/mapiproxy/libmapistore/mapistore.h
+++ b/mapiproxy/libmapistore/mapistore.h
@@ -362,7 +362,7 @@ enum mapistore_error mapistore_properties_get_properties(struct mapistore_contex
 enum mapistore_error mapistore_properties_set_properties(struct mapistore_context *, uint32_t, void *, struct SRow *);
 
 enum MAPISTATUS mapistore_error_to_mapi(enum mapistore_error);
-
+enum mapistore_error mapi_error_to_mapistore(enum MAPISTATUS);
 
 /* definitions from mapistore_processing.c */
 enum mapistore_error mapistore_set_mapping_path(const char *);

--- a/mapiproxy/libmapistore/mapistore_interface.c
+++ b/mapiproxy/libmapistore/mapistore_interface.c
@@ -1813,3 +1813,60 @@ _PUBLIC_ enum MAPISTATUS mapistore_error_to_mapi(enum mapistore_error mapistore_
 
 	return mapi_err;
 }
+
+/**
+   \details Map a MAPI error code to MAPISTORE error code. We cannot
+   map 1 to 1 for the reduced MAPISTORE scope, then we mostly likely
+   return general MAPISTORE error code.
+
+   \param mapi_err the mapi status error code
+
+   \return the mapped MAPISTORE error
+ */
+_PUBLIC_ enum mapistore_error mapi_error_to_mapistore(enum MAPISTATUS mapi_err)
+{
+        enum mapistore_error mapistore_err;
+
+        /* We cannot map 1 to 1 so we do the general error mapping */
+
+        switch(mapi_err) {
+        case MAPI_E_SUCCESS:
+                mapistore_err = MAPISTORE_SUCCESS;
+                break;
+        case MAPI_E_NO_SUPPORT:
+                mapistore_err = MAPISTORE_ERROR;
+                break;
+        case MAPI_E_NOT_ENOUGH_MEMORY:
+                mapistore_err = MAPISTORE_ERR_NO_MEMORY;
+                break;
+        case MAPI_E_NOT_INITIALIZED:
+                mapistore_err = MAPISTORE_ERR_NOT_INITIALIZED;
+                break;
+        case MAPI_E_CORRUPT_STORE:
+                mapistore_err = MAPISTORE_ERR_CORRUPTED;
+                break;
+        case MAPI_E_DISK_ERROR:
+                mapistore_err = MAPISTORE_ERR_INVALID_DATA;
+                break;
+        case MAPI_E_NOT_FOUND:
+                mapistore_err = MAPISTORE_ERR_NOT_FOUND;
+                break;
+        case MAPI_E_COLLISION:
+                mapistore_err = MAPISTORE_ERR_EXIST;
+                break;
+        case MAPI_E_NO_ACCESS:
+                mapistore_err = MAPISTORE_ERR_DENIED;
+                break;
+        case MAPI_E_NOT_IMPLEMENTED:
+                mapistore_err = MAPISTORE_ERR_NOT_IMPLEMENTED;
+                break;
+        case MAPI_E_INVALID_PARAMETER:
+                mapistore_err = MAPISTORE_ERR_INVALID_PARAMETER;
+                break;
+        default:
+                DEBUG(4, ("Using default mapistore error for %s\n", mapi_get_errstr(mapi_err)));
+                mapistore_err = MAPISTORE_ERROR;
+        }
+
+        return mapistore_err;
+}

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -2082,7 +2082,7 @@ _PUBLIC_ enum mapistore_error emsmdbp_object_message_open(TALLOC_CTX *mem_ctx, s
 	local_mem_ctx = talloc_zero(NULL, TALLOC_CTX);
 	retval = emsmdbp_object_open_folder_by_fid(local_mem_ctx, emsmdbp_ctx, parent_object, folderID, &folder_object);
 	if (retval != MAPI_E_SUCCESS)  {
-		ret = MAPISTORE_ERROR;
+		ret = mapi_error_to_mapistore(retval);
 		goto end;
 	}
 

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -1972,8 +1972,8 @@ static enum MAPISTATUS emsmdbp_fetch_freebusy(TALLOC_CTX *mem_ctx,
 	/* open Inbox */
 	retval = openchangedb_get_SystemFolderID(emsmdbp_ctx->oc_ctx, username, EMSMDBP_INBOX, &inboxFID);
 	OPENCHANGE_RETVAL_IF(retval != MAPI_E_SUCCESS, retval, local_mem_ctx);
-	retval_mapistore = emsmdbp_object_open_folder_by_fid(local_mem_ctx, emsmdbp_ctx, mailbox, inboxFID, &inbox);
-	OPENCHANGE_RETVAL_IF(retval_mapistore != MAPISTORE_SUCCESS, MAPI_E_NOT_FOUND, local_mem_ctx);
+	retval = emsmdbp_object_open_folder_by_fid(local_mem_ctx, emsmdbp_ctx, mailbox, inboxFID, &inbox);
+	OPENCHANGE_RETVAL_IF(retval != MAPI_E_SUCCESS, retval, local_mem_ctx);
 
 	/* retrieve Calendar entry id */
 	props = talloc_zero(mem_ctx, struct SPropTagArray);
@@ -1994,8 +1994,8 @@ static enum MAPISTATUS emsmdbp_fetch_freebusy(TALLOC_CTX *mem_ctx,
 	calendarFID |= 1;
 
 	/* open user calendar */
-	retval_mapistore = emsmdbp_object_open_folder_by_fid(local_mem_ctx, emsmdbp_ctx, mailbox, calendarFID, &calendar);
-	OPENCHANGE_RETVAL_IF(retval_mapistore != MAPISTORE_SUCCESS, MAPI_E_NOT_FOUND, local_mem_ctx);
+	retval = emsmdbp_object_open_folder_by_fid(local_mem_ctx, emsmdbp_ctx, mailbox, calendarFID, &calendar);
+	OPENCHANGE_RETVAL_IF(retval != MAPI_E_SUCCESS, retval, local_mem_ctx);
 
 	if (!emsmdbp_is_mapistore(calendar)) {
 		DEBUG(5, ("[emsmdbp_object][%s:%d]: non-mapistore calendars are not supported for freebusy\n",
@@ -2080,8 +2080,9 @@ _PUBLIC_ enum mapistore_error emsmdbp_object_message_open(TALLOC_CTX *mem_ctx, s
 	if (!parent_object) return MAPISTORE_ERROR;
 
 	local_mem_ctx = talloc_zero(NULL, TALLOC_CTX);
-	ret = emsmdbp_object_open_folder_by_fid(local_mem_ctx, emsmdbp_ctx, parent_object, folderID, &folder_object);
-	if (ret != MAPISTORE_SUCCESS)  {
+	retval = emsmdbp_object_open_folder_by_fid(local_mem_ctx, emsmdbp_ctx, parent_object, folderID, &folder_object);
+	if (retval != MAPI_E_SUCCESS)  {
+		ret = MAPISTORE_ERROR;
 		goto end;
 	}
 

--- a/mapiproxy/servers/default/emsmdb/oxcmsg.c
+++ b/mapiproxy/servers/default/emsmdb/oxcmsg.c
@@ -387,14 +387,9 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopCreateMessage(TALLOC_CTX *mem_ctx,
 	folderID = mapi_req->u.mapi_CreateMessage.FolderId;
 
 	/* Step 1. Retrieve parent handle in the hierarchy */
-	ret = emsmdbp_object_open_folder_by_fid(mem_ctx, emsmdbp_ctx, context_object, folderID, &folder_object);
-	if (ret != MAPISTORE_SUCCESS) {
-		if (ret == MAPISTORE_ERR_DENIED) {
-			mapi_repl->error_code = MAPI_E_NO_ACCESS;
-		}
-		else {
-			mapi_repl->error_code = MAPI_E_NO_SUPPORT;
-		}
+	retval = emsmdbp_object_open_folder_by_fid(mem_ctx, emsmdbp_ctx, context_object, folderID, &folder_object);
+	if (retval != MAPI_E_SUCCESS) {
+		mapi_repl->error_code = retval;
 		goto end;
 	}
 


### PR DESCRIPTION
From `enum mapistore_error` to `enum MAPISTATUS`.

Added an utility function to map MAPISTATUS to the mapistore_error as well to try to keep real error code available.

Fixed use case: 
Opening a shared calendar with no permissions returns MAPI_E_NO_ACCESS instead of MAPI_E_NOT_FOUND making work when the shared calendar access is later granted.