### PR TITLE
Fix EmptyFolder ROP

### DIFF
--- a/mapiproxy/libmapistore/mapistore_interface.c
+++ b/mapiproxy/libmapistore/mapistore_interface.c
@@ -481,8 +481,11 @@ _PUBLIC_ enum mapistore_error mapistore_create_root_folder(const char *username,
    \param mstore_ctx pointer to the mapistore context
    \param context_id the context identifier referencing the backend
    where the directory will be opened
-   \param parent_fid the parent folder identifier
+   \param folder the parent folder object
+   \param mem_ctx the memory context where child_folder is created
    \param fid folder identifier to open
+   \param [out] child_folder location where to store new mapistore
+   backend object on success
 
    \return MAPISTORE_SUCCESS on success, otherwise MAPISTORE errors
  */

--- a/mapiproxy/servers/default/emsmdb/oxcfold.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfold.c
@@ -858,7 +858,7 @@ static enum MAPISTATUS RopEmptyFolder_GenericFolder(TALLOC_CTX *mem_ctx,
 
 	/* Step 3. Delete contents of the folder in mapistore */
 	for (i = 0; i < childFolderCount; ++i) {
-		retval = mapistore_folder_open_folder(emsmdbp_ctx->mstore_ctx, context_id, folder, local_mem_ctx, childFolders[i], &subfolder);
+		retval = mapistore_folder_open_folder(emsmdbp_ctx->mstore_ctx, context_id, folder_object->backend_object, local_mem_ctx, childFolders[i], &subfolder);
 		if (retval != MAPISTORE_SUCCESS) {
 			ret = MAPI_E_NOT_FOUND;
 			goto end;


### PR DESCRIPTION
mapistore_folder_open_folder expects a backend folder object and
not a emsmdbp object according to other calls.

This has been detected by running OXCFOLD-CREATEFOLDER mapitest.