### PR TITLE
Fixed NSPI UpdateStat and QueryRows methods

### DIFF
--- a/exchange.idl
+++ b/exchange.idl
@@ -538,7 +538,7 @@ System Attendant Private Interface
 		[in] policy_handle	*handle,
 		[in] uint32		Reserved,
 		[in,out] STAT		*pStat,
-		[in,out,unique] uint32	*plDelta
+		[in,out,unique] int32	*plDelta
 		);
 
 	/*****************/

--- a/libmapi/libmapi.h
+++ b/libmapi/libmapi.h
@@ -90,7 +90,7 @@ __BEGIN_DECLS
 /* The following public definitions come from libmapi/nspi.c */
 struct nspi_context	*nspi_bind(TALLOC_CTX *, struct dcerpc_pipe *, struct cli_credentials *, uint32_t, uint32_t, uint32_t);
 enum MAPISTATUS		nspi_unbind(struct nspi_context *);
-enum MAPISTATUS		nspi_UpdateStat(struct nspi_context *, TALLOC_CTX *, uint32_t *);
+enum MAPISTATUS		nspi_UpdateStat(struct nspi_context *, TALLOC_CTX *, int32_t *);
 enum MAPISTATUS		nspi_QueryRows(struct nspi_context *, TALLOC_CTX *, struct SPropTagArray *, struct PropertyTagArray_r *MIds, uint32_t, struct PropertyRowSet_r **);
 enum MAPISTATUS		nspi_SeekEntries(struct nspi_context *, TALLOC_CTX *, enum TableSortOrders, struct PropertyValue_r *, struct SPropTagArray *, struct PropertyTagArray_r *pMIds, struct PropertyRowSet_r **);
 enum MAPISTATUS		nspi_GetMatches(struct nspi_context *, TALLOC_CTX *, struct SPropTagArray *, struct Restriction_r *, uint32_t ulRequested, struct PropertyRowSet_r **, struct PropertyTagArray_r **ppOutMIds);

