### PR TITLE
openchange_user_cleanup: clean memcached

### DIFF
--- a/mapiproxy/libmapistore/backends/indexing_mysql.c
+++ b/mapiproxy/libmapistore/backends/indexing_mysql.c
@@ -602,9 +602,9 @@ static enum mapistore_error mysql_record_del(struct indexing_context *ictx,
 	}
 
 	retval = mysql_record_get_uri(ictx, username, mem_ctx, fmid, &uri, &IsSoftDeleted);
-	MAPISTORE_RETVAL_IF(retval, retval, mem_ctx);
+	MAPISTORE_RETVAL_IF(retval != MAPISTORE_SUCCESS, retval, mem_ctx);
 
-	execute_query(MYSQL(ictx), sql);
+	ret = execute_query(MYSQL(ictx), sql);
 	MAPISTORE_RETVAL_IF(ret != MYSQL_SUCCESS, MAPISTORE_ERR_DATABASE_OPS, mem_ctx);
 
 	retval = _memcached_delete_record(ictx, uri);


### PR DESCRIPTION
It removes all keys from memcached (including no openchange values).

It could be done better (deleting only the user specific keys) but it'd need an implementation of `ccan/hash.c`. This script won't be executed frequently and memcached is a cache (O RLY?) so it doesn't hurt.