### PR TITLE
Third iteration of the asynchronous emsmdb endpoint service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1212,7 +1212,7 @@ bin/mapiprofile: 	utils/mapiprofile.o 			\
 # rpcextract
 ###################
 
-ocnotify: bin/ocnotify
+ocnotify: libmapistore bin/ocnotify
 
 ocnotify-install: ocnotify
 	$(INSTALL) -d $(DESTDIR)$(bindir)

--- a/mapiproxy/libmapistore/mapistore.h
+++ b/mapiproxy/libmapistore/mapistore.h
@@ -426,6 +426,11 @@ enum mapistore_error mapistore_notification_resolver_exist(struct mapistore_cont
 enum mapistore_error mapistore_notification_resolver_get(TALLOC_CTX *, struct mapistore_context *, const char *, uint32_t *, const char ***);
 enum mapistore_error mapistore_notification_resolver_delete(struct mapistore_context *, const char *, const char *);
 
+enum mapistore_error mapistore_notification_subscription_add(struct mapistore_context *, struct GUID, uint32_t, uint16_t, uint64_t, uint64_t, uint32_t, enum MAPITAGS *);
+enum mapistore_error mapistore_notification_subscription_exist(struct mapistore_context *, struct GUID);
+enum mapistore_error mapistore_notification_subscription_delete(struct mapistore_context *, struct GUID);
+enum mapistore_error mapistore_notification_subscription_delete_by_handle(struct mapistore_context *, struct GUID, uint32_t);
+
 __END_DECLS
 
 #endif	/* ! __MAPISTORE_H */

--- a/mapiproxy/libmapistore/mapistore.h
+++ b/mapiproxy/libmapistore/mapistore.h
@@ -431,6 +431,11 @@ enum mapistore_error mapistore_notification_subscription_exist(struct mapistore_
 enum mapistore_error mapistore_notification_subscription_delete(struct mapistore_context *, struct GUID);
 enum mapistore_error mapistore_notification_subscription_delete_by_handle(struct mapistore_context *, struct GUID, uint32_t);
 
+enum mapistore_error mapistore_notification_deliver_add(struct mapistore_context *, struct GUID, uint8_t *, size_t);
+enum mapistore_error mapistore_notification_deliver_exist(struct mapistore_context *, struct GUID);
+enum mapistore_error mapistore_notification_deliver_get(TALLOC_CTX *, struct mapistore_context *, struct GUID, uint8_t **, size_t *);
+enum mapistore_error mapistore_notification_deliver_delete(struct mapistore_context *, struct GUID);
+
 enum mapistore_error mapistore_notification_payload_newmail(TALLOC_CTX *, char *, uint8_t **, size_t *);
 
 __END_DECLS

--- a/mapiproxy/libmapistore/mapistore.h
+++ b/mapiproxy/libmapistore/mapistore.h
@@ -431,6 +431,8 @@ enum mapistore_error mapistore_notification_subscription_exist(struct mapistore_
 enum mapistore_error mapistore_notification_subscription_delete(struct mapistore_context *, struct GUID);
 enum mapistore_error mapistore_notification_subscription_delete_by_handle(struct mapistore_context *, struct GUID, uint32_t);
 
+enum mapistore_error mapistore_notification_payload_newmail(TALLOC_CTX *, char *, uint8_t **, size_t *);
+
 __END_DECLS
 
 #endif	/* ! __MAPISTORE_H */

--- a/mapiproxy/libmapistore/mapistore_notification.c
+++ b/mapiproxy/libmapistore/mapistore_notification.c
@@ -345,7 +345,9 @@ _PUBLIC_ enum mapistore_error mapistore_notification_session_get(TALLOC_CTX *mem
 	MAPISTORE_RETVAL_IF(!value, ret_to_mapistore(rc), local_mem_ctx);
 
 	/* Unpack session structure */
-	blob.data = (uint8_t *) value;
+	blob.data = talloc_memdup(local_mem_ctx, (uint8_t *) value, value_len);
+	free(value);
+	MAPISTORE_RETVAL_IF(!blob.data, MAPISTORE_ERR_NO_MEMORY, local_mem_ctx);
 	blob.length = value_len;
 
 	ndr = ndr_pull_init_blob(&blob, local_mem_ctx);
@@ -563,7 +565,9 @@ _PUBLIC_ enum mapistore_error mapistore_notification_resolver_get(TALLOC_CTX *me
 	MAPISTORE_RETVAL_IF(!value, ret_to_mapistore(rc), local_mem_ctx);
 
 	/* Unpack resolver structure */
-	blob.data = (uint8_t *) value;
+	blob.data = talloc_memdup(local_mem_ctx, (uint8_t *) value, value_len);
+	free(value);
+	MAPISTORE_RETVAL_IF(!blob.data, MAPISTORE_ERR_NO_MEMORY, local_mem_ctx);
 	blob.length = value_len;
 
 	ndr = ndr_pull_init_blob(&blob, local_mem_ctx);
@@ -797,7 +801,9 @@ enum mapistore_error mapistore_notification_subscription_get(TALLOC_CTX *mem_ctx
 	MAPISTORE_RETVAL_IF(!value, ret_to_mapistore(rc), local_mem_ctx);
 
 	/* Unpack subscription structure */
-	blob.data = (uint8_t *) value;
+	blob.data = talloc_memdup(local_mem_ctx, (uint8_t *) value, value_len);
+	free(value);
+	MAPISTORE_RETVAL_IF(!blob.data, MAPISTORE_ERR_NO_MEMORY, local_mem_ctx);
 	blob.length = value_len;
 
 	ndr = ndr_pull_init_blob(&blob, mem_ctx);

--- a/mapiproxy/libmapistore/mapistore_notification.c
+++ b/mapiproxy/libmapistore/mapistore_notification.c
@@ -724,7 +724,7 @@ _PUBLIC_ enum mapistore_error mapistore_notification_resolver_exist(struct mapis
 
    \param mem_ctx pointer to the memory context
    \param uuid the uuid of the session to compute
-   \param pointer on pointer to the key to return
+   \param _key pointer on pointer to the key to return
 
    \note the caller is responsible for freeing _key
 

--- a/mapiproxy/libmapistore/mapistore_notification.c
+++ b/mapiproxy/libmapistore/mapistore_notification.c
@@ -1302,6 +1302,7 @@ _PUBLIC_ enum mapistore_error mapistore_notification_deliver_delete(struct mapis
 	return MAPISTORE_SUCCESS;
 }
 
+/**
    \details Generate a newmail notification payload to be consumed by
    the service referenced by resolver entries.
 

--- a/mapiproxy/libmapistore/mapistore_notification.h
+++ b/mapiproxy/libmapistore/mapistore_notification.h
@@ -33,5 +33,6 @@
 #define	MSTORE_MEMC_FMT_SESSION	"session:%s"
 #define	MSTORE_MEMC_FMT_RESOLVER "resolver:%s"
 #define	MSTORE_MEMC_FMT_SUBSCRIPTION "subscription:%s"
+#define	MSTORE_MEMC_FMT_DELIVER "deliver:%s"
 
 #endif /* MAPISTORE_NOTIFICATION_H */

--- a/mapiproxy/libmapistore/mapistore_notification.h
+++ b/mapiproxy/libmapistore/mapistore_notification.h
@@ -32,5 +32,6 @@
 /* Define format strings used for key storage in memcached */
 #define	MSTORE_MEMC_FMT_SESSION	"session:%s"
 #define	MSTORE_MEMC_FMT_RESOLVER "resolver:%s"
+#define	MSTORE_MEMC_FMT_SUBSCRIPTION "subscription:%s"
 
 #endif /* MAPISTORE_NOTIFICATION_H */

--- a/mapiproxy/libmapistore/mapistore_notification.idl
+++ b/mapiproxy/libmapistore/mapistore_notification.idl
@@ -71,4 +71,42 @@ interface mapistore_notification
 		[switch_is(vnum)] resolver_ver	v;
 	} mapistore_notification_resolver;
 
+
+	/* subscriptions */
+	typedef [public,bitmap16bit] bitmap {
+		sub_WholeStore		= 0x0001,
+		sub_NewMail		= 0x0002,
+		sub_ObjectCreated	= 0x0004,
+		sub_ObjectDeleted	= 0x0008,
+		sub_ObjectModified	= 0x0010,
+		sub_ObjectMoved		= 0x0020,
+		sub_ObjectCopied	= 0x0040,
+		sub_SearchCompleted	= 0x0080,
+		sub_TableModified	= 0x0100,
+		sub_Reserved		= 0x0400
+	} sub_NotificationFlags;
+
+	typedef [public, flag(LIBNDR_FLAG_NOALIGN)] struct {
+		uint32			handle;
+		sub_NotificationFlags	flags;
+		hyper			fid;
+		hyper			mid;
+		uint16			count;
+		uint32			properties[count];
+	} subscription_object_v1;
+
+	typedef [public, flag(LIBNDR_FLAG_NOALIGN)] struct {
+		[range(0, 100)] uint32				count;
+		[size_is(count)] subscription_object_v1		subscription[];
+	} subscription_v1;
+
+	typedef [public, flag(LIBNDR_FLAG_NOALIGN), nodiscriminant] union {
+		[case(MAPISTORE_NOTIFICATION_V1)] subscription_v1 v1;
+		[default];
+	} subscription_ver;
+
+	typedef [public, flag(LIBNDR_FLAG_NOALIGN)] struct {
+		interface_vnum				vnum;
+		[switch_is(vnum)] subscription_ver	v;
+	} mapistore_notification_subscription;
 }

--- a/mapiproxy/libmapistore/mapistore_notification.idl
+++ b/mapiproxy/libmapistore/mapistore_notification.idl
@@ -109,4 +109,28 @@ interface mapistore_notification
 		interface_vnum				vnum;
 		[switch_is(vnum)] subscription_ver	v;
 	} mapistore_notification_subscription;
+
+	/* External notifications */
+	typedef [public, flag(LIBNDR_FLAG_NOALIGN)] struct {
+		[flag(LIBNDR_FLAG_STR_ASCII|LIBNDR_FLAG_STR_NULLTERM)] string eml;
+	} newmail_v1;
+
+	typedef [public, flag(LIBNDR_FLAG_NOALIGN), nodiscriminant] union {
+		[case(sub_NewMail)] newmail_v1		newmail;
+		[default];
+	} notification_data_v1;
+
+	typedef [public, flag(LIBNDR_FLAG_NOALIGN)] struct {
+		sub_NotificationFlags			flags;
+		[switch_is(flags)] notification_data_v1	u;
+	} notification_v1;
+
+	typedef [public, flag(LIBNDR_FLAG_NOALIGN), nodiscriminant] union {
+		[case(MAPISTORE_NOTIFICATION_V1)] notification_v1 v1;
+	} notification_ver;
+
+	typedef [public, flag(LIBNDR_FLAG_NOALIGN)] struct {
+		interface_vnum				vnum;
+		[switch_is(vnum)] notification_ver	v;
+	} mapistore_notification;
 }

--- a/mapiproxy/libmapistore/mapistore_notification.idl
+++ b/mapiproxy/libmapistore/mapistore_notification.idl
@@ -127,6 +127,7 @@ interface mapistore_notification
 
 	typedef [public, flag(LIBNDR_FLAG_NOALIGN), nodiscriminant] union {
 		[case(MAPISTORE_NOTIFICATION_V1)] notification_v1 v1;
+		[default];
 	} notification_ver;
 
 	typedef [public, flag(LIBNDR_FLAG_NOALIGN)] struct {

--- a/mapiproxy/libmapistore/mapistore_private.h
+++ b/mapiproxy/libmapistore/mapistore_private.h
@@ -25,6 +25,7 @@
 #include <talloc.h>
 #include "backends/namedprops_backend.h"
 #include "utils/dlinklist.h"
+#include "mapiproxy/libmapistore/gen_ndr/mapistore_notification.h"
 
 #ifndef	ISDOT
 #define ISDOT(path) ( \
@@ -194,6 +195,7 @@ enum mapistore_error mapistore_indexing_record_del_fmid(struct mapistore_context
 
 /* definitions from mapistore_notification.c */
 enum mapistore_error mapistore_notification_init(TALLOC_CTX *, struct loadparm_context *, struct mapistore_notification_context **);
+enum mapistore_error mapistore_notification_subscription_get(TALLOC_CTX *, struct mapistore_context *, struct GUID, struct mapistore_notification_subscription *);
 
 __END_DECLS
 

--- a/mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.h
+++ b/mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.h
@@ -28,6 +28,7 @@
 
 #include "mapiproxy/libmapistore/mapistore.h"
 #include "mapiproxy/libmapistore/mapistore_errors.h"
+#include "mapiproxy/libmapistore/gen_ndr/mapistore_notification.h"
 
 #include <nanomsg/nn.h>
 #include <nanomsg/pipeline.h>
@@ -37,6 +38,7 @@ struct asyncemsmdb_private_data {
 	struct EcDoAsyncWaitEx			*r;
 	struct mapistore_context		*mstore_ctx;
 	char					*emsmdb_session_str;
+	struct GUID				emsmdb_uuid;
 	struct tevent_fd			*fd_event;
 	int					sock;
 	int					fd;

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
@@ -113,8 +113,9 @@ enum emsmdbp_object_type {
 	EMSMDBP_OBJECT_TABLE		= 0x4,
 	EMSMDBP_OBJECT_STREAM		= 0x5,
 	EMSMDBP_OBJECT_ATTACHMENT	= 0x6,
-	EMSMDBP_OBJECT_FTCONTEXT	= 0x7, /* Fast Transfer */
-	EMSMDBP_OBJECT_SYNCCONTEXT	= 0x8
+	EMSMDBP_OBJECT_SUBSCRIPTION	= 0x7,
+	EMSMDBP_OBJECT_FTCONTEXT	= 0x8, /* Fast Transfer */
+	EMSMDBP_OBJECT_SYNCCONTEXT	= 0x9
 };
 
 struct emsmdbp_object_mailbox {
@@ -148,6 +149,7 @@ struct emsmdbp_object_table {
 	uint32_t				numerator;
 	uint32_t				denominator;
 	uint8_t					flags;
+	bool					subscription;
 };
 
 struct emsmdbp_object_stream {
@@ -166,6 +168,10 @@ struct emsmdbp_stream_data {
 
 struct emsmdbp_object_attachment {
 	uint32_t			attachmentID;
+};
+
+struct emsmdbp_object_subscription {
+	uint32_t			handle;
 };
 
 struct emsmdbp_object_synccontext {
@@ -218,6 +224,7 @@ union emsmdbp_objects {
 	struct emsmdbp_object_table	*table;
 	struct emsmdbp_object_stream	*stream;
 	struct emsmdbp_object_attachment *attachment;
+	struct emsmdbp_object_subscription *subscription;
 	struct emsmdbp_object_synccontext *synccontext;
 	struct emsmdbp_object_ftcontext *ftcontext;
 };
@@ -346,6 +353,7 @@ struct emsmdbp_object *emsmdbp_object_message_open_attachment_table(TALLOC_CTX *
 struct emsmdbp_object *emsmdbp_object_stream_init(TALLOC_CTX *, struct emsmdbp_context *, struct emsmdbp_object *);
 int emsmdbp_object_stream_commit(struct emsmdbp_object *);
 struct emsmdbp_object *emsmdbp_object_attachment_init(TALLOC_CTX *, struct emsmdbp_context *, uint64_t, struct emsmdbp_object *);
+struct emsmdbp_object *emsmdbp_object_subscription_init(TALLOC_CTX *, struct emsmdbp_context *, struct emsmdbp_object *);
 int emsmdbp_object_get_available_properties(TALLOC_CTX *, struct emsmdbp_context *, struct emsmdbp_object *, struct SPropTagArray **);
 int emsmdbp_object_set_properties(struct emsmdbp_context *, struct emsmdbp_object *, struct SRow *);
 void **emsmdbp_object_get_properties(TALLOC_CTX *, struct emsmdbp_context *, struct emsmdbp_object *, struct SPropTagArray *, enum MAPISTATUS **);

--- a/mapiproxy/servers/default/emsmdb/emsmdbp.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp.c
@@ -197,6 +197,22 @@ _PUBLIC_ struct emsmdbp_context *emsmdbp_init(struct loadparm_context *lp_ctx,
 
 
 /**
+   \details Associate the session uuid to the emsmdb context
+
+   \param emsmdbp_ctx pointer to the emsmdb context
+   \param uuid the uuid to associate
+
+   \return true on success, otherwise false
+ */
+_PUBLIC_ bool emsmdbp_set_session_uuid(struct emsmdbp_context *emsmdbp_ctx, struct GUID uuid)
+{
+  if (!emsmdbp_ctx) return false;
+
+  emsmdbp_ctx->session_uuid = uuid;
+  return true;
+}
+
+/**
    \details Open openchange.ldb database
 
    \param lp_ctx pointer on the loadparm_context

--- a/mapiproxy/servers/default/emsmdb/oxcnotif.c
+++ b/mapiproxy/servers/default/emsmdb/oxcnotif.c
@@ -3,7 +3,7 @@
 
    EMSMDBP: EMSMDB Provider implementation
 
-   Copyright (C) Julien Kerihuel 2009
+   Copyright (C) Julien Kerihuel 2009-2015
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -28,6 +28,7 @@
 #include "mapiproxy/dcesrv_mapiproxy.h"
 #include "mapiproxy/libmapiproxy/libmapiproxy.h"
 #include "mapiproxy/libmapiserver/libmapiserver.h"
+#include "mapiproxy/libmapistore/gen_ndr/mapistore_notification.h"
 #include "dcesrv_exchange_emsmdb.h"
 
 
@@ -54,11 +55,14 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopRegisterNotification(TALLOC_CTX *mem_ctx,
 							 uint32_t *handles, uint16_t *size)
 {
 	enum MAPISTATUS		retval;
+	enum mapistore_error	mretval;
 	struct mapi_handles	*parent_rec = NULL;
 	struct mapi_handles	*subscription_rec = NULL;
 	uint32_t		handle;
-        struct emsmdbp_object   *parent_object;
         void                    *data;
+	uint16_t		flags;
+	uint64_t		fid = 0;
+	uint64_t		mid = 0;
 
 	OC_DEBUG(4, "exchange_emsmdb: [OXCNOTIF] RegisterNotification (0x29)\n");
 
@@ -87,16 +91,33 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopRegisterNotification(TALLOC_CTX *mem_ctx,
 		OC_DEBUG(5, "  handle data not found, idx = %x\n", mapi_req->handle_idx);
 		goto end;
 	}
-	parent_object = (struct emsmdbp_object *) data;
 
 	retval = mapi_handles_add(emsmdbp_ctx->handles_ctx, handle, &subscription_rec);
 	if (retval) {
 		mapi_repl->error_code = retval;
 		goto end;
 	}
-	handles[mapi_repl->handle_idx] = subscription_rec->handle;
-
 	/* TODO: handling of notification subscriptions */
+	flags = mapi_req->u.mapi_RegisterNotification.NotificationFlags;
+	if (mapi_req->u.mapi_RegisterNotification.WantWholeStore) {
+		flags |= sub_WholeStore;
+	} else {
+		fid = mapi_req->u.mapi_RegisterNotification.FolderId.ID;
+		mid = mapi_req->u.mapi_RegisterNotification.MessageId.ID;
+	}
+
+	mretval = mapistore_notification_subscription_add(emsmdbp_ctx->mstore_ctx,
+							  emsmdbp_ctx->session_uuid,
+							  subscription_rec->handle,
+							  flags, fid, mid, 0, NULL);
+	if (mretval != MAPISTORE_SUCCESS) {
+		/* MS-OXCROPS section 2.2.14.1 does not describe a
+		 * failure response buffer for RegisterNotification
+		 * Rop */
+		OC_DEBUG(0, "Failed to add subscription: %s", mapistore_errstr(mretval));
+	}
+
+	handles[mapi_repl->handle_idx] = subscription_rec->handle;
 
 end:
 	*size += libmapiserver_RopRegisterNotification_size();

--- a/mapiproxy/servers/default/emsmdb/oxctabl.c
+++ b/mapiproxy/servers/default/emsmdb/oxctabl.c
@@ -539,6 +539,8 @@ finish:
 								  table->properties);
 		if (mretval != MAPISTORE_SUCCESS) {
 			OC_DEBUG(0, "Failed to add subscription");
+		} else {
+			table->subscription = true;
 		}
 	}
 

--- a/testsuite/libmapistore/mapistore_notification.c
+++ b/testsuite/libmapistore/mapistore_notification.c
@@ -23,6 +23,7 @@
 #include "mapiproxy/libmapistore/mapistore.h"
 #include "mapiproxy/libmapistore/mapistore_private.h"
 #include "mapiproxy/libmapistore/mapistore_errors.h"
+#include "mapiproxy/libmapistore/gen_ndr/mapistore_notification.h"
 
 /* Global variables */
 static struct GUID	gl_async_uuid;
@@ -31,6 +32,13 @@ static const char	*gl_cn = "FooBar";
 static const char	*gl_host1 = "tcp://host1:9005";
 static const char	*gl_host2 = "tcp://host2:9006";
 static const char	*gl_host3 = "tcp://host3:9007";
+static const uint64_t	gl_FolderId = 0xf503000000000001;
+static const uint64_t	gl_MessageId = 0xdeadbeef00000001;
+static const uint32_t	gl_handle = 0x42;
+static const uint16_t	gl_flags_newmail = sub_NewMail;
+static const uint16_t	gl_flags_table = sub_TableModified;
+static const uint16_t	gl_flags_wholestore = sub_WholeStore;
+static enum MAPITAGS	gl_tags[] = { PidTagParentFolderId, PidTagSubject };
 
 START_TEST(test_initialization) {
 	TALLOC_CTX				*mem_ctx = NULL;
@@ -536,12 +544,349 @@ START_TEST(resolver_delete) {
 
 } END_TEST
 
+
+START_TEST(subscription_add) {
+	TALLOC_CTX					*mem_ctx;
+	struct mapistore_context			mstore_ctx;
+	enum mapistore_error				retval;
+	struct loadparm_context				*lp_ctx;
+	struct mapistore_notification_context		*ctx = NULL;
+	struct mapistore_notification_context		_ctx;
+	struct mapistore_notification_subscription	r;
+	uint16_t					flags;
+
+	/* Check sanity check compliance */
+	retval = mapistore_notification_subscription_add(NULL, gl_uuid, gl_handle, gl_flags_newmail,
+							 gl_FolderId, gl_MessageId, 0, NULL);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_INITIALIZED);
+
+	retval = mapistore_notification_subscription_add(&mstore_ctx, gl_uuid, gl_handle,
+							 gl_flags_newmail, gl_FolderId,
+							 gl_MessageId, 1, NULL);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_INVALID_PARAMETER);
+
+	/* notification_ctx checks */
+	mstore_ctx.notification_ctx = NULL;
+	retval = mapistore_notification_subscription_add(&mstore_ctx, gl_uuid, gl_handle,
+							 gl_flags_newmail, gl_FolderId,
+							 gl_MessageId, 0, NULL);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_AVAILABLE);
+
+	mstore_ctx.notification_ctx = &_ctx;
+	mstore_ctx.notification_ctx->memc_ctx = NULL;
+	retval = mapistore_notification_subscription_add(&mstore_ctx, gl_uuid, gl_handle,
+							 gl_flags_newmail, gl_FolderId,
+							 gl_MessageId, 0, NULL);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_AVAILABLE);
+
+
+	/* Initialize mapistore notification system */
+	mem_ctx = talloc_named(NULL, 0, "subscription_add");
+	ck_assert(mem_ctx != NULL);
+
+	lp_ctx = loadparm_init(mem_ctx);
+	ck_assert(lp_ctx != NULL);
+
+	retval = mapistore_notification_init(mem_ctx, lp_ctx, &ctx);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+	mstore_ctx.notification_ctx = ctx;
+
+	/* add subscription on folder */
+	retval = mapistore_notification_subscription_add(&mstore_ctx, gl_uuid, gl_handle,
+							 gl_flags_newmail, gl_FolderId,
+							 0x0, 0x0, NULL);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+
+	/* check if record now exists */
+	retval = mapistore_notification_subscription_exist(&mstore_ctx, gl_uuid);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+
+	/* try to add same subscription twice */
+	retval = mapistore_notification_subscription_add(&mstore_ctx, gl_uuid, gl_handle,
+							 gl_flags_newmail, gl_FolderId,
+							 0x0, 0x0, NULL);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_EXIST);
+
+	/* retrieve subscription and check value */
+	retval = mapistore_notification_subscription_get(mem_ctx, &mstore_ctx, gl_uuid, &r);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+	ck_assert_int_eq(r.vnum, 1);
+	ck_assert_int_eq(r.v.v1.count, 1);
+	talloc_free(r.v.v1.subscription);
+
+	/* try to add a second subscription */
+	flags = sub_WholeStore|sub_ObjectModified;
+	retval = mapistore_notification_subscription_add(&mstore_ctx, gl_uuid, gl_handle + 1,
+							 flags, 0x0, 0x0, 0x0, NULL);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+
+	retval = mapistore_notification_subscription_get(mem_ctx, &mstore_ctx, gl_uuid, &r);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+	ck_assert_int_eq(r.vnum, 1);
+	ck_assert_int_eq(r.v.v1.count, 2);
+	ck_assert_int_eq(r.v.v1.subscription[0].flags, gl_flags_newmail);
+	ck_assert_int_eq(r.v.v1.subscription[1].flags, flags);
+	talloc_free(r.v.v1.subscription);
+
+	/* try to add a table subscription */
+	flags = sub_WholeStore|sub_TableModified;
+	retval = mapistore_notification_subscription_add(&mstore_ctx, gl_uuid, gl_handle + 2,
+							 flags, gl_FolderId, 0x0, 2, gl_tags);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+
+	retval = mapistore_notification_subscription_get(mem_ctx, &mstore_ctx, gl_uuid, &r);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+	ck_assert_int_eq(r.vnum, 1);
+	ck_assert_int_eq(r.v.v1.count, 3);
+	ck_assert_int_eq(r.v.v1.subscription[2].flags, flags);
+	ck_assert_int_eq(r.v.v1.subscription[2].count, 2);
+	ck_assert_int_eq(r.v.v1.subscription[2].properties[0], gl_tags[0]);
+	ck_assert_int_eq(r.v.v1.subscription[2].properties[1], gl_tags[1]);
+	talloc_free(r.v.v1.subscription[2].properties);
+	talloc_free(r.v.v1.subscription);
+
+	talloc_free(lp_ctx);
+	talloc_free(mem_ctx);
+
+} END_TEST
+
+START_TEST(subscription_exist) {
+	TALLOC_CTX				*mem_ctx;
+	struct mapistore_context		mstore_ctx;
+	enum mapistore_error			retval;
+	struct loadparm_context			*lp_ctx;
+	struct mapistore_notification_context	*ctx = NULL;
+	struct mapistore_notification_context	_ctx;
+
+	/* Check sanity check compliance */
+	retval = mapistore_notification_subscription_exist(NULL, gl_uuid);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_INITIALIZED);
+
+	mstore_ctx.notification_ctx = NULL;
+	retval = mapistore_notification_subscription_exist(&mstore_ctx, gl_uuid);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_AVAILABLE);
+
+	mstore_ctx.notification_ctx = &_ctx;
+	mstore_ctx.notification_ctx->memc_ctx = NULL;
+	retval = mapistore_notification_subscription_exist(&mstore_ctx, gl_uuid);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_AVAILABLE);
+
+	/* Initialize mapistore notification system */
+	mem_ctx = talloc_named(NULL, 0, "subscription_exist");
+	ck_assert(mem_ctx != NULL);
+
+	lp_ctx = loadparm_init(mem_ctx);
+	ck_assert(lp_ctx != NULL);
+
+	retval = mapistore_notification_init(mem_ctx, lp_ctx, &ctx);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+
+	mstore_ctx.notification_ctx = ctx;
+
+	/* Test gl_uuid existence */
+	retval = mapistore_notification_subscription_exist(&mstore_ctx, gl_uuid);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+
+	/* Test non existent uuid */
+	retval = mapistore_notification_subscription_exist(&mstore_ctx, GUID_random());
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_FOUND);
+
+	talloc_free(lp_ctx);
+	talloc_free(mem_ctx);
+
+} END_TEST
+
+START_TEST(subscription_get) {
+	TALLOC_CTX					*mem_ctx;
+	struct mapistore_context			mstore_ctx;
+	enum mapistore_error				retval;
+	struct loadparm_context				*lp_ctx;
+	struct mapistore_notification_context		*ctx = NULL;
+	struct mapistore_notification_context		_ctx;
+	struct mapistore_notification_subscription	r;
+
+	/* Check sanity check compliance */
+	retval = mapistore_notification_subscription_get(NULL, NULL, gl_uuid, &r);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_INITIALIZED);
+
+	retval = mapistore_notification_subscription_get(NULL, &mstore_ctx, gl_uuid, NULL);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_INVALID_PARAMETER);
+
+	mstore_ctx.notification_ctx = NULL;
+	retval = mapistore_notification_subscription_get(NULL, &mstore_ctx, gl_uuid, &r);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_AVAILABLE);
+
+	mstore_ctx.notification_ctx = &_ctx;
+	mstore_ctx.notification_ctx->memc_ctx = NULL;
+	retval = mapistore_notification_subscription_get(NULL, &mstore_ctx, gl_uuid, &r);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_AVAILABLE);
+
+	/* Initialize mapistore notification system */
+	mem_ctx = talloc_named(NULL, 0, "subscription_get");
+	ck_assert(mem_ctx != NULL);
+
+	lp_ctx = loadparm_init(mem_ctx);
+	ck_assert(lp_ctx != NULL);
+
+	retval = mapistore_notification_init(mem_ctx, lp_ctx, &ctx);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+	mstore_ctx.notification_ctx = ctx;
+
+	/* Try to retrieve non existent key */
+	retval = mapistore_notification_subscription_get(mem_ctx, &mstore_ctx, GUID_random(), &r);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_FOUND);
+
+	/* Try to retrieve existent key */
+	retval = mapistore_notification_subscription_get(mem_ctx, &mstore_ctx, gl_uuid, &r);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+	ck_assert_int_eq(r.v.v1.count, 3);
+
+	talloc_free(lp_ctx);
+	talloc_free(mem_ctx);
+
+} END_TEST
+
+START_TEST(subscription_delete) {
+	TALLOC_CTX				*mem_ctx;
+	struct mapistore_context		mstore_ctx;
+	enum mapistore_error			retval;
+	struct loadparm_context			*lp_ctx;
+	struct mapistore_notification_context	*ctx = NULL;
+	struct mapistore_notification_context	_ctx;
+
+	/* Check sanity check compliance */
+	retval = mapistore_notification_subscription_delete(NULL, gl_uuid);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_INITIALIZED);
+
+	mstore_ctx.notification_ctx = NULL;
+	retval = mapistore_notification_subscription_delete(&mstore_ctx, gl_uuid);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_AVAILABLE);
+
+	mstore_ctx.notification_ctx = &_ctx;
+	mstore_ctx.notification_ctx->memc_ctx = NULL;
+	retval = mapistore_notification_subscription_delete(&mstore_ctx, gl_uuid);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_AVAILABLE);
+
+	/* Initialize mapistore notification system */
+	mem_ctx = talloc_named(NULL, 0, "subscription_delete");
+	ck_assert(mem_ctx != NULL);
+
+	lp_ctx = loadparm_init(mem_ctx);
+	ck_assert(lp_ctx != NULL);
+
+	retval = mapistore_notification_init(mem_ctx, lp_ctx, &ctx);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+	mstore_ctx.notification_ctx = ctx;
+
+	/* Try to delete non existent key */
+	retval = mapistore_notification_subscription_delete(&mstore_ctx, GUID_random());
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_FOUND);
+
+	/* add subscription on folder */
+	retval = mapistore_notification_subscription_add(&mstore_ctx, gl_uuid, gl_handle,
+							 gl_flags_newmail, gl_FolderId,
+							 0x0, 0x0, NULL);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+
+	/* check if record now exists */
+	retval = mapistore_notification_subscription_exist(&mstore_ctx, gl_uuid);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+
+	/* Try to delete gl_uuid record */
+	retval = mapistore_notification_subscription_delete(&mstore_ctx, gl_uuid);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+
+	/* try to delete gl_uuid twice */
+	retval = mapistore_notification_subscription_delete(&mstore_ctx, gl_uuid);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_FOUND);
+
+	talloc_free(lp_ctx);
+	talloc_free(mem_ctx);
+
+} END_TEST
+
+START_TEST(subscription_delete_by_handle) {
+	TALLOC_CTX					*mem_ctx;
+	struct mapistore_context			mstore_ctx;
+	enum mapistore_error				retval;
+	struct loadparm_context				*lp_ctx;
+	struct mapistore_notification_context		*ctx = NULL;
+	struct mapistore_notification_context		_ctx;
+	struct mapistore_notification_subscription	r;
+
+	/* Check sanity check compliance */
+	retval = mapistore_notification_subscription_delete_by_handle(NULL, gl_uuid, gl_handle);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_INITIALIZED);
+
+	mstore_ctx.notification_ctx = NULL;
+	retval = mapistore_notification_subscription_delete_by_handle(&mstore_ctx, gl_uuid, gl_handle);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_AVAILABLE);
+
+	mstore_ctx.notification_ctx = &_ctx;
+	mstore_ctx.notification_ctx->memc_ctx = NULL;
+	retval = mapistore_notification_subscription_delete_by_handle(&mstore_ctx, gl_uuid, gl_handle);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_AVAILABLE);
+
+	/* Initialize mapistore notification system */
+	mem_ctx = talloc_named(NULL, 0, "subscription_delete_by_handle");
+	ck_assert(mem_ctx != NULL);
+
+	lp_ctx = loadparm_init(mem_ctx);
+	ck_assert(lp_ctx != NULL);
+
+	retval = mapistore_notification_init(mem_ctx, lp_ctx, &ctx);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+	mstore_ctx.notification_ctx = ctx;
+
+	/* Try to delete non existent key */
+	retval = mapistore_notification_subscription_delete_by_handle(&mstore_ctx, GUID_random(), gl_handle);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_FOUND);
+
+	/* Try to delete non existent handle */
+	retval = mapistore_notification_subscription_delete_by_handle(&mstore_ctx, gl_uuid, 6);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_FOUND);
+
+	/* Try to delete existing handle */
+	retval = mapistore_notification_subscription_delete_by_handle(&mstore_ctx, gl_uuid, gl_handle);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+
+	retval = mapistore_notification_subscription_get(mem_ctx, &mstore_ctx, gl_uuid, &r);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+	ck_assert_int_eq(r.v.v1.count, 2);
+	talloc_free(r.v.v1.subscription);
+
+	/* Try to delete same handle twice */
+	retval = mapistore_notification_subscription_delete_by_handle(&mstore_ctx, gl_uuid, gl_handle);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_FOUND);
+
+	/* try to delete other 2 handles */
+	retval = mapistore_notification_subscription_delete_by_handle(&mstore_ctx, gl_uuid, gl_handle + 1);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+
+	retval = mapistore_notification_subscription_get(mem_ctx, &mstore_ctx, gl_uuid, &r);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+	ck_assert_int_eq(r.v.v1.count, 1);
+	talloc_free(r.v.v1.subscription);
+
+	/* Try to delete last handle */
+	retval = mapistore_notification_subscription_delete_by_handle(&mstore_ctx, gl_uuid, gl_handle + 2);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+
+	retval = mapistore_notification_subscription_exist(&mstore_ctx, gl_uuid);
+	ck_assert_int_eq(retval, MAPISTORE_ERR_NOT_FOUND);
+
+	talloc_free(lp_ctx);
+	talloc_free(mem_ctx);
+
+} END_TEST
+
 Suite *mapistore_notification_suite(void)
 {
 	Suite	*s;
 	TCase	*tc_config;
 	TCase	*tc_session;
 	TCase	*tc_resolver;
+	TCase	*tc_subscription;
 
 	s = suite_create("libmapistore notification");
 
@@ -568,6 +913,15 @@ Suite *mapistore_notification_suite(void)
 	tcase_add_test(tc_resolver, resolver_get);
 	tcase_add_test(tc_resolver, resolver_delete);
 	suite_add_tcase(s, tc_resolver);
+
+	/* Subscription */
+	tc_subscription = tcase_create("subscription API");
+	tcase_add_test(tc_subscription, subscription_add);
+	tcase_add_test(tc_subscription, subscription_exist);
+	tcase_add_test(tc_subscription, subscription_get);
+	tcase_add_test(tc_subscription, subscription_delete_by_handle);
+	tcase_add_test(tc_subscription, subscription_delete);
+	suite_add_tcase(s, tc_subscription);
 
 	return s;
 }

