### PR TITLE
Allow WriteStream operation with different lengths

### DIFF
--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -2989,6 +2989,10 @@ _PUBLIC_ void emsmdbp_stream_write_buffer(TALLOC_CTX *mem_ctx, struct emsmdbp_st
 	uint32_t old_length;
 	uint8_t *old_data;
 
+        if (stream->position == 0) {
+                stream->buffer.length = 0;
+        }
+
 	new_position = stream->position + new_buffer.length;
 	if (new_position >= stream->buffer.length) {
 		old_length = stream->buffer.length;


### PR DESCRIPTION
* If a stream was open, the size of the buffer was set to the size of the existing property. Therefore, writing a stream of a different size resulted in partially overwriting the previous value of the property.
* This fixes the "weird HTML body" bug when sending from _Drafts_ in the REST API