### PR TITLE
Give support to calendar sharing invitation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 
 ## [Unreleased]
 
+### Added
+* Calendar sharing invitation among different Outlook versions
+
 ### Fixes
 * Fixed `Too many connections to ldap` when openchange runs on samba as member of a domain.
 

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
@@ -362,6 +362,8 @@ DATA_BLOB emsmdbp_stream_read_buffer(struct emsmdbp_stream *, uint32_t);
 void emsmdbp_stream_write_buffer(TALLOC_CTX *, struct emsmdbp_stream *, DATA_BLOB);
 void emsmdbp_fill_table_row_blob(TALLOC_CTX *, struct emsmdbp_context *, DATA_BLOB *, uint16_t, enum MAPITAGS *, void **, enum MAPISTATUS *);
 void emsmdbp_fill_row_blob(TALLOC_CTX *, struct emsmdbp_context *, uint8_t *, DATA_BLOB *,struct SPropTagArray *, void **, enum MAPISTATUS *, bool *);
+enum MAPISTATUS emsmdbp_object_attach_sharing_metadata_XML_file(struct emsmdbp_context *emsmdbp_ctx, struct emsmdbp_object *sharing_object);
+
 
 /* definitions from oxcfold.c */
 enum MAPISTATUS EcDoRpc_RopOpenFolder(TALLOC_CTX *, struct emsmdbp_context *, struct EcDoRpc_MAPI_REQ *, struct EcDoRpc_MAPI_REPL *, uint32_t *, uint16_t *);

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -2631,7 +2631,14 @@ static int emsmdbp_object_get_properties_mapistore_root(TALLOC_CTX *mem_ctx, str
 			}
 		}
                 else {
-			retval = openchangedb_get_folder_property(data_pointers, emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, properties->aulPropTag[i], folder->folderID, data_pointers + i);
+                        /* We are not using emsmdbp_ctx->username because we want to impersonate to get the properties
+                           on shared folders */
+			owner = emsmdbp_get_owner(object);
+			if (!owner) {
+				/* Public folder? Then, use logged user */
+				owner = emsmdbp_ctx->username;
+			}
+			retval = openchangedb_get_folder_property(data_pointers, emsmdbp_ctx->oc_ctx, owner, properties->aulPropTag[i], folder->folderID, data_pointers + i);
                 }
 		retvals[i] = retval;
         }

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -3129,3 +3129,232 @@ _PUBLIC_ struct emsmdbp_object *emsmdbp_object_ftcontext_init(TALLOC_CTX *mem_ct
 
 	return object;
 }
