### PR TITLE
Sharing request and invitation for other types of folders

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,8 +7,7 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 ## [Unreleased]
 
 ### Added
-* Calendar sharing request among different Outlook versions
-* Calendar sharing invitation among different Outlook versions
+* Sharing request and invitation of folders among different Outlook versions
 
 ### Fixes
 * Fixed `Too many connections to ldap` when openchange runs on samba as member of a domain.


### PR DESCRIPTION
Using PidLidSharingLocalType property.

Not available in any spec but tested empirically.

It requires #244 to work.