--- a/libmapi/nspi.c
+++ b/libmapi/nspi.c
@@ -209,7 +209,7 @@ _PUBLIC_ enum MAPISTATUS nspi_unbind(struct nspi_context *nspi_ctx)
  */
 _PUBLIC_ enum MAPISTATUS nspi_UpdateStat(struct nspi_context *nspi_ctx, 
 					 TALLOC_CTX *mem_ctx,
-					 uint32_t *plDelta)
+					 int32_t *plDelta)
 {
 	struct NspiUpdateStat		r;
 	NTSTATUS			status;

--- a/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
+++ b/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
@@ -117,6 +117,8 @@ static void dcesrv_NspiBind(struct dcesrv_call_state *dce_call,
 		goto failure;
 	}
 
+	DCESRV_NSP_RETURN_IF(r->in.pStat->CodePage == CP_UNICODE, r, MAPI_E_NO_SUPPORT, NULL);
+
 	/* Step 1. Initialize the emsabp context */
 	emsabp_ctx = emsabp_init(dce_call->conn->dce_ctx->lp_ctx, emsabp_tdb_ctx);
 	if (!emsabp_ctx) {
@@ -557,6 +559,8 @@ static void dcesrv_NspiSeekEntries(struct dcesrv_call_state *dce_call,
 
 	DEBUG(3, ("exchange_nsp: NspiSeekEntries (0x4)\n"));
 
+	DCESRV_NSP_RETURN_IF(r->in.pStat->CodePage == CP_UNICODE, r, MAPI_E_NO_SUPPORT, NULL);
+
 	emsabp_ctx = dcesrv_find_emsabp_context(&r->in.handle->uuid);
 	if (!emsabp_ctx) {
 		DCESRV_NSP_RETURN(r, MAPI_E_CALL_FAILED, NULL);
@@ -663,6 +667,8 @@ static void dcesrv_NspiGetMatches(struct dcesrv_call_state *dce_call,
 		DEBUG(1, ("No challenge requested by client, cannot authenticate\n"));
 		DCESRV_NSP_RETURN(r, MAPI_E_LOGON_FAILED, NULL);
 	}
+
+	DCESRV_NSP_RETURN_IF(r->in.pStat->CodePage == CP_UNICODE, r, MAPI_E_NO_SUPPORT, NULL);
 
 	emsabp_ctx = dcesrv_find_emsabp_context(&r->in.handle->uuid);
 	if (!emsabp_ctx) {
@@ -952,6 +958,8 @@ static void dcesrv_NspiGetSpecialTable(struct dcesrv_call_state *dce_call,
 {
 	struct emsabp_context		*emsabp_ctx = NULL;
 	bool				nspi_address_creation_templates;
+	bool				nspi_unicode_strings;
+	bool				unsupported_codepage;
 
 	DEBUG(3, ("exchange_nsp: NspiGetSpecialTable (0xC)\n"));
 
@@ -962,7 +970,10 @@ static void dcesrv_NspiGetSpecialTable(struct dcesrv_call_state *dce_call,
 	}
 
 	nspi_address_creation_templates = r->in.dwFlags & NspiAddressCreationTemplates;
+	nspi_unicode_strings = r->in.dwFlags & NspiUnicodeStrings;
 	/* Check in 3.1.4.1.3 Server Processing rules step 1 */
+	unsupported_codepage = !nspi_address_creation_templates && !nspi_unicode_strings && r->in.pStat->CodePage == CP_UNICODE;
+	DCESRV_NSP_RETURN_IF(unsupported_codepage, r, MAPI_E_NO_SUPPORT, NULL);
 
 	emsabp_ctx = dcesrv_find_emsabp_context(&r->in.handle->uuid);
 	if (!emsabp_ctx) {
@@ -1141,6 +1152,8 @@ static void dcesrv_NspiResolveNames(struct dcesrv_call_state *dce_call,
 		DEBUG(1, ("No challenge requested by client, cannot authenticate\n"));
 		DCESRV_NSP_RETURN(r, MAPI_E_LOGON_FAILED, NULL);
 	}
+
+	DCESRV_NSP_RETURN_IF(r->in.pStat->CodePage == CP_UNICODE, r, MAPI_E_NO_SUPPORT, NULL);
 
 	emsabp_ctx = dcesrv_find_emsabp_context(&r->in.handle->uuid);
 	if (!emsabp_ctx) {

--- a/utils/mapitest/modules/module_nspi.c
+++ b/utils/mapitest/modules/module_nspi.c
@@ -41,7 +41,7 @@ _PUBLIC_ bool mapitest_nspi_UpdateStat(struct mapitest *mt)
 	TALLOC_CTX		*mem_ctx;
 	enum MAPISTATUS		retval;
 	struct nspi_context	*nspi_ctx;
-	uint32_t       		plDelta = 1;
+	int32_t       		plDelta = 1;
 	struct PropertyRowSet_r	*RowSet;
 
 	mem_ctx = talloc_named(NULL, 0, "mapitest_nspi_UpdateStat");

--- a/utils/mapitest/modules/module_zentyal.c
+++ b/utils/mapitest/modules/module_zentyal.c
@@ -156,7 +156,7 @@ _PUBLIC_ bool mapitest_zentyal_1645(struct mapitest *mt)
 {
 	TALLOC_CTX			*mem_ctx;
 	struct nspi_context		*nspi_ctx;
-	uint32_t        		plDelta = 1;
+	int32_t				plDelta = 1;
 	enum MAPISTATUS	retval;
 
 	/* Sanity checks */


### PR DESCRIPTION
Also added to NSPI methods the codepage check mandated by specifications

The NSPI UpdateStat and QueryRow method are called when browsing the entries in the address book before they failed in their implemntation and if you had more of 40 entries it dont worked correctly.