--- a/utils/ocnotify.c
+++ b/utils/ocnotify.c
@@ -35,14 +35,36 @@
 #include <nanomsg/nn.h>
 #include <nanomsg/pipeline.h>
 
-static void ocnotify_newmail(TALLOC_CTX *mem_ctx, uint32_t count,
-			     const char **hosts, const char *data)
+struct ocnotify_private {
+	struct mapistore_context	mstore_ctx;
+	const char			*username;
+	bool				flush;
+};
+
+static void ocnotify_flush(struct ocnotify_private ocnotify, const char *host)
+{
+	enum mapistore_error	retval;
+
+	if (ocnotify.flush) {
+		retval = mapistore_notification_resolver_delete(&ocnotify.mstore_ctx, ocnotify.username, host);
+		if (retval == MAPISTORE_SUCCESS) {
+			oc_log(0, "* [OK]   %s resolver entry for user %s deleted", host, ocnotify.username);
+		} else {
+			oc_log(0, "* [ERR]  %s resolver entry for user %s not deleted", host, ocnotify.username);
+		}
+	}
+}
+
+static void ocnotify_newmail(TALLOC_CTX *mem_ctx, struct ocnotify_private ocnotify,
+			     uint32_t count, const char **hosts, const char *data)
 {
 	int	sock;
 	int	endpoint;
 	char	*msg = NULL;
 	int	i;
 	int	bytes;
+	int	timeout;
+	int	rc;
 	size_t	msglen;
 
 	if (data) {
@@ -61,10 +83,18 @@ static void ocnotify_newmail(TALLOC_CTX *mem_ctx, uint32_t count,
 		exit (1);
 	}
 
+	timeout = 200;
+	rc = nn_setsockopt(sock, NN_SOL_SOCKET, NN_SNDTIMEO, &timeout, sizeof(timeout));
+	if (rc < 0) {
+		oc_log(OC_LOG_WARNING, "unable to set timeout on socket send");
+	}
+
 	for (i = 0; i < count; i++) {
 		endpoint = nn_connect(sock, hosts[i]);
 		if (endpoint < 0) {
 			oc_log(OC_LOG_ERROR, "unable to connect to %s", hosts[i]);
+			ocnotify_flush(ocnotify, hosts[i]);
+			continue;
 		}
 		msglen = strlen(msg) + 1;
 		bytes = nn_send(sock, msg, msglen, 0);
@@ -84,9 +114,8 @@ int main(int argc, const char *argv[])
 	poptContext				pc;
 	int					opt;
 	struct loadparm_context			*lp_ctx;
-	struct mapistore_context		mstore_ctx;
+	struct ocnotify_private			ocnotify;
 	struct mapistore_notification_context	*ctx;
-	const char				*opt_username = NULL;
 	const char				*opt_server = NULL;
 	bool					opt_newmail = false;
 	bool					opt_list_server = false;
@@ -98,13 +127,14 @@ int main(int argc, const char *argv[])
 	uint32_t				count = 0;
 	const char				**hosts = NULL;
 
-	enum { OPT_USERNAME=1000, OPT_SERVER, OPT_DATA, OPT_SERVER_LIST, OPT_NEWMAIL, OPT_VERBOSE };
+	enum { OPT_USERNAME=1000, OPT_SERVER, OPT_DATA, OPT_SERVER_LIST, OPT_FLUSH, OPT_NEWMAIL, OPT_VERBOSE };
 
 	struct poptOption long_options[] = {
 		POPT_AUTOHELP
 		{ "username", 'U', POPT_ARG_STRING, NULL, OPT_USERNAME, "set the username", NULL },
 		{ "server", 'H', POPT_ARG_STRING, NULL, OPT_SERVER, "set the resolver address", NULL },
 		{ "list", 0, POPT_ARG_NONE, NULL, OPT_SERVER_LIST, "list notification service instances", NULL },
+		{ "flush", 0, POPT_ARG_NONE, NULL, OPT_FLUSH, "flush notification cache for the user", NULL },
 		{ "newmail", 'n', POPT_ARG_NONE, NULL, OPT_NEWMAIL, "send newmail notification", NULL },
 		{ "data", 'D', POPT_ARG_STRING, NULL, OPT_DATA, "user-specified data to send", NULL },
 		{ "verbose", 'v', POPT_ARG_NONE, NULL, OPT_VERBOSE, "Add one or more -v to increase verbosity", NULL },
@@ -119,17 +149,22 @@ int main(int argc, const char *argv[])
 
 	oc_log_init_stdout();
 
+	memset(&ocnotify, 0, sizeof (struct ocnotify_private));
+
 	pc = poptGetContext("ocnotify", argc, argv, long_options, 0);
 	while ((opt = poptGetNextOpt(pc)) != -1) {
 		switch (opt) {
 		case OPT_USERNAME:
-			opt_username = poptGetOptArg(pc);
+			ocnotify.username = poptGetOptArg(pc);
 			break;
 		case OPT_SERVER:
 			opt_server = poptGetOptArg(pc);
 			break;
 		case OPT_SERVER_LIST:
 			opt_list_server = true;
+			break;
+		case OPT_FLUSH:
+			ocnotify.flush = true;
 			break;
 		case OPT_DATA:
 			opt_data = poptGetOptArg(pc);
@@ -143,7 +178,7 @@ int main(int argc, const char *argv[])
 		}
 	}
 
-	if (!opt_username) {
+	if (!ocnotify.username) {
 		fprintf(stderr, "[ERR] username not specified\n");
 		exit (1);
 	}
@@ -169,17 +204,17 @@ int main(int argc, const char *argv[])
 		oc_log(OC_LOG_FATAL, "[ERR] unable to initialize mapistore notification");
 		exit(1);
 	}
-	mstore_ctx.notification_ctx = ctx;
+	ocnotify.mstore_ctx.notification_ctx = ctx;
 
 	/* Check if the user is registered */
-	retval = mapistore_notification_resolver_exist(&mstore_ctx, opt_username);
+	retval = mapistore_notification_resolver_exist(&ocnotify.mstore_ctx, ocnotify.username);
 	if (retval) {
 		oc_log(OC_LOG_ERROR, "[ERR] resolver session: '%s'", mapistore_errstr(retval));
 		exit(1);
 	}
 
 	/* Retrieve server instances */
-	retval = mapistore_notification_resolver_get(mem_ctx, &mstore_ctx, opt_username,
+	retval = mapistore_notification_resolver_get(mem_ctx, &ocnotify.mstore_ctx, ocnotify.username,
 						     &count, &hosts);
 	if (retval) {
 		oc_log(OC_LOG_ERROR, "[ERR] resolver record: '%s'", mapistore_errstr(retval));
@@ -187,7 +222,7 @@ int main(int argc, const char *argv[])
 	}
 
 	if (opt_list_server) {
-		oc_log(0, "%d servers found for '%s'\n", count, opt_username);
+		oc_log(0, "%d servers found for '%s'\n", count, ocnotify.username);
 		for (i = 0; i < count; i++) {
 			oc_log(0, "\t* %s\n", hosts[i]);
 		}
@@ -195,7 +230,14 @@ int main(int argc, const char *argv[])
 
 	/* Send mail notification */
 	if (opt_newmail) {
-		ocnotify_newmail(mem_ctx, count, hosts, opt_data);
+		ocnotify_newmail(mem_ctx, ocnotify, count, hosts, opt_data);
+	}
+
+	/* Flush invalid data */
+	if (ocnotify.flush) {
+		for (i = 0; i < count; i++) {
+			retval = mapistore_notification_resolver_delete(&ocnotify.mstore_ctx, ocnotify.username, hosts[i]);
+		}
 	}
 
 	talloc_free(ctx);


### PR DESCRIPTION
Add API and unit test for the notification subscription model. This part of the API is used in emsmdb to emit subscription on events for which to be notified and consumed in asyncemsmdb.