### PR TITLE
nspi: Added missing call in dcesrv_NspiUpdateStat PR#208

### DIFF
--- a/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
+++ b/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
@@ -362,6 +362,7 @@ static void dcesrv_NspiUpdateStat(struct dcesrv_call_state *dce_call, TALLOC_CTX
 
 	DCESRV_NSP_RETURN_IF(r->in.pStat->CodePage == CP_UNICODE, r, MAPI_E_NO_SUPPORT, NULL);
 
+	emsabp_ctx = dcesrv_find_emsabp_context(&r->in.handle->uuid);
 	DCESRV_NSP_RETURN_IF(!emsabp_ctx, r, MAPI_E_CALL_FAILED, NULL);
 
 	if (r->in.pStat->ContainerID) {


### PR DESCRIPTION
I lost this method call in the refactoring of #208  . Also this path is not taken if you not select a filter in the addresses dialog display so i not detected it in the smoke test.