### PR TITLE
Stop including samba_util.h.

### DIFF
--- a/mapiproxy/dcesrv_mapiproxy.h
+++ b/mapiproxy/dcesrv_mapiproxy.h
@@ -36,7 +36,6 @@
 #include <samba/session.h>
 
 #include <dcerpc_server.h>
-#include <samba_util.h>
 #include <param.h>
 #include <credentials.h>
 

--- a/mapiproxy/dcesrv_mapiproxy_unused.c
+++ b/mapiproxy/dcesrv_mapiproxy_unused.c
@@ -36,7 +36,6 @@
 #include "gen_ndr/exchange.h"
 
 #include <dcerpc_server.h>
-#include <samba_util.h>
 #include <param.h>
 
 #include "gen_ndr/ndr_exchange.h"

--- a/mapiproxy/libmapiproxy/backends/openchangedb_mysql.c
+++ b/mapiproxy/libmapiproxy/backends/openchangedb_mysql.c
@@ -27,7 +27,6 @@
 #include "libmapi/libmapi.h"
 #include "libmapi/libmapi_private.h"
 #include <mysql/mysql.h>
-#include <samba_util.h>
 #include <inttypes.h>
 #include <time.h>
 #include "../../util/mysql.h"

--- a/mapiproxy/libmapistore/backends/indexing_mysql.c
+++ b/mapiproxy/libmapistore/backends/indexing_mysql.c
@@ -31,7 +31,6 @@
 #include "../../util/mysql.h"
 #include "mapiproxy/libmapiproxy/backends/openchangedb_mysql.h"
 
-#include <samba_util.h>
 #include <talloc.h>
 
 

--- a/mapiproxy/libmapistore/backends/namedprops_mysql.c
+++ b/mapiproxy/libmapistore/backends/namedprops_mysql.c
@@ -29,7 +29,6 @@
 #include <mysql/mysql.h>
 #include <mysql/mysqld_error.h>
 #include <ldb.h>
-#include <samba_util.h>
 
 
 static enum mapistore_error get_mapped_id(struct namedprops_context *self,

--- a/mapiproxy/libmapistore/mapistore_backend.c
+++ b/mapiproxy/libmapistore/mapistore_backend.c
@@ -33,7 +33,6 @@
 #include "mapistore_private.h"
 #include <dlinklist.h>
 
-#include <samba_util.h>
 #include <util/debug.h>
 
 /**

--- a/utils/backup/openchangebackup.h
+++ b/utils/backup/openchangebackup.h
@@ -34,7 +34,6 @@
 #include <inttypes.h>
 
 /* Samba4 includes */
-#include <samba_util.h>
 #include <talloc.h>
 #include <ldb_errors.h>
 #include <ldb.h>


### PR DESCRIPTION
This is another step towards being able to build without Samba installed.