### PR TITLE
nspi: QueryRows now can accept a NumPos bigger or equal to table size.

### DIFF
--- a/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
+++ b/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
@@ -449,7 +449,7 @@ static void dcesrv_NspiQueryRows(struct dcesrv_call_state *dce_call,
 			goto failure;
 		}
 
-		if (r->in.pStat->Delta >= 0) {
+		if (r->in.pStat->Delta >= 0 && r->in.pStat->NumPos < ldb_res->count) {
 			start_pos = r->in.pStat->NumPos + r->in.pStat->Delta;
 			if (start_pos != 0 && start_pos >= ldb_res->count) {
 				/* inexistent position */


### PR DESCRIPTION
This is necessary because Outlook 2010 sometime send a NSPI QueryRow where
the initial position is after the end of the table. For example,
using the search in the GAL.
If I interpret the requested delta as going backwards, the client behavior
is fine so I suspect in a sign error in the client side.