### PR TITLE
mapitest: zentyal_1872 expects MAPI_E_SUCCESS

### DIFF
--- a/utils/mapitest/modules/module_zentyal.c
+++ b/utils/mapitest/modules/module_zentyal.c
@@ -63,7 +63,7 @@ _PUBLIC_ bool mapitest_zentyal_1872(struct mapitest *mt)
 	retval = nspi_QueryRows(nspi_ctx, mem_ctx, NULL, MIds, 1, &RowSet);
 	MAPIFreeBuffer(RowSet);
 	mapitest_print_retval_clean(mt, "1872", retval);
-	if (retval != MAPI_E_INVALID_PARAMETER) {
+	if (retval != MAPI_E_SUCCESS) {
 		MAPIFreeBuffer(MIds);
 		talloc_free(mem_ctx);
 		return false;


### PR DESCRIPTION
NSPI table position functionality has been rewritten following
rules from MS-OXNSPI, in this case 3.1.4.5.1 describes absolute
positioning and NumPos value is not relevant but Delta field.

Long story short, this RoP should return MAPI_E_SUCCESS and that's
what happens now, so let's adjust the test to reality