### PR TITLE
Implement read backwards on a oxctabl in QueryRows ROP

### DIFF
--- a/exchange.idl
+++ b/exchange.idl
@@ -1824,9 +1824,14 @@ System Attendant Private Interface
 		TBL_ENABLEPACKEDBUFFERS = 0x2
 	} QueryRowsFlags;
 
+	typedef [enum8bit] enum {
+		TBL_BACKWARD_READ	= 0x0,
+		TBL_FORWARD_READ	= 0x1
+	} ForwardRead;
+
 	typedef [flag(NDR_NOALIGN)] struct {
 		QueryRowsFlags	QueryRowsFlags;
-		uint8		ForwardRead;
+		ForwardRead	ForwardRead;
 		uint16		RowCount;
 	} QueryRows_req;
 

--- a/libexchange2ical/exchange2ical.c
+++ b/libexchange2ical/exchange2ical.c
@@ -409,7 +409,7 @@ static uint8_t exchange2ical_exception_from_EmbeddedObj(struct exchange2ical *ex
 		SPropTagArray = set_SPropTagArray(exchange2ical->mem_ctx, 0x1, PR_ATTACH_NUM);
 		retval = SetColumns(&obj_tb_attach, SPropTagArray);
 		MAPIFreeBuffer(SPropTagArray);
-		retval = QueryRows(&obj_tb_attach, 0xa, TBL_ADVANCE, &rowset_attach);
+		retval = QueryRows(&obj_tb_attach, 0xa, TBL_ADVANCE, TBL_FORWARD_READ, &rowset_attach);
 
 		for (i = 0; i < rowset_attach.cRows; i++) {
 			
@@ -635,7 +635,7 @@ icalcomponent * _Exchange2Ical(mapi_object_t *obj_folder, struct exchange2ical_c
 		return NULL;
 	}
 	
-	while ((retval = QueryRows(&obj_table, count, TBL_ADVANCE, &SRowSet)) != MAPI_E_NOT_FOUND && SRowSet.cRows) {
+	while ((retval = QueryRows(&obj_table, count, TBL_ADVANCE, TBL_FORWARD_READ, &SRowSet)) != MAPI_E_NOT_FOUND && SRowSet.cRows) {
 		count -= SRowSet.cRows;
 		for (i = (SRowSet.cRows-1); i >= 0; i--) {
 			mapi_object_init(&exchange2ical.obj_message);

--- a/libexchange2ical/exchange2ical_property.c
+++ b/libexchange2ical/exchange2ical_property.c
@@ -72,7 +72,7 @@ void ical_property_ATTACH(struct exchange2ical *exchange2ical)
 		SPropTagArray = set_SPropTagArray(exchange2ical->mem_ctx, 0x1, PR_ATTACH_NUM);
 		retval = SetColumns(&obj_tb_attach, SPropTagArray);
 		MAPIFreeBuffer(SPropTagArray);
-		retval = QueryRows(&obj_tb_attach, 0xa, TBL_ADVANCE, &rowset_attach);
+		retval = QueryRows(&obj_tb_attach, 0xa, TBL_ADVANCE, TBL_FORWARD_READ, &rowset_attach);
 		
 		for (i = 0; i < rowset_attach.cRows; i++) {
 			attach_num = (const uint32_t *)find_SPropValue_data(&(rowset_attach.aRow[i]), PR_ATTACH_NUM);

--- a/libmapi++/src/folder.cpp
+++ b/libmapi++/src/folder.cpp
@@ -50,7 +50,7 @@ folder::message_container_type folder::fetch_messages() throw(mapi_exception)
 	message_container_type message_container;
 	message_container.reserve(contents_table_row_count);
 
-	while( (QueryRows(&contents_table, rows_to_read, TBL_ADVANCE, &row_set) == MAPI_E_SUCCESS) && row_set.cRows) {
+	while( (QueryRows(&contents_table, rows_to_read, TBL_ADVANCE, TBL_FORWARD_READ, &row_set) == MAPI_E_SUCCESS) && row_set.cRows) {
 		rows_to_read -= row_set.cRows;
 		for (unsigned int i = 0; i < row_set.cRows; ++i) {
 			try {
@@ -96,7 +96,7 @@ folder::hierarchy_container_type folder::fetch_hierarchy() throw(mapi_exception)
 	hierarchy_container_type hierarchy_container;
 	hierarchy_container.reserve(hierarchy_table_row_count);
 
-	while( (QueryRows(&hierarchy_table, rows_to_read, TBL_ADVANCE, &row_set) == MAPI_E_SUCCESS) && row_set.cRows) {
+	while( (QueryRows(&hierarchy_table, rows_to_read, TBL_ADVANCE, TBL_FORWARD_READ, &row_set) == MAPI_E_SUCCESS) && row_set.cRows) {
 		rows_to_read -= row_set.cRows;
 		for (unsigned int i = 0; i < row_set.cRows; ++i) {
 			try {

--- a/libmapi++/src/message.cpp
+++ b/libmapi++/src/message.cpp
@@ -45,7 +45,7 @@ message::attachment_container_type message::fetch_attachments()
 	SRowSet  row_set;
 	attachment_container_type attachment_container;
 
-	while( (QueryRows(&attachment_table, 0x32, TBL_ADVANCE, &row_set) == MAPI_E_SUCCESS) && row_set.cRows) {
+	while( (QueryRows(&attachment_table, 0x32, TBL_ADVANCE, TBL_FORWARD_READ, &row_set) == MAPI_E_SUCCESS) && row_set.cRows) {
 		for (unsigned int i = 0; i < row_set.cRows; ++i) {
 			try {
 				attachment_container.push_back(attachment_shared_ptr(new attachment(*this, row_set.aRow[i].lpProps[0].value.l)));

--- a/libmapi/IMAPITable.c
+++ b/libmapi/IMAPITable.c
@@ -218,12 +218,17 @@ _PUBLIC_ enum MAPISTATUS QueryPosition(mapi_object_t *obj_table,
    \param obj_table the table we are requesting properties from
    \param row_count the maximum number of rows to retrieve
    \param flags flags to use for the query
+   \param forward_read the direction to read
    \param rowSet the results
 
    flags possible values:
    - TBL_ADVANCE: index automatically increased from last rowcount
    - TBL_NOADVANCE: should be used for a single QueryRows call
    - TBL_ENABLEPACKEDBUFFERS: (not yet implemented)
+
+   forward_read possible values:
+   - TBL_FORWARD_READ: to read forwards
+   - TBL_BACKWARD_READ: to read backwards
 
    \return MAPI_E_SUCCESS on success, otherwise MAPI error.
 
@@ -238,7 +243,8 @@ _PUBLIC_ enum MAPISTATUS QueryPosition(mapi_object_t *obj_table,
  */
 _PUBLIC_ enum MAPISTATUS QueryRows(mapi_object_t *obj_table, 
 				   uint16_t row_count,
-				   enum QueryRowsFlags flags, 
+				   enum QueryRowsFlags flags,
+				   enum ForwardRead forward_read,
 				   struct SRowSet *rowSet)
 {
 	struct mapi_context	*mapi_ctx;
@@ -272,8 +278,7 @@ _PUBLIC_ enum MAPISTATUS QueryRows(mapi_object_t *obj_table,
 
 	/* Fill the QueryRows operation */
 	request.QueryRowsFlags = flags;
-	/* TODO: search backwards for negative row_count */
-	request.ForwardRead = 1;
+	request.ForwardRead = forward_read;
 	request.RowCount = row_count;
 	size += 4;
 

--- a/libmapi/libmapi.h
+++ b/libmapi/libmapi.h
@@ -383,7 +383,7 @@ enum MAPISTATUS		MonitorNotification(struct mapi_session *, void *, struct mapi_
 /* The following public definitions come from libmapi/IMAPITable.c */
 enum MAPISTATUS		SetColumns(mapi_object_t *, struct SPropTagArray *);
 enum MAPISTATUS		QueryPosition(mapi_object_t *, uint32_t *, uint32_t *);
-enum MAPISTATUS		QueryRows(mapi_object_t *, uint16_t, enum QueryRowsFlags, struct SRowSet *);
+enum MAPISTATUS		QueryRows(mapi_object_t *, uint16_t, enum QueryRowsFlags, enum ForwardRead, struct SRowSet *);
 enum MAPISTATUS		QueryColumns(mapi_object_t *, struct SPropTagArray *);
 enum MAPISTATUS		SeekRow(mapi_object_t *, enum BOOKMARK, int32_t, uint32_t *);
 enum MAPISTATUS		SeekRowBookmark(mapi_object_t *, uint32_t, uint32_t, uint32_t *);

--- a/libmapi/simple_mapi.c
+++ b/libmapi/simple_mapi.c
@@ -621,7 +621,7 @@ _PUBLIC_ enum MAPISTATUS ModifyUserPermission(mapi_object_t *obj_folder,
 	retval = QueryPosition(&obj_table, &Numerator, &Denominator);
 	OPENCHANGE_RETVAL_IF(retval, retval, mem_ctx);
 
-	retval = QueryRows(&obj_table, Denominator, TBL_ADVANCE, &rowset);
+	retval = QueryRows(&obj_table, Denominator, TBL_ADVANCE, TBL_FORWARD_READ, &rowset);
 	OPENCHANGE_RETVAL_IF(retval, retval, mem_ctx);
 
 	for (i = 0; i < rowset.cRows; i++) {
@@ -731,7 +731,7 @@ _PUBLIC_ enum MAPISTATUS RemoveUserPermission(mapi_object_t *obj_folder,
 	retval = QueryPosition(&obj_table, &Numerator, &Denominator);
 	OPENCHANGE_RETVAL_IF(retval, retval, mem_ctx);
 
-	retval = QueryRows(&obj_table, Denominator, TBL_ADVANCE, &rowset);
+	retval = QueryRows(&obj_table, Denominator, TBL_ADVANCE, TBL_FORWARD_READ, &rowset);
 	OPENCHANGE_RETVAL_IF(retval, retval, mem_ctx);
 
 	for (i = 0; i < rowset.cRows; i++) {

--- a/libocpf/ocpf_public.c
+++ b/libocpf/ocpf_public.c
@@ -442,7 +442,7 @@ static enum MAPISTATUS ocpf_folder_lookup(TALLOC_CTX *mem_ctx,
 	MAPIFreeBuffer(SPropTagArray);
 	if (retval != MAPI_E_SUCCESS) return false;
 
-	while (((retval = QueryRows(&obj_htable, 0x32, TBL_ADVANCE, &SRowSet)) != MAPI_E_NOT_FOUND && SRowSet.cRows)) {
+	while (((retval = QueryRows(&obj_htable, 0x32, TBL_ADVANCE, TBL_FORWARD_READ, &SRowSet)) != MAPI_E_NOT_FOUND && SRowSet.cRows)) {
 		for (i = 0; i < SRowSet.cRows; i++) {
 			fid = (const uint64_t *)find_SPropValue_data(&SRowSet.aRow[i], PR_FID);
 			if (fid && *fid == sfid) {

--- a/utils/backup/openchangemapidump.c
+++ b/utils/backup/openchangemapidump.c
@@ -131,7 +131,7 @@ static enum MAPISTATUS mapidump_walk_attachment(TALLOC_CTX *mem_ctx,
 	/* Walk through the table */
 	retval = QueryPosition(&obj_atable, &Numerator, &Denominator);
 
-	while ((retval = QueryRows(&obj_atable, Denominator, TBL_ADVANCE, &rowset)) != MAPI_E_NOT_FOUND && rowset.cRows) {
+	while ((retval = QueryRows(&obj_atable, Denominator, TBL_ADVANCE, TBL_FORWARD_READ, &rowset)) != MAPI_E_NOT_FOUND && rowset.cRows) {
 		for (i = 0; i < rowset.cRows; i++) {
 			attach_num = (const uint32_t *)find_SPropValue_data(&(rowset.aRow[i]), PR_ATTACH_NUM);
 			/* Open attachment */
@@ -198,7 +198,7 @@ static enum MAPISTATUS mapidump_walk_content(TALLOC_CTX *mem_ctx,
 	MAPIFreeBuffer(SPropTagArray);
 	MAPI_RETVAL_IF(retval, GetLastError(), NULL);
 
-	while ((retval = QueryRows(&obj_ctable, count, TBL_ADVANCE, &rowset)) != MAPI_E_NOT_FOUND && rowset.cRows) {
+	while ((retval = QueryRows(&obj_ctable, count, TBL_ADVANCE, TBL_FORWARD_READ, &rowset)) != MAPI_E_NOT_FOUND && rowset.cRows) {
 		for (i = 0; i < rowset.cRows; i++) {
 			mapi_object_init(&obj_message);
 			fid = (const uint64_t *) get_SPropValue_SRow_data(&rowset.aRow[i], PR_FID);
@@ -306,7 +306,7 @@ static enum MAPISTATUS mapidump_walk_container(TALLOC_CTX *mem_ctx,
 		MAPIFreeBuffer(SPropTagArray);
 		MAPI_RETVAL_IF(retval, GetLastError(), NULL);
 
-		while ((retval = QueryRows(&obj_htable, rcount, TBL_ADVANCE, &rowset) != MAPI_E_NOT_FOUND) && rowset.cRows) {
+		while ((retval = QueryRows(&obj_htable, rcount, TBL_ADVANCE, TBL_FORWARD_READ, &rowset) != MAPI_E_NOT_FOUND) && rowset.cRows) {
 			for (i = 0; i < rowset.cRows; i++) {
 				fid = (const uint64_t *)find_SPropValue_data(&rowset.aRow[i], PR_FID);
 				retval = mapidump_walk_container(mem_ctx, ocb_ctx, &obj_folder, *fid, containerdn, count + 1);

--- a/utils/exchange2mbox.c
+++ b/utils/exchange2mbox.c
@@ -153,7 +153,7 @@ static bool delete_messages(
 	if (retval != MAPI_E_SUCCESS)
 		return false;
 
-	while ((retval = QueryRows(&obj_table, 0xa, TBL_ADVANCE, &SRowSet)) == MAPI_E_SUCCESS) {
+	while ((retval = QueryRows(&obj_table, 0xa, TBL_ADVANCE, TBL_FORWARD_READ, &SRowSet)) == MAPI_E_SUCCESS) {
 		if (!SRowSet.cRows)
 			break;
 
@@ -835,7 +835,7 @@ old_code:
 			MAPIFreeBuffer(SPropTagArray);
 			MAPI_RETVAL_IF(retval, retval, NULL);
 			
-			retval = QueryRows(&obj_tb_attach, 0xa, TBL_ADVANCE, &rowset_attach);
+			retval = QueryRows(&obj_tb_attach, 0xa, TBL_ADVANCE, TBL_FORWARD_READ, &rowset_attach);
 			MAPI_RETVAL_IF(retval, retval, NULL);
 			
 			for (i = 0; i < rowset_attach.cRows; i++) {
@@ -1178,7 +1178,7 @@ int main(int argc, const char *argv[])
 	MAPIFreeBuffer(SPropTagArray);
 	MAPI_RETVAL_IF(retval, retval, mem_ctx);
 
-	while ((retval = QueryRows(&obj_table, 0xa, TBL_ADVANCE, &rowset)) != MAPI_E_NOT_FOUND && rowset.cRows) {
+	while ((retval = QueryRows(&obj_table, 0xa, TBL_ADVANCE, TBL_FORWARD_READ, &rowset)) != MAPI_E_NOT_FOUND && rowset.cRows) {
 		for (i = 0; i < rowset.cRows; i++) {
 			mapi_object_init(&obj_message);
 			retval = OpenMessage(&obj_store, 

--- a/utils/mapitest/mapitest_common.c
+++ b/utils/mapitest/mapitest_common.c
@@ -122,7 +122,7 @@ _PUBLIC_ bool mapitest_common_message_delete_by_subject(struct mapitest *mt,
 		return false;
 	}
 
-	while (((retval = QueryRows(&obj_ctable, count, TBL_ADVANCE, &SRowSet)) != MAPI_E_NOT_FOUND) && !retval && SRowSet.cRows) {
+	while (((retval = QueryRows(&obj_ctable, count, TBL_ADVANCE, TBL_FORWARD_READ, &SRowSet)) != MAPI_E_NOT_FOUND) && !retval && SRowSet.cRows) {
 		for (i = 0; i < SRowSet.cRows; i++) {
 			if (retval == MAPI_E_SUCCESS) {
 				msgids[0] = SRowSet.aRow[i].lpProps[0].value.d;
@@ -177,7 +177,7 @@ _PUBLIC_ bool mapitest_common_find_folder(struct mapitest *mt,
 		return false;
 	}
 
-	while (((retval = QueryRows(&obj_htable, count, TBL_ADVANCE, &rowset)) != MAPI_E_NOT_FOUND) && rowset.cRows) {
+	while (((retval = QueryRows(&obj_htable, count, TBL_ADVANCE, TBL_FORWARD_READ, &rowset)) != MAPI_E_NOT_FOUND) && rowset.cRows) {
 		for (index = 0; index < rowset.cRows; index++) {
 			fid = (const uint64_t *)find_SPropValue_data(&rowset.aRow[index], PR_FID);
 			newname = (const char *)find_SPropValue_data(&rowset.aRow[index], PR_DISPLAY_NAME);

--- a/utils/mapitest/module.c
+++ b/utils/mapitest/module.c
@@ -383,6 +383,7 @@ _PUBLIC_ uint32_t module_zentyal_init(struct mapitest *mt)
 	mapitest_suite_add_test(suite, "NSPI-1645", "Test SortTypePhoneticDisplayName is not supported in UpdateStat", mapitest_zentyal_1645);
 	mapitest_suite_add_test(suite, "OXCMSG-1804", "Test multi-value properties in ModifyRecipients", mapitest_zentyal_1804);
 	mapitest_suite_add_test(suite, "OXCMSG-4872", "Test different prop count in Recipient Row and ModifyRecipients", mapitest_zentyal_4872);
+	mapitest_suite_add_test(suite, "OXCTABL-6723", "Test Backward Read on QueryRows", mapitest_zentyal_6723);
 
 	mapitest_suite_register(mt, suite);
 

--- a/utils/mapitest/modules/module_oxcfold.c
+++ b/utils/mapitest/modules/module_oxcfold.c
@@ -1029,7 +1029,7 @@ _PUBLIC_ bool mapitest_oxcfold_MoveCopyMessages(struct mapitest *mt)
 		goto release;
 	}
 
-	retval = QueryRows(&(dst_contents), 20, TBL_NOADVANCE, &SRowSet);
+	retval = QueryRows(&(dst_contents), 20, TBL_NOADVANCE, TBL_FORWARD_READ, &SRowSet);
 	mapitest_print_retval(mt, "QueryRows");
 	if ( (retval == MAPI_E_SUCCESS) && (SRowSet.cRows > 0) ) {
 		for (i = 0; i < SRowSet.cRows; ++i) {
@@ -1375,7 +1375,7 @@ _PUBLIC_ bool mapitest_oxcfold_HardDeleteMessages(struct mapitest *mt)
 	mapitest_print_retval(mt, "SetColumns");
 	MAPIFreeBuffer(SPropTagArray);
 
-	retval = QueryRows(&(contents), 50, TBL_NOADVANCE, &SRowSet);
+	retval = QueryRows(&(contents), 50, TBL_NOADVANCE, TBL_FORWARD_READ, &SRowSet);
 	mapitest_print_retval(mt, "QueryRows");
 	if (retval == MAPI_E_SUCCESS) {
 		for (i = 0; i < SRowSet.cRows; ++i) {
@@ -1393,7 +1393,7 @@ _PUBLIC_ bool mapitest_oxcfold_HardDeleteMessages(struct mapitest *mt)
 	}
 
 	/* Step 7. Check the restriction again */
-	retval = QueryRows(&(contents), 50, TBL_NOADVANCE, &SRowSet);
+	retval = QueryRows(&(contents), 50, TBL_NOADVANCE, TBL_FORWARD_READ, &SRowSet);
 	mapitest_print_retval(mt, "QueryRows");
 	if ( retval != MAPI_E_SUCCESS ) {
 		ret = false;

--- a/utils/mapitest/modules/module_oxcmsg.c
+++ b/utils/mapitest/modules/module_oxcmsg.c
@@ -881,7 +881,7 @@ _PUBLIC_ bool mapitest_oxcmsg_GetMessageStatus(struct mapitest *mt)
 	}
 
 	/* Step 6. Get Message Status */
-	while (((retval = QueryRows(&obj_ctable, count, TBL_ADVANCE, &SRowSet)) != MAPI_E_NOT_FOUND) &&
+	while (((retval = QueryRows(&obj_ctable, count, TBL_ADVANCE, TBL_FORWARD_READ, &SRowSet)) != MAPI_E_NOT_FOUND) &&
 	       SRowSet.cRows) {
 		count -= SRowSet.cRows;
 		for (i = 0; i < SRowSet.cRows; i++) {
@@ -1021,7 +1021,7 @@ _PUBLIC_ bool mapitest_oxcmsg_SetMessageStatus(struct mapitest *mt)
 	}
 
 	/* Fetch the first email */
-	retval = QueryRows(&obj_ctable, 1, TBL_NOADVANCE, &SRowSet);
+	retval = QueryRows(&obj_ctable, 1, TBL_NOADVANCE, TBL_FORWARD_READ, &SRowSet);
 	mapitest_print_retval_clean(mt, "QueryRows", retval);
 	if (retval != MAPI_E_SUCCESS || SRowSet.cRows == 0) {
 		ret = false;
@@ -1121,7 +1121,7 @@ _PUBLIC_ bool mapitest_oxcmsg_SetReadFlags(struct mapitest *mt)
 		goto cleanup;
 	}
 
-	retval = QueryRows(&obj_test_folder, 10, TBL_NOADVANCE, &SRowSet);
+	retval = QueryRows(&obj_test_folder, 10, TBL_NOADVANCE, TBL_FORWARD_READ, &SRowSet);
 	mapitest_print_retval_clean(mt, "QueryRows", retval);
 	if (retval != MAPI_E_SUCCESS) {
 		ret = false;
@@ -1148,7 +1148,7 @@ _PUBLIC_ bool mapitest_oxcmsg_SetReadFlags(struct mapitest *mt)
 		goto cleanup;
 	}
 
-	retval = QueryRows(&obj_test_folder, 10, TBL_NOADVANCE, &SRowSet);
+	retval = QueryRows(&obj_test_folder, 10, TBL_NOADVANCE, TBL_FORWARD_READ, &SRowSet);
 	mapitest_print_retval_clean(mt, "QueryRows", retval);
 	if (retval != MAPI_E_SUCCESS) {
 		ret = false;
@@ -1171,7 +1171,7 @@ _PUBLIC_ bool mapitest_oxcmsg_SetReadFlags(struct mapitest *mt)
 
 	SetReadFlags(&(context->obj_test_folder), CLEAR_READ_FLAG, 5, messageIds);
 
-	retval = QueryRows(&obj_test_folder, 10, TBL_NOADVANCE, &SRowSet);
+	retval = QueryRows(&obj_test_folder, 10, TBL_NOADVANCE, TBL_FORWARD_READ, &SRowSet);
 	mapitest_print_retval_clean(mt, "QueryRows", retval);
 	if (retval != MAPI_E_SUCCESS) {
 		ret = false;

--- a/utils/mapitest/modules/module_oxcperm.c
+++ b/utils/mapitest/modules/module_oxcperm.c
@@ -115,7 +115,7 @@ _PUBLIC_ bool mapitest_oxcperm_GetPermissionsTable(struct mapitest *mt)
 		goto cleanup;
 	}
 
-	retval = QueryRows(&obj_permtable, 0x20, TBL_ADVANCE, &SRowSet);
+	retval = QueryRows(&obj_permtable, 0x20, TBL_ADVANCE, TBL_FORWARD_READ, &SRowSet);
 	if (retval != MAPI_E_SUCCESS) {
 		mapitest_print_retval(mt, "QueryRows");
 		ret = false;
@@ -211,7 +211,7 @@ _PUBLIC_ bool mapitest_oxcperm_ModifyPermissions(struct mapitest *mt)
 		goto cleanup;
 	}
 
-	retval = QueryRows(&obj_permtable, 0x20, TBL_ADVANCE, &SRowSet);
+	retval = QueryRows(&obj_permtable, 0x20, TBL_ADVANCE, TBL_FORWARD_READ, &SRowSet);
 	if (retval != MAPI_E_SUCCESS) {
 		mapitest_print_retval(mt, "QueryRows");
 		ret = false;
@@ -245,7 +245,7 @@ _PUBLIC_ bool mapitest_oxcperm_ModifyPermissions(struct mapitest *mt)
 		goto cleanup;
 	}
 
-	retval = QueryRows(&obj_permtable, 0x20, TBL_ADVANCE, &SRowSet);
+	retval = QueryRows(&obj_permtable, 0x20, TBL_ADVANCE, TBL_FORWARD_READ, &SRowSet);
 	if (retval != MAPI_E_SUCCESS) {
 		mapitest_print_retval(mt, "QueryRows");
 		ret = false;
@@ -279,7 +279,7 @@ _PUBLIC_ bool mapitest_oxcperm_ModifyPermissions(struct mapitest *mt)
 		goto cleanup;
 	}
 
-	retval = QueryRows(&obj_permtable, 0x20, TBL_ADVANCE, &SRowSet);
+	retval = QueryRows(&obj_permtable, 0x20, TBL_ADVANCE, TBL_FORWARD_READ, &SRowSet);
 	if (retval != MAPI_E_SUCCESS) {
 		mapitest_print_retval(mt, "QueryRows");
 		ret = false;

--- a/utils/mapitest/modules/module_oxctable.c
+++ b/utils/mapitest/modules/module_oxctable.c
@@ -292,7 +292,7 @@ _PUBLIC_ bool mapitest_oxctable_QueryRows(struct mapitest *mt)
 
 	/* Step 3. QueryRows */
 	do {
-		retval = QueryRows(&obj_htable, 0x2, TBL_ADVANCE, &SRowSet);
+		retval = QueryRows(&obj_htable, 0x2, TBL_ADVANCE, TBL_FORWARD_READ, &SRowSet);
 		if (SRowSet.cRows > 0) {
 			idx += SRowSet.cRows;
 			if (retval == MAPI_E_SUCCESS) {
@@ -332,7 +332,7 @@ _PUBLIC_ bool mapitest_oxctable_QueryRows(struct mapitest *mt)
 	/* Step 6. QueryRows on test folder contents */
 	idx = 0;
 	do {
-		retval = QueryRows(&(obj_test_folder), 0x2, TBL_ADVANCE, &SRowSet);
+		retval = QueryRows(&(obj_test_folder), 0x2, TBL_ADVANCE, TBL_FORWARD_READ, &SRowSet);
 		if (SRowSet.cRows > 0) {
 			idx += SRowSet.cRows;
 			if (retval == MAPI_E_SUCCESS) {
@@ -559,7 +559,7 @@ _PUBLIC_ bool mapitest_oxctable_CreateBookmark(struct mapitest *mt)
 
 	/* Step 3. Create Bookmarks */
 	bkPosition = talloc_array(mt->mem_ctx, uint32_t, 1);
-	retval = QueryRows(&obj_htable, 100, TBL_ADVANCE, &SRowSet);
+	retval = QueryRows(&obj_htable, 100, TBL_ADVANCE, TBL_FORWARD_READ, &SRowSet);
 	for (i = 0; i < SRowSet.cRows; i++) {
 		bkPosition = talloc_realloc(mt->mem_ctx, bkPosition, uint32_t, i + 2);
 		retval = CreateBookmark(&obj_htable, &(bkPosition[i]));
@@ -632,7 +632,7 @@ _PUBLIC_ bool mapitest_oxctable_SeekRowBookmark(struct mapitest *mt)
 
 	/* Step 3. Create Bookmarks */
 	bkPosition = talloc_array(mt->mem_ctx, uint32_t, 1);
-	retval = QueryRows(&obj_htable, 100, TBL_ADVANCE, &SRowSet);
+	retval = QueryRows(&obj_htable, 100, TBL_ADVANCE, TBL_FORWARD_READ, &SRowSet);
 	for (i = 0; i < SRowSet.cRows; i++) {
 		bkPosition = talloc_realloc(mt->mem_ctx, bkPosition, uint32_t, i + 2);
 		retval = CreateBookmark(&obj_htable, &(bkPosition[i]));
@@ -763,7 +763,7 @@ _PUBLIC_ bool mapitest_oxctable_Category(struct mapitest *mt)
 	}
 
 	rowcount =  2 * origcount;
-	QueryRows(&(obj_test_folder), rowcount, TBL_ADVANCE, &SRowSet);
+	QueryRows(&(obj_test_folder), rowcount, TBL_ADVANCE, TBL_FORWARD_READ, &SRowSet);
 	mapitest_print_retval(mt, "QueryRows");
 	if (GetLastError() != MAPI_E_SUCCESS) {
 		ret = false;

--- a/utils/openchangeclient.c
+++ b/utils/openchangeclient.c
@@ -132,7 +132,7 @@ static enum MAPISTATUS openchangeclient_getdir(TALLOC_CTX *mem_ctx,
 		MAPIFreeBuffer(SPropTagArray);
 		MAPI_RETVAL_IF(retval, retval, folder);
 
-		while (((retval = QueryRows(&obj_htable, 0x32, TBL_ADVANCE, &SRowSet)) != MAPI_E_NOT_FOUND) && SRowSet.cRows) {
+		while (((retval = QueryRows(&obj_htable, 0x32, TBL_ADVANCE, TBL_FORWARD_READ, &SRowSet)) != MAPI_E_NOT_FOUND) && SRowSet.cRows) {
 			for (index = 0; (index < SRowSet.cRows) && (found == false); index++) {
 				fid = (const uint64_t *)find_SPropValue_data(&SRowSet.aRow[index], PR_FID);
 				name = (const char *)find_SPropValue_data(&SRowSet.aRow[index], PR_DISPLAY_NAME_UNICODE);
@@ -442,7 +442,7 @@ static enum MAPISTATUS openchangeclient_fetchmail(mapi_object_t *obj_store,
 	MAPIFreeBuffer(SPropTagArray);
 	MAPI_RETVAL_IF(retval, retval, mem_ctx);
 
-	while ((retval = QueryRows(&obj_table, count, TBL_ADVANCE, &rowset)) != MAPI_E_NOT_FOUND && rowset.cRows) {
+	while ((retval = QueryRows(&obj_table, count, TBL_ADVANCE, TBL_FORWARD_READ, &rowset)) != MAPI_E_NOT_FOUND && rowset.cRows) {
 		count -= rowset.cRows;
 		for (i = 0; i < rowset.cRows; i++) {
 			mapi_object_init(&obj_message);
@@ -481,7 +481,7 @@ static enum MAPISTATUS openchangeclient_fetchmail(mapi_object_t *obj_store,
 							if (retval != MAPI_E_SUCCESS) return retval;
 							MAPIFreeBuffer(SPropTagArray);
 							
-							retval = QueryRows(&obj_tb_attach, 0xa, TBL_ADVANCE, &rowset_attach);
+							retval = QueryRows(&obj_tb_attach, 0xa, TBL_ADVANCE, TBL_FORWARD_READ, &rowset_attach);
 							if (retval != MAPI_E_SUCCESS) return retval;
 							
 							for (j = 0; j < rowset_attach.cRows; j++) {
@@ -1006,7 +1006,7 @@ static bool openchangeclient_deletemail(TALLOC_CTX *mem_ctx,
 	retval = SetColumns(&obj_table, SPropTagArray);
 	if (retval != MAPI_E_SUCCESS) return false;
 	
-	while ((retval = QueryRows(&obj_table, 0x10, TBL_ADVANCE, &SRowSet)) == MAPI_E_SUCCESS) {
+	while ((retval = QueryRows(&obj_table, 0x10, TBL_ADVANCE, TBL_FORWARD_READ, &SRowSet)) == MAPI_E_SUCCESS) {
 		count_rows = SRowSet.cRows;
 		if (!count_rows) break;
 		id_messages = talloc_array(mem_ctx, uint64_t, count_rows);
@@ -1615,7 +1615,7 @@ static bool get_child_folders(TALLOC_CTX *mem_ctx, mapi_object_t *parent, mapi_i
 	MAPIFreeBuffer(SPropTagArray);
 	if (retval != MAPI_E_SUCCESS) return false;
 	
-	while (((retval = QueryRows(&obj_htable, 0x32, TBL_ADVANCE, &rowset)) != MAPI_E_NOT_FOUND) && rowset.cRows) {
+	while (((retval = QueryRows(&obj_htable, 0x32, TBL_ADVANCE, TBL_FORWARD_READ, &rowset)) != MAPI_E_NOT_FOUND) && rowset.cRows) {
 		for (index = 0; index < rowset.cRows; index++) {
 			fid = (const uint64_t *)find_SPropValue_data(&rowset.aRow[index], PR_FID);
 			name = (const char *)find_SPropValue_data(&rowset.aRow[index], PR_DISPLAY_NAME_UNICODE);
@@ -1673,7 +1673,7 @@ static bool get_child_folders_pf(TALLOC_CTX *mem_ctx, mapi_object_t *parent, map
 	MAPIFreeBuffer(SPropTagArray);
 	if (retval != MAPI_E_SUCCESS) return false;
 	
-	while (((retval = QueryRows(&obj_htable, 0x32, TBL_ADVANCE, &rowset)) != MAPI_E_NOT_FOUND) && rowset.cRows) {
+	while (((retval = QueryRows(&obj_htable, 0x32, TBL_ADVANCE, TBL_FORWARD_READ, &rowset)) != MAPI_E_NOT_FOUND) && rowset.cRows) {
 		for (index = 0; index < rowset.cRows; index++) {
 			fid = (const uint64_t *)find_SPropValue_data(&rowset.aRow[index], PR_FID);
 			name = (const char *)find_SPropValue_data(&rowset.aRow[index], PR_DISPLAY_NAME_UNICODE);
@@ -1816,7 +1816,7 @@ static bool openchangeclient_fetchitems(TALLOC_CTX *mem_ctx, mapi_object_t *obj_
 	MAPIFreeBuffer(SPropTagArray);
 	if (retval != MAPI_E_SUCCESS) return false;
 
-	while ((retval = QueryRows(&obj_table, count, TBL_ADVANCE, &SRowSet)) != MAPI_E_NOT_FOUND && SRowSet.cRows) {
+	while ((retval = QueryRows(&obj_table, count, TBL_ADVANCE, TBL_FORWARD_READ, &SRowSet)) != MAPI_E_NOT_FOUND && SRowSet.cRows) {
 		count -= SRowSet.cRows;
 		for (i = 0; i < SRowSet.cRows; i++) {
 			mapi_object_init(&obj_message);
@@ -1903,7 +1903,7 @@ static enum MAPISTATUS folder_lookup(TALLOC_CTX *mem_ctx,
 	MAPIFreeBuffer(SPropTagArray);
 	if (retval != MAPI_E_SUCCESS) return retval;
 
-	while (((retval = QueryRows(&obj_htable, 0x32, TBL_ADVANCE, &SRowSet)) != MAPI_E_NOT_FOUND && SRowSet.cRows)) {
+	while (((retval = QueryRows(&obj_htable, 0x32, TBL_ADVANCE, TBL_FORWARD_READ, &SRowSet)) != MAPI_E_NOT_FOUND && SRowSet.cRows)) {
 		for (i = 0; i < SRowSet.cRows; i++) {
 			fid = (const uint64_t *)find_SPropValue_data(&SRowSet.aRow[i], PR_FID);
 			if (fid && *fid == sfid) {
@@ -1951,7 +1951,7 @@ static enum MAPISTATUS message_lookup(TALLOC_CTX *mem_ctx,
 	MAPIFreeBuffer(SPropTagArray);
 	if (retval != MAPI_E_SUCCESS) return retval;
 
-	while (((retval = QueryRows(&obj_htable, 0x32, TBL_ADVANCE, &SRowSet)) != MAPI_E_NOT_FOUND) && SRowSet.cRows) {
+	while (((retval = QueryRows(&obj_htable, 0x32, TBL_ADVANCE, TBL_FORWARD_READ, &SRowSet)) != MAPI_E_NOT_FOUND) && SRowSet.cRows) {
 		for (i = 0; i < SRowSet.cRows; i++) {
 			fid = (const uint64_t *)find_SPropValue_data(&SRowSet.aRow[i], PR_FID);
 			mid = (const uint64_t *)find_SPropValue_data(&SRowSet.aRow[i], PR_MID);
@@ -2147,7 +2147,7 @@ static enum MAPISTATUS openchangeclient_findmail(mapi_object_t *obj_store,
 	MAPIFreeBuffer(SPropTagArray);
 	MAPI_RETVAL_IF(retval, GetLastError(), mem_ctx);
 
-	while ((retval = QueryRows(&obj_table, 0xa, TBL_ADVANCE, &SRowSet)) != MAPI_E_NOT_FOUND && SRowSet.cRows) {
+	while ((retval = QueryRows(&obj_table, 0xa, TBL_ADVANCE, TBL_FORWARD_READ, &SRowSet)) != MAPI_E_NOT_FOUND && SRowSet.cRows) {
 		for (i = 0; i < SRowSet.cRows; i++) {
 			lpProp = get_SPropValue_SRowSet(&SRowSet, PR_MID);
 			if (lpProp != NULL) {

--- a/utils/openchangepfadmin.c
+++ b/utils/openchangepfadmin.c
@@ -106,7 +106,7 @@ static bool get_child_folders_pf(TALLOC_CTX *mem_ctx, mapi_object_t *parent, map
 	MAPIFreeBuffer(SPropTagArray);
 	if (retval != MAPI_E_SUCCESS) return false;
 	
-	while (((retval = QueryRows(&obj_htable, 0x32, TBL_ADVANCE, &rowset)) != MAPI_E_NOT_FOUND) && rowset.cRows) {
+	while (((retval = QueryRows(&obj_htable, 0x32, TBL_ADVANCE, TBL_FORWARD_READ, &rowset)) != MAPI_E_NOT_FOUND) && rowset.cRows) {
 		for (index = 0; index < rowset.cRows; index++) {
 			fid = (const uint64_t *)find_SPropValue_data(&rowset.aRow[index], PR_FID);
 			name = (const char *)find_SPropValue_data(&rowset.aRow[index], PR_DISPLAY_NAME_UNICODE);
@@ -150,7 +150,7 @@ static enum MAPISTATUS openchangepfadmin_getdir(TALLOC_CTX *mem_ctx,
 	MAPIFreeBuffer(SPropTagArray);
 	if (retval != MAPI_E_SUCCESS) return MAPI_E_NOT_FOUND;
 	
-	while (((retval = QueryRows(&obj_htable, 0x32, TBL_ADVANCE, &rowset)) != MAPI_E_NOT_FOUND) && rowset.cRows) {
+	while (((retval = QueryRows(&obj_htable, 0x32, TBL_ADVANCE, TBL_FORWARD_READ, &rowset)) != MAPI_E_NOT_FOUND) && rowset.cRows) {
 		for (index = 0; index < rowset.cRows; index++) {
 			fid = (const uint64_t *)find_SPropValue_data(&rowset.aRow[index], PR_FID);
 			name = (const char *)find_SPropValue_data(&rowset.aRow[index], PR_DISPLAY_NAME_UNICODE);


### PR DESCRIPTION
Instead of crashing.

And we have implemented in libmapi for MAPI clients:

* Give support to set read direction on QueryRows oxctabl in libmapi
* Current limitation: Read backwards from BOOKMARK_BEGINNING will always return the first row. MAPI clients should check Origin response field to know nothing else to read. Current `libmapi:QueryRows` does not support it.