### PR TITLE
4.1 is now the stable version for the bug-analysis tool

### DIFF
--- a/script/bug-analysis/apport-config.backup/Ubuntu 14.04/sources.list
+++ b/script/bug-analysis/apport-config.backup/Ubuntu 14.04/sources.list
@@ -1,6 +1,5 @@
 deb http://archive.zentyal.org/old 4.0 main
-#deb http://archive.zentyal.org/zentyal 3.5 main
-#deb-src http://archive.zentyal.org/zentyal 3.5 main
+deb http://archive.zentyal.org/old 4.1 main
 deb http://fr.archive.ubuntu.com/ubuntu/ trusty main universe multiverse restricted
 deb-src http://fr.archive.ubuntu.com/ubuntu/ trusty main universe multiverse restricted
 deb http://fr.archive.ubuntu.com/ubuntu/ trusty-updates main universe multiverse restricted

--- a/script/bug-analysis/apport-config.proposed/Ubuntu 14.04/sources.list
+++ b/script/bug-analysis/apport-config.proposed/Ubuntu 14.04/sources.list
@@ -1,6 +1,6 @@
-deb http://archive.zentyal.org/zentyal-beta 4.0-proposed main
-deb-src http://archive.zentyal.org/zentyal-beta 4.0-proposed main
-deb http://archive.zentyal.org/zentyal 4.0 main
+deb http://archive.zentyal.org/zentyal-beta 4.1-proposed main
+deb-src http://archive.zentyal.org/zentyal-beta 4.1-proposed main
+deb http://archive.zentyal.org/zentyal 4.1 main
 deb http://gb.archive.ubuntu.com/ubuntu/ trusty main universe multiverse restricted
 deb-src http://gb.archive.ubuntu.com/ubuntu/ trusty main universe multiverse restricted
 deb http://gb.archive.ubuntu.com/ubuntu/ trusty-updates main universe multiverse restricted

--- a/script/bug-analysis/apport-config/Ubuntu 14.04/sources.list
+++ b/script/bug-analysis/apport-config/Ubuntu 14.04/sources.list
@@ -1,5 +1,5 @@
-deb http://archive.zentyal.org/zentyal 4.0 main
-deb-src http://archive.zentyal.org/zentyal 4.0 main
+deb http://archive.zentyal.org/zentyal 4.1 main
+deb-src http://archive.zentyal.org/zentyal 4.1 main
 deb http://gb.archive.ubuntu.com/ubuntu/ trusty main universe multiverse restricted
 deb-src http://gb.archive.ubuntu.com/ubuntu/ trusty main universe multiverse restricted
 deb http://gb.archive.ubuntu.com/ubuntu/ trusty-updates main universe multiverse restricted


### PR DESCRIPTION
Please @sixstone-qq review this it shouldn't had problems but just in case. I'm maintaining the proposed up to update just in case we start using that repo again. Additionally I added two "old" repos to maintain the differences between 4.0 and 4., It shouldn't cause problems right?