### PR TITLE
provision: Make dns_onwner comparation case insensitive

### DIFF
--- a/python/openchange/provision.py
+++ b/python/openchange/provision.py
@@ -560,7 +560,7 @@ def get_schema_master(db):
 def get_dns_owner(db, ntds_owner):
     res = db.search(base=ntds_owner, scope=ldb.SCOPE_BASE, attrs=["dnsHostname"])
     dns_hostname = res[0]['dnsHostname'][0]
-    return dns_hostname
+    return dns_hostname.lower()
 
 
 def get_schema_master_samdb(names, lp, creds):
@@ -568,6 +568,7 @@ def get_schema_master_samdb(names, lp, creds):
     ntds_owner = get_schema_master(local_db)
     dns_owner = get_dns_owner(local_db, ntds_owner)
     fqdn = names.hostname + '.' + names.dnsdomain
+    fqdn = fqdn.lower()
     if dns_owner == fqdn:
         return local_db
 


### PR DESCRIPTION
The provision process compares the dns_owner with the fqdn to check
if the directory is local or resides in another controller.
Since the check is with DNS names it should be case insensitive.