### PR TITLE
Remove ncacn_np from OpenChange DCE/RPC endpoints.

### DIFF
--- a/exchange.idl
+++ b/exchange.idl
@@ -41,7 +41,7 @@ cpp_quote("#include <gen_ndr/ndr_misc.h>")
 
 [
   uuid("1544f5e0-613c-11d1-93df-00c04fd7bd09"),
-  endpoint("ncacn_np:[\\pipe\\lsass]","ncacn_np:[\\pipe\\protected_storage]","ncacn_ip_tcp:[]"),
+  endpoint("ncacn_ip_tcp:"),
   authservice("exchangeRFR"),
   pointer_default(unique),
   version(1.0),
@@ -180,7 +180,7 @@ System Attendant Private Interface
 
 [
   uuid("f5cc5a18-4264-101a-8c59-08002b2f8426"),
-  endpoint("ncacn_np:[\\pipe\\lsass]","ncacn_np:[\\pipe\\protected_storage]","ncacn_ip_tcp:[]"),
+  endpoint("ncacn_ip_tcp:"),
   authservice("exchangeAB"),
   pointer_default(unique),
   version(56.0),
@@ -765,7 +765,7 @@ System Attendant Private Interface
 [
   uuid("a4f1db00-ca47-1067-b31f-00dd010662da"),
   pointer_default(unique),
-  endpoint("ncacn_np:[\\pipe\\lsass]","ncacn_np:[\\pipe\\protected_storage]","ncacn_ip_tcp:"),
+  endpoint("ncacn_ip_tcp:"),
   authservice("exchangeMDB"),
   //version(0.81),
   version(5308416),


### PR DESCRIPTION
Windows doesn't make these interfaces available over ncacn_np either,
and this will make it significantly easier to create a standalone openchange daemon.