### PR TITLE
Fix prop type for PidNameKeywords

### DIFF
--- a/libmapi/conf/mapi-named-properties
+++ b/libmapi/conf/mapi-named-properties
@@ -449,7 +449,7 @@ PidNameRightsManagementLicense                         NULL                     
 PidNameEditTime                                        NULL                          0x0000 EditTime                      PT_UNICODE    MNID_STRING PS_PUBLIC_STRINGS	   0x90e0
 ###PidNameJunkEmailMoveStamp                              NULL                          0x0000 http://schemas.microsoft.com/exchange/junkemailmovestamp PT_LONG     MNID_STRING PS_PUBLIC_STRINGS 0x917e
 PidNameHiddenCount                                     NULL                          0x0000 HiddenCount                   PT_LONG       MNID_STRING PS_PUBLIC_STRINGS	   0x90f1
-PidNameKeywords                                        NULL                          0x0000 Keywords                      PT_MV_STRING8 MNID_STRING PS_PUBLIC_STRINGS	   0x90db
+PidNameKeywords                                        NULL                          0x0000 Keywords                      PT_MV_UNICODE MNID_STRING PS_PUBLIC_STRINGS	   0x90db
 PidNameLastAuthor                                      NULL                          0x0000 LastAuthor                    PT_UNICODE    MNID_STRING PS_PUBLIC_STRINGS	   0x90de
 PidNameLastPrinted                                     NULL                          0x0000 LastPrinted                   PT_SYSTIME    MNID_STRING PS_PUBLIC_STRINGS	   0x90e1
 PidNameLastSaveDateTime                                NULL                          0x0000 LastSaveDtm                   PT_SYSTIME    MNID_STRING PS_PUBLIC_STRINGS	   0x90e3


### PR DESCRIPTION
It is PtypMultipleString (0x101F) Unicode and not String 8b
according to [MS-OXPROPS] Section 2.444