### PR TITLE
mapiproxy: do not release samdb connection

### DIFF
--- a/mapiproxy/servers/default/emsmdb/emsmdbp.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp.c
@@ -137,9 +137,9 @@ _PUBLIC_ struct emsmdbp_context *emsmdbp_init(struct loadparm_context *lp_ctx,
 
 		/* return an opaque context pointer on samDB database */
 		if (!samdb_url) {
-			samdb_ctx = samdb_connect(mem_ctx, ev, lp_ctx, system_session(lp_ctx), 0);
+			samdb_ctx = samdb_connect(talloc_autofree_context(), ev, lp_ctx, system_session(lp_ctx), 0);
 		} else {
-			samdb_ctx = samdb_connect_url(mem_ctx, ev, lp_ctx, system_session(lp_ctx), LDB_FLG_RECONNECT, samdb_url);
+			samdb_ctx = samdb_connect_url(talloc_autofree_context(), ev, lp_ctx, system_session(lp_ctx), LDB_FLG_RECONNECT, samdb_url);
 		}
 	}
 

--- a/mapiproxy/servers/default/nspi/emsabp.c
+++ b/mapiproxy/servers/default/nspi/emsabp.c
@@ -87,9 +87,9 @@ _PUBLIC_ struct emsabp_context *emsabp_init(struct loadparm_context *lp_ctx,
 
 		/* return an opaque context pointer on samDB database */
 		if (!samdb_url) {
-			samdb_ctx = samdb_connect(mem_ctx, ev, lp_ctx, system_session(lp_ctx), 0);
+			samdb_ctx = samdb_connect(talloc_autofree_context(), ev, lp_ctx, system_session(lp_ctx), 0);
 		} else {
-			samdb_ctx = samdb_connect_url(mem_ctx, ev, lp_ctx, system_session(lp_ctx), LDB_FLG_RECONNECT, samdb_url);
+			samdb_ctx = samdb_connect_url(talloc_autofree_context(), ev, lp_ctx, system_session(lp_ctx), LDB_FLG_RECONNECT, samdb_url);
 		}
 	}
 


### PR DESCRIPTION
Fix ad02428d3b504380e6ddb90df242e1ff537048ca where samdb connections were changed to have only one. We cannot use the memory context of the emsmdb/nspi session but use a global one so they won't be released until the end.