### PR TITLE
mapiproxy: do not release samdb connection, tevent

### DIFF
--- a/mapiproxy/servers/default/emsmdb/emsmdbp.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp.c
@@ -121,17 +121,17 @@ _PUBLIC_ struct emsmdbp_context *emsmdbp_init(struct loadparm_context *lp_ctx,
 
 	emsmdbp_ctx->mem_ctx = mem_ctx;
 
-	ev = tevent_context_init(mem_ctx);
-	if (!ev) {
-		talloc_free(mem_ctx);
-		return NULL;
-	}
-	tevent_loop_allow_nesting(ev); 
-
 	/* Save a pointer to the loadparm context */
 	emsmdbp_ctx->lp_ctx = lp_ctx;
 
 	if (!samdb_ctx) {
+		ev = tevent_context_init(talloc_autofree_context());
+		if (!ev) {
+			talloc_free(mem_ctx);
+			return NULL;
+		}
+		tevent_loop_allow_nesting(ev);
+
 		/* Retrieve samdb url (local or external) */
 		samdb_url = lpcfg_parm_string(lp_ctx, NULL, "dcerpc_mapiproxy", "samdb_url");
 

--- a/mapiproxy/servers/default/emsmdb/emsmdbp.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp.c
@@ -29,6 +29,7 @@
 #include "mapiproxy/dcesrv_mapiproxy.h"
 #include "dcesrv_exchange_emsmdb.h"
 #include "mapiproxy/libmapiserver/libmapiserver.h"
+#include "mapiproxy/libmapiproxy/fault_util.h"
 
 #include <ldap_ndr.h>
 
@@ -49,6 +50,41 @@ static struct GUID MagicGUID = {
 	.node = { 0xde, 0xad, 0xfa, 0xce, 0xca, 0xfe }
 };
 const struct GUID *const MagicGUIDp = &MagicGUID;
+
+/**
+   \details Initialize ldb_context to samdb, creates one for all emsmdbp
+   contexts
+
+   \param lp_ctx pointer to the loadparm context
+ */
+static struct ldb_context *samdb_init(struct loadparm_context *lp_ctx)
+{
+	TALLOC_CTX		*mem_ctx;
+	struct tevent_context	*ev;
+	const char		*samdb_url;
+
+	if (samdb_ctx) return samdb_ctx;
+
+	mem_ctx = talloc_autofree_context();
+	ev = tevent_context_init(mem_ctx);
+	if (!ev) {
+		OC_PANIC(false, ("Fail to initialize tevent_context\n"));
+		return NULL;
+	}
+	tevent_loop_allow_nesting(ev);
+
+	/* Retrieve samdb url (local or external) */
+	samdb_url = lpcfg_parm_string(lp_ctx, NULL, "dcerpc_mapiproxy", "samdb_url");
+
+	if (!samdb_url) {
+		samdb_ctx = samdb_connect(mem_ctx, ev, lp_ctx, system_session(lp_ctx), 0);
+	} else {
+		samdb_ctx = samdb_connect_url(mem_ctx, ev, lp_ctx, system_session(lp_ctx),
+					      LDB_FLG_RECONNECT, samdb_url);
+	}
+
+	return samdb_ctx;
+}
 
 /**
    \details Release the MAPISTORE context used by EMSMDB provider
@@ -94,7 +130,7 @@ static int emsmdbp_mapi_handles_destructor(void *data)
    \param lp_ctx pointer to the loadparm_context
    \param username account name for current session
    \param ldb_ctx pointer to the openchange dispatcher ldb database
-   
+
    \return Allocated emsmdbp_context pointer on success, otherwise
    NULL
  */
@@ -104,9 +140,7 @@ _PUBLIC_ struct emsmdbp_context *emsmdbp_init(struct loadparm_context *lp_ctx,
 {
 	TALLOC_CTX		*mem_ctx;
 	struct emsmdbp_context	*emsmdbp_ctx;
-	struct tevent_context	*ev;
 	enum mapistore_error	ret;
-	const char		*samdb_url;
 
 	/* Sanity Checks */
 	if (!lp_ctx) return NULL;
@@ -124,26 +158,7 @@ _PUBLIC_ struct emsmdbp_context *emsmdbp_init(struct loadparm_context *lp_ctx,
 	/* Save a pointer to the loadparm context */
 	emsmdbp_ctx->lp_ctx = lp_ctx;
 
-	if (!samdb_ctx) {
-		ev = tevent_context_init(talloc_autofree_context());
-		if (!ev) {
-			talloc_free(mem_ctx);
-			return NULL;
-		}
-		tevent_loop_allow_nesting(ev);
-
-		/* Retrieve samdb url (local or external) */
-		samdb_url = lpcfg_parm_string(lp_ctx, NULL, "dcerpc_mapiproxy", "samdb_url");
-
-		/* return an opaque context pointer on samDB database */
-		if (!samdb_url) {
-			samdb_ctx = samdb_connect(talloc_autofree_context(), ev, lp_ctx, system_session(lp_ctx), 0);
-		} else {
-			samdb_ctx = samdb_connect_url(talloc_autofree_context(), ev, lp_ctx, system_session(lp_ctx), LDB_FLG_RECONNECT, samdb_url);
-		}
-	}
-
-	emsmdbp_ctx->samdb_ctx = samdb_ctx;
+	emsmdbp_ctx->samdb_ctx = samdb_init(lp_ctx);
 	if (!emsmdbp_ctx->samdb_ctx) {
 		talloc_free(mem_ctx);
 		DEBUG(0, ("[%s:%d]: Connection to \"sam.ldb\" failed\n", __FUNCTION__, __LINE__));
@@ -157,7 +172,6 @@ _PUBLIC_ struct emsmdbp_context *emsmdbp_init(struct loadparm_context *lp_ctx,
 	emsmdbp_ctx->mstore_ctx = mapistore_init(mem_ctx, lp_ctx, NULL);
 	if (!emsmdbp_ctx->mstore_ctx) {
 		DEBUG(0, ("[%s:%d]: MAPISTORE initialization failed\n", __FUNCTION__, __LINE__));
-
 		talloc_free(mem_ctx);
 		return NULL;
 	}

--- a/mapiproxy/servers/default/nspi/emsabp.c
+++ b/mapiproxy/servers/default/nspi/emsabp.c
@@ -42,6 +42,41 @@ struct ldb_context *samdb_connect(TALLOC_CTX *, struct tevent_context *,
 static struct ldb_context *samdb_ctx = NULL;
 
 /**
+   \details Initialize ldb_context to samdb, creates one for all emsabp
+   contexts
+
+   \param lp_ctx pointer to the loadparm context
+ */
+static struct ldb_context *samdb_init(struct loadparm_context *lp_ctx)
+{
+	TALLOC_CTX		*mem_ctx;
+	struct tevent_context	*ev;
+	const char		*samdb_url;
+
+	if (samdb_ctx) return samdb_ctx;
+
+	mem_ctx = talloc_autofree_context();
+	ev = tevent_context_init(mem_ctx);
+	if (!ev) {
+		OC_PANIC(false, ("Fail to initialize tevent_context\n"));
+		return NULL;
+	}
+	tevent_loop_allow_nesting(ev);
+
+	/* Retrieve samdb url (local or external) */
+	samdb_url = lpcfg_parm_string(lp_ctx, NULL, "dcerpc_mapiproxy", "samdb_url");
+
+	if (!samdb_url) {
+		samdb_ctx = samdb_connect(mem_ctx, ev, lp_ctx, system_session(lp_ctx), 0);
+	} else {
+		samdb_ctx = samdb_connect_url(mem_ctx, ev, lp_ctx, system_session(lp_ctx),
+					      LDB_FLG_RECONNECT, samdb_url);
+	}
+
+	return samdb_ctx;
+}
+
+/**
    \details Initialize the EMSABP context and open connections to
    Samba databases.
 
@@ -55,14 +90,12 @@ _PUBLIC_ struct emsabp_context *emsabp_init(struct loadparm_context *lp_ctx,
 {
 	TALLOC_CTX		*mem_ctx;
 	struct emsabp_context	*emsabp_ctx;
-	struct tevent_context	*ev;
-	const char		*samdb_url;
 
 	/* Sanity checks */
 	if (!lp_ctx) return NULL;
 
 	mem_ctx = talloc_named(NULL, 0, "emsabp_init");
-	
+
 	emsabp_ctx = talloc_zero(mem_ctx, struct emsabp_context);
 	if (!emsabp_ctx) {
 		talloc_free(mem_ctx);
@@ -74,29 +107,10 @@ _PUBLIC_ struct emsabp_context *emsabp_init(struct loadparm_context *lp_ctx,
 	/* Save a pointer to the loadparm context */
 	emsabp_ctx->lp_ctx = lp_ctx;
 
-	if (!samdb_ctx) {
-		ev = tevent_context_init(talloc_autofree_context());
-		if (!ev) {
-			talloc_free(mem_ctx);
-			return NULL;
-		}
-		tevent_loop_allow_nesting(ev);
-
-		/* Retrieve samdb url (local or external) */
-		samdb_url = lpcfg_parm_string(lp_ctx, NULL, "dcerpc_mapiproxy", "samdb_url");
-
-		/* return an opaque context pointer on samDB database */
-		if (!samdb_url) {
-			samdb_ctx = samdb_connect(talloc_autofree_context(), ev, lp_ctx, system_session(lp_ctx), 0);
-		} else {
-			samdb_ctx = samdb_connect_url(talloc_autofree_context(), ev, lp_ctx, system_session(lp_ctx), LDB_FLG_RECONNECT, samdb_url);
-		}
-	}
-
-	emsabp_ctx->samdb_ctx = samdb_ctx;
+	emsabp_ctx->samdb_ctx = samdb_init(lp_ctx);
 	if (!emsabp_ctx->samdb_ctx) {
 		talloc_free(mem_ctx);
-		DEBUG(0, ("[%s:%d]: Connection to \"sam.ldb\" failed\n", __FUNCTION__, __LINE__));
+		DEBUG(0, ("[nspi] Connection to \"sam.ldb\" failed\n"));
 		return NULL;
 	}
 
@@ -107,6 +121,7 @@ _PUBLIC_ struct emsabp_context *emsabp_init(struct loadparm_context *lp_ctx,
 	 * temporary MId used within EMSABP */
 	emsabp_ctx->ttdb_ctx = emsabp_tdb_init_tmp(emsabp_ctx->mem_ctx);
 	if (!emsabp_ctx->ttdb_ctx) {
+		talloc_free(mem_ctx);
 		OC_PANIC(false , ("[nspi] Unable to create on-memory TDB database\n"));
 		return NULL;
 	}

--- a/mapiproxy/servers/default/nspi/emsabp.c
+++ b/mapiproxy/servers/default/nspi/emsabp.c
@@ -71,17 +71,17 @@ _PUBLIC_ struct emsabp_context *emsabp_init(struct loadparm_context *lp_ctx,
 
 	emsabp_ctx->mem_ctx = mem_ctx;
 
-	ev = tevent_context_init(mem_ctx);
-	if (!ev) {
-		talloc_free(mem_ctx);
-		return NULL;
-	}
-	tevent_loop_allow_nesting(ev);
-
 	/* Save a pointer to the loadparm context */
 	emsabp_ctx->lp_ctx = lp_ctx;
 
 	if (!samdb_ctx) {
+		ev = tevent_context_init(talloc_autofree_context());
+		if (!ev) {
+			talloc_free(mem_ctx);
+			return NULL;
+		}
+		tevent_loop_allow_nesting(ev);
+
 		/* Retrieve samdb url (local or external) */
 		samdb_url = lpcfg_parm_string(lp_ctx, NULL, "dcerpc_mapiproxy", "samdb_url");
 


### PR DESCRIPTION
Fixes 9519a9e227dae8d1de70705313c5a72517c99574 tevent needs also to have the global autofree memory context