### PR TITLE
Use talloc_new instead of talloc_zero(NULL, TALLOC_CTX)

### DIFF
--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -250,7 +250,8 @@ static enum mapistore_error emsmdbp_object_folder_commit_creation(struct emsmdbp
 		return ret;
 	}
 
-	mem_ctx = talloc_zero(NULL, TALLOC_CTX);
+	mem_ctx = talloc_new(NULL);
+	OPENCHANGE_RETVAL_IF(!mem_ctx, MAPISTORE_ERR_NO_MEMORY, NULL);
 
 	value = get_SPropValue_SRow(new_folder->object.folder->postponed_props, PR_CONTAINER_CLASS_UNICODE);
 	if (!value) {
@@ -805,7 +806,9 @@ static int emsmdbp_copy_properties(struct emsmdbp_context *emsmdbp_ctx, struct e
 	struct SPropValue	newValue;
 	uint32_t		i;
 
-	mem_ctx = talloc_zero(NULL, TALLOC_CTX);
+	mem_ctx = talloc_new(NULL);
+	OPENCHANGE_RETVAL_IF(!mem_ctx, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
+
 	if (emsmdbp_object_get_available_properties(mem_ctx, emsmdbp_ctx, source_object, &properties) == MAPISTORE_ERROR) {
 		DEBUG(0, ("["__location__"] - mapistore support not implemented yet - shouldn't occur\n"));
 		talloc_free(mem_ctx);
@@ -903,7 +906,9 @@ static inline int emsmdbp_copy_message_recipients_mapistore(struct emsmdbp_conte
 	}
 
 	/* Fetch data from source message */
-	mem_ctx = talloc_zero(NULL, TALLOC_CTX);
+	mem_ctx = talloc_new(NULL);
+	OPENCHANGE_RETVAL_IF(!mem_ctx, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
+
 	contextID = emsmdbp_get_contextID(source_object);
 	mapistore_message_get_message_data(emsmdbp_ctx->mstore_ctx, contextID, source_object->backend_object, mem_ctx, &msg_data);
 
@@ -963,7 +968,8 @@ static inline int emsmdbp_copy_message_attachments_mapistore(struct emsmdbp_cont
 		return MAPI_E_SUCCESS;
 	}
 
-	mem_ctx = talloc_zero(NULL, TALLOC_CTX);
+	mem_ctx = talloc_new(NULL);
+	OPENCHANGE_RETVAL_IF(!mem_ctx, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
 
 	/* we fetch the attachment nums */
 	table_object = emsmdbp_object_message_open_attachment_table(mem_ctx, emsmdbp_ctx, source_object);
@@ -1303,7 +1309,8 @@ _PUBLIC_ enum mapistore_error emsmdbp_folder_delete(struct emsmdbp_context *emsm
 	void			*subfolder;
 	char			*mapistoreURL;
 
-	mem_ctx = talloc_zero(NULL, TALLOC_CTX);
+	mem_ctx = talloc_new(NULL);
+	OPENCHANGE_RETVAL_IF(!mem_ctx, MAPISTORE_ERR_NO_MEMORY, NULL);
 
 	mailboxstore = emsmdbp_is_mailboxstore(parent_folder);
 	if (emsmdbp_is_mapistore(parent_folder)) {	/* fid is not a mapistore root */
@@ -1950,7 +1957,7 @@ static enum MAPISTATUS emsmdbp_fetch_freebusy(TALLOC_CTX *mem_ctx,
 	OPENCHANGE_RETVAL_IF(!username, MAPI_E_INVALID_PARAMETER, NULL);
 	OPENCHANGE_RETVAL_IF(!fb_props_p, MAPI_E_INVALID_PARAMETER, NULL);
 
-	local_mem_ctx = talloc_zero(NULL, TALLOC_CTX);
+	local_mem_ctx = talloc_new(NULL);
 	OPENCHANGE_RETVAL_IF(!local_mem_ctx, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
 
 	retval = mapiserver_get_administrative_group_legacyexchangedn(local_mem_ctx, emsmdbp_ctx, &administrativegroup);
@@ -2036,7 +2043,7 @@ static enum MAPISTATUS emsmdbp_object_message_fill_freebusy_properties(struct em
 	enum MAPISTATUS				*retvals = NULL;
 	enum MAPISTATUS				retval;
 
-	mem_ctx = talloc_zero(NULL, TALLOC_CTX);
+	mem_ctx = talloc_new(NULL);
 	OPENCHANGE_RETVAL_IF(!mem_ctx, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
 
 	/* 1. retrieve subject and deduce username */
@@ -2079,7 +2086,9 @@ _PUBLIC_ enum mapistore_error emsmdbp_object_message_open(TALLOC_CTX *mem_ctx, s
 	if (!messageP) return MAPISTORE_ERROR;
 	if (!parent_object) return MAPISTORE_ERROR;
 
-	local_mem_ctx = talloc_zero(NULL, TALLOC_CTX);
+	local_mem_ctx = talloc_new(NULL);
+	OPENCHANGE_RETVAL_IF(!mem_ctx, MAPISTORE_ERR_NO_MEMORY, NULL);
+
 	retval = emsmdbp_object_open_folder_by_fid(local_mem_ctx, emsmdbp_ctx, parent_object, folderID, &folder_object);
 	if (retval != MAPI_E_SUCCESS)  {
 		ret = mapi_error_to_mapistore(retval);
@@ -2757,7 +2766,9 @@ _PUBLIC_ int emsmdbp_object_set_properties(struct emsmdbp_context *emsmdbp_ctx, 
 	 * dispatcher db, not mapistore */
 	if (object->type == EMSMDBP_OBJECT_FOLDER
 	    && object->object.folder->mapistore_root == true) {
-		mem_ctx = talloc_zero(NULL, TALLOC_CTX);
+		mem_ctx = talloc_new(NULL);
+		OPENCHANGE_RETVAL_IF(!mem_ctx, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
+
 		mapistore_uri = NULL;
 		openchangedb_get_mapistoreURI(mem_ctx, emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, object->object.folder->folderID, &mapistore_uri, true);
 		openchangedb_set_folder_properties(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, object->object.folder->folderID, rowp);

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_provisioning.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_provisioning.c
@@ -109,7 +109,7 @@ _PUBLIC_ enum MAPISTATUS emsmdbp_mailbox_provision_public_freebusy(struct emsmdb
 	OPENCHANGE_RETVAL_IF(!emsmdbp_ctx, MAPI_E_INVALID_PARAMETER, NULL);
 	OPENCHANGE_RETVAL_IF(!EssDN, MAPI_E_INVALID_PARAMETER, NULL);
 
-	mem_ctx = talloc_zero(NULL, TALLOC_CTX);
+	mem_ctx = talloc_new(NULL);
 	OPENCHANGE_RETVAL_IF(!mem_ctx, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
 
 	dn_root = talloc_asprintf(mem_ctx, "EX:%s", EssDN);
@@ -310,7 +310,8 @@ FolderId: 0x67ca828f02000001      Display Name: "                        ";  Con
 	void					*backend_object, *backend_table, *backend_message;
 	char	 				*organization_name, *group_name;
 
-	mem_ctx = talloc_zero(NULL, TALLOC_CTX);
+	mem_ctx = talloc_new(NULL);
+	OPENCHANGE_RETVAL_IF(!mem_ctx, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
 
 	/* Retrieve list of folders from backends */
 	retval = mapistore_list_contexts_for_user(emsmdbp_ctx->mstore_ctx, username, mem_ctx, &contexts_list);

--- a/mapiproxy/servers/default/emsmdb/oxcfold.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfold.c
@@ -832,7 +832,8 @@ static enum MAPISTATUS RopEmptyFolder_GenericFolder(TALLOC_CTX *mem_ctx,
 	}
 	context_id = emsmdbp_get_contextID(folder_object);
 
-	local_mem_ctx = talloc_zero(NULL, TALLOC_CTX);
+	local_mem_ctx = talloc_new(NULL);
+	OPENCHANGE_RETVAL_IF(!local_mem_ctx, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
 
 	retval = mapistore_folder_get_child_fmids(emsmdbp_ctx->mstore_ctx, context_id, folder_object->backend_object, MAPISTORE_FOLDER_TABLE, local_mem_ctx,
 						  &childFolders, &childFolderCount);

--- a/mapiproxy/servers/default/emsmdb/oxcfxics.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfxics.c
@@ -297,7 +297,6 @@ static void oxcfxics_ndr_push_properties(struct ndr_push *ndr, struct ndr_push *
 			}
 			ndr_push_uint32(cutmarks_ndr, NDR_SCALARS, 0);
 			ndr_push_uint32(cutmarks_ndr, NDR_SCALARS, ndr->offset);
-
 			if ((prop_type & MV_FLAG)) {
 				prop_type &= 0x0fff;
 
@@ -553,7 +552,7 @@ static void oxcfxics_push_messageChange_recipients(struct emsmdbp_context *emsmd
 	min_string_value_buffer = oxcfxics_compute_cutmark_min_value_buffer(PT_UNICODE);
 
 	if (msg) {
-		local_mem_ctx = talloc_zero(NULL, TALLOC_CTX);
+		local_mem_ctx = talloc_new(NULL);
 
 		if (SPropTagArray_find(*msg->columns, PidTagDisplayName, &cn_idx) == MAPI_E_NOT_FOUND
 		    && SPropTagArray_find(*msg->columns, PidTagAddressBookDisplayNamePrintable, &cn_idx) == MAPI_E_NOT_FOUND
@@ -632,7 +631,7 @@ static void oxcfxics_push_messageChange_attachment_embedded_message(struct emsmd
 	enum MAPISTATUS			*retvals;
 	uint32_t			i;
 
-	mem_ctx = talloc_zero(NULL, TALLOC_CTX);
+	mem_ctx = talloc_new(NULL);
 
 	ret = mapistore_message_attachment_open_embedded_message(emsmdbp_ctx->mstore_ctx, contextID, attachment, mem_ctx, &embedded_message, &messageID, &msg);
 	if (ret == MAPISTORE_SUCCESS) {
@@ -878,7 +877,7 @@ static bool oxcfxics_push_messageChange(struct emsmdbp_context *emsmdbp_ctx, str
 
 	/* open each message and fetch properties */
 	for (; sync_data->ndr->offset < max_message_sync_size && message_sync_data->count < message_sync_data->max; message_sync_data->count++) {
-		msg_ctx = talloc_zero(NULL, TALLOC_CTX);
+		msg_ctx = talloc_new(NULL);
 
 		if (folder_is_mapistore && (message_sync_data->count % message_preload_interval) == 0) {
 			preload_mids.lpui8 = message_sync_data->mids + message_sync_data->count;

--- a/mapiproxy/servers/default/emsmdb/oxcprpt.c
+++ b/mapiproxy/servers/default/emsmdb/oxcprpt.c
@@ -119,7 +119,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopGetPropertiesSpecific(TALLOC_CTX *mem_ctx,
 		goto end;
 	}
 
-        local_mem_ctx = talloc_zero(NULL, TALLOC_CTX);
+        local_mem_ctx = talloc_new(NULL);
         OPENCHANGE_RETVAL_IF(!local_mem_ctx, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
 
         properties = talloc_zero(local_mem_ctx, struct SPropTagArray);

--- a/mapiproxy/servers/default/emsmdb/oxomsg.c
+++ b/mapiproxy/servers/default/emsmdb/oxomsg.c
@@ -49,7 +49,7 @@ static void oxomsg_mapistore_handle_message_relocation(struct emsmdbp_context *e
 	struct emsmdbp_object		*message_object;
 	enum MAPISTATUS			retval;
 
-	mem_ctx = talloc_zero(NULL, TALLOC_CTX);
+	mem_ctx = talloc_new(NULL);
 
 	property_data = talloc_array(mem_ctx, struct mapistore_property_data, properties_count);
 


### PR DESCRIPTION
As suggested by @blaxter and @jelmer to avoid creating two
talloc contexts where is not required to create a temporary
context.