+
+/**
+   \details Create the XML file from the sharing message object and store it as
+            binary property in attach_bin out parameter.
+
+   \param emsmdbp_ctx pointer to the emsmdb provider cotnext
+   \param sharing_object the sharing message object to get the XML data from
+   \param [out] attach_bin pointer to Binary_r property value pointer where the XML data is stored
+   \param mem_ctx pointer to memory context where the attach_bin is created
+
+   \note On success attach_bin is allocated in mem_ctx. It is up to the developer
+   to free that memory context when it is not needed anymore.
+
+   \return MAPI_E_SUCCESS on success, a mapi error code otherwise
+ */
+static enum MAPISTATUS emsmdbp_object_sharing_metadata_property(struct emsmdbp_context *emsmdbp_ctx, struct emsmdbp_object *sharing_object, struct Binary_r **attach_bin, TALLOC_CTX *mem_ctx)
+{
+	struct Binary_r		       *bin;
+	char			       *xml;
+	struct emsmdbp_prop_index      prop_index;
+	int			       i;
+	enum MAPISTATUS		       *retvals = NULL;
+	struct mapistore_message       *msg_data = NULL;
+	const enum MAPITAGS	       sharing_prop_tags[] = {PidLidSharingLocalType, PidLidSharingInitiatorName, PidLidSharingInitiatorSmtp, PidLidSharingInitiatorEntryId, PidLidSharingRemoteName, PidLidSharingRemoteUid, PidLidSharingRemoteStoreUid}; /* Only managing invitations by now */
+	struct SBinary_short	       *entryId;
+	struct SPropTagArray	       *sharing_properties;
+	struct SPropValue	       *attach_bin_property;
+	TALLOC_CTX		       *local_mem_ctx;
+	const uint32_t		       SHARING_PROPS_COUNT = sizeof(sharing_prop_tags) / sizeof(enum MAPITAGS);
+	uint32_t		       contextID;
+	void			       **data_pointers;
+
+	attach_bin_property = talloc_zero(mem_ctx, struct SPropValue);
+	OPENCHANGE_RETVAL_IF(!attach_bin_property, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
+
+	local_mem_ctx = talloc_named(NULL, 0, "sharing_metadata_property");
+	OPENCHANGE_RETVAL_IF(!local_mem_ctx, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
+
+	/* We get the required properties from the mapistore */
+	sharing_properties = talloc_zero(mem_ctx, struct SPropTagArray);
+	OPENCHANGE_RETVAL_IF(!sharing_properties, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+	sharing_properties->cValues = SHARING_PROPS_COUNT;
+	sharing_properties->aulPropTag = talloc_array(local_mem_ctx, enum MAPITAGS, SHARING_PROPS_COUNT);
+	memcpy(sharing_properties->aulPropTag, sharing_prop_tags, sizeof(sharing_prop_tags));
+
+	data_pointers = emsmdbp_object_get_properties(local_mem_ctx, emsmdbp_ctx, sharing_object,
+						      sharing_properties, &retvals);
+	OPENCHANGE_RETVAL_IF(!data_pointers || retvals[0] != MAPI_E_SUCCESS, MAPI_E_NOT_FOUND, local_mem_ctx);
+
+	/* TODO: We do only support calendar invitation by now. Checks on PidLidSharingLocalType */
+	if (strncmp((char *)data_pointers[0], "IPF.Appointment", strlen("IPF.Appointment")) != 0) {
+		talloc_free(local_mem_ctx);
+		return MAPI_E_NO_SUPPORT;
+	}
+
+	/* Check every retval is SUCCESS to build up the XML */
+	for (i = 1; i < SHARING_PROPS_COUNT; i++) {
+		OPENCHANGE_RETVAL_IF(retvals[i] != MAPI_E_SUCCESS, MAPI_E_NOT_FOUND, local_mem_ctx);
+	}
+
+	xml = talloc_asprintf(local_mem_ctx,
+			      "<?xml version=\"1.0\"?> "
+			      "<SharingMessage xmlns=\"http://schemas.microsoft.com/sharing/2008\">"
+			      "<DataType>calendar</DataType>"
+			      "<Initiator>");
+	OPENCHANGE_RETVAL_IF(!xml, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+
+	/*** Initiator ***/
+	xml = talloc_asprintf_append(xml, "<Name>%s</Name>", (char *)data_pointers[1]);	 /* PidLidSharingInitiatorName */
+	OPENCHANGE_RETVAL_IF(!xml, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+
+	xml = talloc_asprintf_append(xml, "<SmtpAddress>%s</SmtpAddress>", (char *)data_pointers[2]); /*PidLidSharingInitiatorSmtp */
+	OPENCHANGE_RETVAL_IF(!xml, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+
+	/* Take the binary EntryId and transform to Hex encoded field */
+	xml = talloc_asprintf_append(xml, "<EntryId>");
+	OPENCHANGE_RETVAL_IF(!xml, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+	entryId = data_pointers[3]; /* PidLidSharingInitiatorEntryId */
+	for (i = 0; i < entryId->cb; i++) {
+		xml = talloc_asprintf_append(xml, "%.2X", *(entryId->lpb + i));
+		OPENCHANGE_RETVAL_IF(!xml, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+	}
+	xml = talloc_asprintf_append(xml, "</EntryId>");
+	OPENCHANGE_RETVAL_IF(!xml, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+
+	xml = talloc_asprintf_append(xml, "</Initiator>");
+	OPENCHANGE_RETVAL_IF(!xml, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+
+	/*** Invitation ***/
+	xml = talloc_asprintf_append(xml, "<Invitation>");
+	OPENCHANGE_RETVAL_IF(!xml, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+
+	/* This seems to be included when the calendar is not a default one */
+	xml = talloc_asprintf_append(xml, "<Title>%s</Title>", (char *)data_pointers[4]); /* PidLidSharingRemoteName */
+	OPENCHANGE_RETVAL_IF(!xml, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+
+	/*** Provider ***/
+	xml = talloc_asprintf_append(xml, "<Providers><Provider Type=\"ms-exchange-internal\" ");
+	OPENCHANGE_RETVAL_IF(!xml, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+
+	/* Get recipients */
+	contextID = emsmdbp_get_contextID(sharing_object);
+	mapistore_message_get_message_data(emsmdbp_ctx->mstore_ctx, contextID, sharing_object->backend_object, local_mem_ctx, &msg_data);
+	if (msg_data && msg_data->recipients_count > 0) {
+		xml = talloc_asprintf_append(xml, "TargetRecipients=\"");
+		OPENCHANGE_RETVAL_IF(!xml, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+
+		emsmdbp_fill_prop_index(&prop_index, msg_data->columns);
+		for (i = 0; i < msg_data->recipients_count; i++) {
+			if (prop_index.email_address != (uint32_t) -1) {
+				xml = talloc_asprintf_append(xml, "%s", (char *)msg_data->recipients[i].data[prop_index.email_address]);
+				OPENCHANGE_RETVAL_IF(!xml, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+				if (i + 1 < msg_data->recipients_count) {
+					/* ; separated */
+					xml = talloc_asprintf_append(xml, ";");
+					OPENCHANGE_RETVAL_IF(!xml, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+				}
+			}
+		}
+		xml = talloc_asprintf_append(xml, "\"");
+		OPENCHANGE_RETVAL_IF(!xml, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+	}
+	xml = talloc_asprintf_append(xml, ">");
+	OPENCHANGE_RETVAL_IF(!xml, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+
+	xml = talloc_asprintf_append(xml,
+				     "<FolderId xmlns=\"http://schemas.microsoft.com/exchange/sharing/2008\">%s</FolderId>",
+				     (char *)data_pointers[5]);	 /* PidLidSharingRemoteUid */
+	OPENCHANGE_RETVAL_IF(!xml, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+
+	xml = talloc_asprintf_append(xml,
+				     "<MailboxId xmlns=\"http://schemas.microsoft.com/exchange/sharing/2008\">%s</MailboxId>",
+				     (char *)data_pointers[6]);	 /* PidLidSharingRemoteStoreUid */
+	OPENCHANGE_RETVAL_IF(!xml, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+
+	xml = talloc_asprintf_append(xml, "</Provider></Providers></Invitation></SharingMessage>");
+	OPENCHANGE_RETVAL_IF(!xml, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+
+	bin = talloc_zero(mem_ctx, struct Binary_r);
+	OPENCHANGE_RETVAL_IF(!xml, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+	bin->lpb = (uint8_t *) talloc_strdup(mem_ctx, xml);
+	bin->cb = strlen(xml);
+
+	*attach_bin = bin;
+
+	talloc_free(local_mem_ctx);
+
+	return MAPI_E_SUCCESS;
+}
+
+/**
+   \details Create a sharing metadata XML file for folder sharing invitation, request and response
+            and store it as attachment in the sharing object.
+            See [MS-OXSHARE] for this kind of messages and [MS-OXSHRMSG] for the XML format.
+
+   \param emsmdbp_ctx pointer to the emsmdb provider context
+   \param sharing_object the original sharing message object to dump the XML data from
+
+   \return MAPI_E_SUCCESS on success, a MAPI error code otherwise
+ */
+_PUBLIC_ enum MAPISTATUS emsmdbp_object_attach_sharing_metadata_XML_file(struct emsmdbp_context *emsmdbp_ctx, struct emsmdbp_object *sharing_object)
+{
+	struct Binary_r		*attach_bin;
+	struct emsmdbp_object	*attach;
+	enum MAPISTATUS		*retvals = NULL;
+	enum MAPISTATUS		retval;
+	enum mapistore_error	ret;
+	struct SPropTagArray	*props;
+	struct SRow		aRow;
+	TALLOC_CTX		*mem_ctx;
+	uint32_t		contextID, aid;
+	void			**data_pointers;
+
+	/* Sanity checks */
+	OPENCHANGE_RETVAL_IF(!emsmdbp_ctx, MAPI_E_INVALID_PARAMETER, NULL);
+	OPENCHANGE_RETVAL_IF(!sharing_object, MAPI_E_INVALID_PARAMETER, NULL);
+
+	OPENCHANGE_RETVAL_IF(!emsmdbp_is_mapistore(sharing_object), MAPI_E_NO_SUPPORT, NULL);
+
+	mem_ctx = talloc_named(NULL, 0, "attach_sharing_metadata");
+	OPENCHANGE_RETVAL_IF(!mem_ctx, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
+
+	/* 1. Check if the message is a IPM.Sharing message */
+	props = talloc_zero(mem_ctx, struct SPropTagArray);
+	OPENCHANGE_RETVAL_IF(!props, MAPI_E_NOT_ENOUGH_MEMORY, mem_ctx);
+	props->cValues = 1;
+	props->aulPropTag = talloc_zero(props, enum MAPITAGS);
+	OPENCHANGE_RETVAL_IF(!props->aulPropTag, MAPI_E_NOT_ENOUGH_MEMORY, mem_ctx);
+	props->aulPropTag[0] = PidTagMessageClass;
+
+	data_pointers = emsmdbp_object_get_properties(mem_ctx, emsmdbp_ctx, sharing_object, props, &retvals);
+	OPENCHANGE_RETVAL_IF(!data_pointers || retvals[0] != MAPI_E_SUCCESS, MAPI_E_NOT_FOUND, mem_ctx);
+
+	if (strncmp((char *)data_pointers[0], "IPM.Sharing", strlen("IPM.Sharing")) != 0) {
+		talloc_free(mem_ctx);
+		/* No sharing object, then no problems */
+		return MAPI_E_SUCCESS;
+	}
+
+	/* 2. Create the attachment */
+	attach = emsmdbp_object_attachment_init(mem_ctx, emsmdbp_ctx, sharing_object->object.message->messageID, sharing_object);
+	OPENCHANGE_RETVAL_IF(!attach, MAPI_E_NOT_ENOUGH_MEMORY, mem_ctx);
+
+	contextID = emsmdbp_get_contextID(sharing_object);
+
+	ret = mapistore_message_create_attachment(emsmdbp_ctx->mstore_ctx, contextID, sharing_object->backend_object, attach, &attach->backend_object, &aid);
+	OPENCHANGE_RETVAL_IF((ret != MAPISTORE_SUCCESS), mapistore_error_to_mapi(ret), mem_ctx);
+
+	/* 3. Set properties to the attachment */
+	retval = emsmdbp_object_sharing_metadata_property(emsmdbp_ctx, sharing_object, &attach_bin, mem_ctx);
+	OPENCHANGE_RETVAL_IF((retval != MAPI_E_SUCCESS), retval, mem_ctx);
+
+	aRow.cValues = 3;
+	aRow.lpProps = talloc_array(mem_ctx, struct SPropValue, 3);
+	set_SPropValue_proptag(aRow.lpProps, PidTagAttachLongFilename, "sharing_metadata.xml");
+	set_SPropValue_proptag(aRow.lpProps + 1, PidTagAttachDataBinary, attach_bin);
+	set_SPropValue_proptag(aRow.lpProps + 2, PidTagAttachMimeTag, "application/x-sharing-metadata-xml");
+
+	ret = emsmdbp_object_set_properties(emsmdbp_ctx, attach, &aRow);
+	OPENCHANGE_RETVAL_IF(ret != MAPISTORE_SUCCESS, mapistore_error_to_mapi(ret), mem_ctx);
+
+	/* 4. Save the attachment */
+	/* TODO: Include this code once all available backends implement for attachment save */
+	/* ret = mapistore_attachment_save(emsmdbp_ctx->mstore_ctx, contextID, attach->backend_object, mem_ctx); */
+
+	talloc_free(mem_ctx);
+
+	return MAPI_E_SUCCESS;
+}

--- a/mapiproxy/servers/default/emsmdb/oxcfxics.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfxics.c
@@ -790,15 +790,15 @@ static void oxcfxics_table_set_cn_restriction(struct emsmdbp_context *emsmdbp_ct
 static bool oxcfxics_push_messageChange(struct emsmdbp_context *emsmdbp_ctx, struct emsmdbp_object_synccontext *synccontext, const char *owner, struct oxcfxics_sync_data *sync_data, struct emsmdbp_object *folder_object)
 {
 	TALLOC_CTX			*mem_ctx, *msg_ctx;
-	bool				folder_is_mapistore, end_of_table;
+	bool				folder_is_mapistore, end_of_table, changed_prop_index = false;
 	struct emsmdbp_object		*table_object, *message_object;
 	uint32_t			i;
 	static enum MAPITAGS		mid_property = PidTagMid;
-	enum MAPISTATUS			*retvals, *header_retvals;
+	enum MAPISTATUS			*retvals, *header_retvals, retval_msg_class = MAPI_E_NOT_FOUND;
 	void				**data_pointers, **header_data_pointers;
 	struct FILETIME			*lm_time;
 	NTTIME				nt_time;
-	uint32_t			unix_time, contextID;
+	uint32_t			unix_time, contextID, message_class_prop_index;
 	struct UI8Array_r		preload_mids;
 	enum mapistore_table_type	mstore_type;
 	struct SPropTagArray		query_props;
@@ -809,10 +809,11 @@ static bool oxcfxics_push_messageChange(struct emsmdbp_context *emsmdbp_ctx, str
 	struct GUID			replica_guid;
 	struct idset			*original_cnset_seen;
 	struct UI8Array_r		*deleted_eids;
-	struct SPropTagArray		*properties;
+	struct SPropTagArray		*msg_properties, *properties, *sharing_properties;
 	struct oxcfxics_message_sync_data	*message_sync_data;
 	struct SSortOrderSet		lpSortCriteria;
 	uint8_t				status;
+	struct oxcfxics_prop_index	msg_prop_index;
 
 	mem_ctx = talloc_zero(NULL, void);
 
@@ -826,6 +827,8 @@ static bool oxcfxics_push_messageChange(struct emsmdbp_context *emsmdbp_ctx, str
 		properties = &synccontext->properties;
 		mstore_type = MAPISTORE_MESSAGE_TABLE;
 	}
+
+	msg_prop_index = sync_data->prop_index;
 
 	if (sync_data->message_sync_data) {
 		message_sync_data = sync_data->message_sync_data;
@@ -889,9 +892,15 @@ static bool oxcfxics_push_messageChange(struct emsmdbp_context *emsmdbp_ctx, str
 		contextID = emsmdbp_get_contextID(folder_object);
 	}
 
+	/* find where PidTagMessageClass is located */
+	if (mstore_type == MAPISTORE_MESSAGE_TABLE) {
+		retval_msg_class = SPropTagArray_find(*properties, PidTagMessageClass, &message_class_prop_index);
+	}
+
 	/* open each message and fetch properties */
 	for (; sync_data->ndr->offset < max_message_sync_size && message_sync_data->count < message_sync_data->max; message_sync_data->count++) {
 		msg_ctx = talloc_new(NULL);
+		msg_properties = properties;
 
 		if (folder_is_mapistore && (message_sync_data->count % message_preload_interval) == 0) {
 			preload_mids.lpui8 = message_sync_data->mids + message_sync_data->count;
@@ -915,11 +924,39 @@ static bool oxcfxics_push_messageChange(struct emsmdbp_context *emsmdbp_ctx, str
 			goto end_row;
 		}
 
-		data_pointers = emsmdbp_object_get_properties(msg_ctx, emsmdbp_ctx, message_object, properties, &retvals);
+		data_pointers = emsmdbp_object_get_properties(msg_ctx, emsmdbp_ctx, message_object, msg_properties, &retvals);
 		if (!data_pointers) {
 			DEBUG(5, ("message '%.16"PRIx64"' returned no value, skipped\n", eid));
 			goto end_row;
 		}
+                /* Check if the message is a sharing object message to
+                   retrieve additional sharing properties for this
+                   message. This could be extensible and more
+                   generic in the future. */
+		if (retval_msg_class == MAPI_E_SUCCESS && retvals[message_class_prop_index] == MAPI_E_SUCCESS
+		    && strncmp((char *)data_pointers[message_class_prop_index], "IPM.Sharing", strlen("IPM.Sharing")) == 0) {
+			/* Get available properties from this specific message */
+			if (emsmdbp_object_get_available_properties(msg_ctx, emsmdbp_ctx, message_object,
+								    &sharing_properties) == MAPISTORE_SUCCESS) {
+				msg_properties = sharing_properties;
+				data_pointers = emsmdbp_object_get_properties(msg_ctx, emsmdbp_ctx,
+									      message_object, msg_properties, &retvals);
+				if (!data_pointers) {
+					DEBUG(5, ("message '%.16"PRIx64"' returned no value, skipped\n", eid));
+					goto end_row;
+				}
+				/* Update prop index for fixed header props */
+				changed_prop_index = true;
+				SPropTagArray_find(*msg_properties, PidTagMid, &msg_prop_index.eid);
+				SPropTagArray_find(*msg_properties, PidTagChangeNumber, &msg_prop_index.change_number);
+				SPropTagArray_find(*msg_properties, PidTagChangeKey, &msg_prop_index.change_key);
+				SPropTagArray_find(*msg_properties, PidTagPredecessorChangeList, &msg_prop_index.predecessor_change_list);
+				SPropTagArray_find(*msg_properties, PidTagLastModificationTime, &msg_prop_index.last_modification_time);
+				SPropTagArray_find(*msg_properties, PidTagAssociated, &msg_prop_index.associated);
+				SPropTagArray_find(*msg_properties, PidTagMessageSize, &msg_prop_index.message_size);
+			}
+		}
+
 
 		oxcfxics_ndr_check(sync_data->ndr, "sync_data->ndr");
 		oxcfxics_ndr_check(sync_data->cutmarks_ndr, "sync_data->cutmarks_ndr");
@@ -943,7 +980,7 @@ static bool oxcfxics_push_messageChange(struct emsmdbp_context *emsmdbp_ctx, str
 		i++;
 
 		/* last modification time */
-		if (retvals[sync_data->prop_index.last_modification_time]) {
+		if (retvals[msg_prop_index.last_modification_time]) {
 			unix_time = oc_version_time;
 			unix_to_nt_time(&nt_time, unix_time);
 			lm_time = talloc_zero(header_data_pointers, struct FILETIME);
@@ -951,7 +988,7 @@ static bool oxcfxics_push_messageChange(struct emsmdbp_context *emsmdbp_ctx, str
 			lm_time->dwHighDateTime = nt_time >> 32;
 		}
 		else {
-			lm_time = (struct FILETIME *) data_pointers[sync_data->prop_index.last_modification_time];
+			lm_time = (struct FILETIME *) data_pointers[msg_prop_index.last_modification_time];
 			nt_time = ((uint64_t) lm_time->dwHighDateTime << 32) | lm_time->dwLowDateTime;
 			unix_time = nt_time_to_unix(nt_time);
 		}
@@ -959,11 +996,11 @@ static bool oxcfxics_push_messageChange(struct emsmdbp_context *emsmdbp_ctx, str
 		header_data_pointers[i] = lm_time;
 		i++;
 
-		if (retvals[sync_data->prop_index.change_number]) {
+		if (retvals[msg_prop_index.change_number]) {
 			DEBUG(5, (__location__": mandatory property PidTagChangeNumber not returned for message\n"));
 			abort();
 		}
-		cn = ((*(uint64_t *) data_pointers[sync_data->prop_index.change_number]) >> 16) & 0x0000ffffffffffff;
+		cn = ((*(uint64_t *) data_pointers[msg_prop_index.change_number]) >> 16) & 0x0000ffffffffffff;
 		if (IDSET_includes_guid_glob(original_cnset_seen, &sync_data->replica_guid, cn)) {
 			synccontext->skipped_objects++;
 			DEBUG(5, (__location__": message changes: cn %.16"PRIx64" already present\n", cn));
@@ -974,18 +1011,18 @@ static bool oxcfxics_push_messageChange(struct emsmdbp_context *emsmdbp_ctx, str
 
 		/* change key */
 		/* bin_data = oxcfxics_make_gid(header_data_pointers, &sync_data->replica_guid, cn); */
-		if (retvals[sync_data->prop_index.change_key]) {
+		if (retvals[msg_prop_index.change_key]) {
 			DEBUG(5, (__location__": mandatory property PidTagChangeKey not returned for message\n"));
 			abort();
 		}
 		query_props.aulPropTag[i] = PidTagChangeKey;
-		bin_data = data_pointers[sync_data->prop_index.change_key];
+		bin_data = data_pointers[msg_prop_index.change_key];
 		header_data_pointers[i] = bin_data;
 		i++;
 
 		/* predecessor change list */
 		query_props.aulPropTag[i] = PidTagPredecessorChangeList;
-		if (retvals[sync_data->prop_index.predecessor_change_list]) {
+		if (retvals[msg_prop_index.predecessor_change_list]) {
 			DEBUG(5, (__location__": mandatory property PidTagPredecessorChangeList not returned for message\n"));
 			/* abort(); */
 
@@ -996,18 +1033,18 @@ static bool oxcfxics_push_messageChange(struct emsmdbp_context *emsmdbp_ctx, str
 			header_data_pointers[i] = &predecessors_data;
 		}
 		else {
-			bin_data = data_pointers[sync_data->prop_index.predecessor_change_list];
+			bin_data = data_pointers[msg_prop_index.predecessor_change_list];
 			header_data_pointers[i] = bin_data;
 		}
 		i++;
 
 		/* associated (could be based on table type ) */
 		query_props.aulPropTag[i] = PidTagAssociated;
-		if (retvals[sync_data->prop_index.associated]) {
+		if (retvals[msg_prop_index.associated]) {
 			header_data_pointers[i] = talloc_zero(header_data_pointers, uint8_t);
 		}
 		else {
-			header_data_pointers[i] = data_pointers[sync_data->prop_index.associated];
+			header_data_pointers[i] = data_pointers[msg_prop_index.associated];
 		}
 		i++;
 
@@ -1021,12 +1058,12 @@ static bool oxcfxics_push_messageChange(struct emsmdbp_context *emsmdbp_ctx, str
 		/* message size (conditional) */
 		if (synccontext->request.request_message_size) {
 			query_props.aulPropTag[i] = PidTagMessageSize;
-			header_data_pointers[i] = data_pointers[sync_data->prop_index.message_size];
-			if (retvals[sync_data->prop_index.parent_fid]) {
+			header_data_pointers[i] = data_pointers[msg_prop_index.message_size];
+			if (retvals[msg_prop_index.parent_fid]) {
 				header_data_pointers[i] = talloc_zero(header_data_pointers, uint32_t);
 			}
 			else {
-				header_data_pointers[i] = data_pointers[sync_data->prop_index.message_size];
+				header_data_pointers[i] = data_pointers[msg_prop_index.message_size];
 			}
 			i++;
 		}
@@ -1052,9 +1089,9 @@ static bool oxcfxics_push_messageChange(struct emsmdbp_context *emsmdbp_ctx, str
 		ndr_push_uint32(sync_data->cutmarks_ndr, NDR_SCALARS, sync_data->ndr->offset);
 
 		/* we shift the number of remaining properties to the amount of properties explicitly requested in RopSyncConfigure that were used above */
-		if (properties->cValues > message_properties_shift) {
-			query_props.cValues = properties->cValues - message_properties_shift;
-			query_props.aulPropTag = properties->aulPropTag + message_properties_shift;
+		if (msg_properties->cValues > message_properties_shift) {
+			query_props.cValues = msg_properties->cValues - message_properties_shift;
+			query_props.aulPropTag = msg_properties->aulPropTag + message_properties_shift;
 			oxcfxics_ndr_push_properties(sync_data->ndr, sync_data->cutmarks_ndr, emsmdbp_ctx->mstore_ctx->nprops_ctx, &query_props, data_pointers + message_properties_shift, (enum MAPISTATUS *) retvals + message_properties_shift);
 		}
 
@@ -1067,6 +1104,10 @@ static bool oxcfxics_push_messageChange(struct emsmdbp_context *emsmdbp_ctx, str
 		oxcfxics_push_messageChange_attachments(emsmdbp_ctx, synccontext, sync_data, message_object);
 
 		synccontext->sent_objects++;
+		if (changed_prop_index) {
+			msg_prop_index = sync_data->prop_index;
+			changed_prop_index = false;
+		}
 	end_row:
 		talloc_free(msg_ctx);
 	}

--- a/mapiproxy/servers/default/emsmdb/oxomsg.c
+++ b/mapiproxy/servers/default/emsmdb/oxomsg.c
@@ -422,6 +422,10 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopTransportSend(TALLOC_CTX *mem_ctx,
 		DEBUG(0, ("Not implemented yet - shouldn't occur\n"));
 		break;
 	case true:
+		retval = emsmdbp_object_attach_sharing_metadata_XML_file(emsmdbp_ctx, object);
+		if (retval != MAPI_E_SUCCESS) {
+			DEBUG(0, ("Failing to create sharing metadata for a sharing object: %s\n", mapi_get_errstr(retval)));
+		}
 		mapistore_message_submit(emsmdbp_ctx->mstore_ctx, emsmdbp_get_contextID(object), object->backend_object, 0);
 
 		oxomsg_mapistore_handle_message_relocation(emsmdbp_ctx, object);


### PR DESCRIPTION
Furthermore, a shared root folder properties managed by OpenChange DB can be read on behalf of other users.

It creates a XML attachment on RopTransportSend following [MS-OXSHRMSG] spec
for the format by reading Sharing Object properties defined in [MS-OXSHARE]
when the class of the message is "IPM.Sharing".

It sends to the mapistore backend, the three relevant properties for the attachment:

  * The long filename
  * The binary data (XML string in UTF8)
  * The MIME tag

In addition to this, it asks to the mapistore backend the additional sharing properties on cached mode when the message has `IPM.Sharing` as `PidTagMessageClass`.