### PR TITLE
mapiproxy: single samdb connection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,18 @@
+# Changes
+
+All notable changes to this project will be documented in this file.
+The descriptions should be useful and understandable for end users of OpenChange.
+Unreleased changes refer to our current [master branch](https://github.com/openchange/openchange/).
+
+## [Unreleased]
+
+### Fixes
+* Fixed `Too many connections to ldap` when openchange runs on samba as member of a domain.
+
+
+
+
+[//]: # (unreleased compare link should be changed to the latest release)
+[//]: # (the current hash was master when this CHANGES.md file was created)
+[unreleased]: https://github.com/openchange/openchange/compare/0460ace70d03de001de11d8fb54f0571128b0b2f...HEAD
+

--- a/mapiproxy/servers/default/emsmdb/emsmdbp.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp.c
@@ -38,6 +38,9 @@ struct ldb_context *samdb_connect(TALLOC_CTX *, struct tevent_context *,
 				  struct auth_session_info *,
 				  unsigned int);
 
+/* Single connection to samdb */
+static struct ldb_context *samdb_ctx = NULL;
+
 static struct GUID MagicGUID = {
 	.time_low = 0xbeefface,
 	.time_mid = 0xcafe,
@@ -128,16 +131,19 @@ _PUBLIC_ struct emsmdbp_context *emsmdbp_init(struct loadparm_context *lp_ctx,
 	/* Save a pointer to the loadparm context */
 	emsmdbp_ctx->lp_ctx = lp_ctx;
 
-	/* Retrieve samdb url (local or external) */
-	samdb_url = lpcfg_parm_string(lp_ctx, NULL, "dcerpc_mapiproxy", "samdb_url");
+	if (!samdb_ctx) {
+		/* Retrieve samdb url (local or external) */
+		samdb_url = lpcfg_parm_string(lp_ctx, NULL, "dcerpc_mapiproxy", "samdb_url");
 
-	/* return an opaque context pointer on samDB database */
-	if (!samdb_url) {
-		emsmdbp_ctx->samdb_ctx = samdb_connect(mem_ctx, ev, lp_ctx, system_session(lp_ctx), 0);
-	} else {
-		emsmdbp_ctx->samdb_ctx = samdb_connect_url(mem_ctx, ev, lp_ctx, system_session(lp_ctx), 0, samdb_url);
+		/* return an opaque context pointer on samDB database */
+		if (!samdb_url) {
+			samdb_ctx = samdb_connect(mem_ctx, ev, lp_ctx, system_session(lp_ctx), 0);
+		} else {
+			samdb_ctx = samdb_connect_url(mem_ctx, ev, lp_ctx, system_session(lp_ctx), LDB_FLG_RECONNECT, samdb_url);
+		}
 	}
 
+	emsmdbp_ctx->samdb_ctx = samdb_ctx;
 	if (!emsmdbp_ctx->samdb_ctx) {
 		talloc_free(mem_ctx);
 		DEBUG(0, ("[%s:%d]: Connection to \"sam.ldb\" failed\n", __FUNCTION__, __LINE__));


### PR DESCRIPTION
There is no need to create a new one for each bound session. So now all nspi and emsmdb session will use the same ldb_context. This will fix a problem (when `dcerpc_mapiproxy:samdb_url` is defined and not local) of too many ldap connection opened.

Also in case the samdb is not local (`dcerpc_mapiproxy:samdb_url` defined) the samdb context is open with reconnect flag.

I'm also introducing a new **CHANGES.md** file which should include for now on (if we see is useful) the new changes from an user perspective.

