### PR TITLE
Update indexing entries when deleting a folder

### DIFF
--- a/libmapi/IMAPIFolder.c
+++ b/libmapi/IMAPIFolder.c
@@ -863,7 +863,8 @@ _PUBLIC_ enum MAPISTATUS DeleteFolder(mapi_object_t *obj_parent,
 	OPENCHANGE_RETVAL_IF(!session, MAPI_E_INVALID_PARAMETER, NULL);
 	OPENCHANGE_RETVAL_IF((!(DeleteFolderFlags & 0x1)) &&
 			     (!(DeleteFolderFlags & 0x4)) &&
-			     (!(DeleteFolderFlags & 0x10)), 
+			     (!(DeleteFolderFlags & 0x10)) &&
+			     DeleteFolderFlags,
 			     MAPI_E_INVALID_PARAMETER, NULL);
 
 	if ((retval = mapi_object_get_logon_id(obj_parent, &logon_id)) != MAPI_E_SUCCESS)

--- a/mapiproxy/libmapistore/mapistore.h
+++ b/mapiproxy/libmapistore/mapistore.h
@@ -327,7 +327,7 @@ enum mapistore_error mapistore_create_root_folder(const char *, enum mapistore_c
 
 enum mapistore_error mapistore_folder_open_folder(struct mapistore_context *, uint32_t, void *, TALLOC_CTX *, uint64_t, void **);
 enum mapistore_error mapistore_folder_create_folder(struct mapistore_context *, uint32_t, void *, TALLOC_CTX *, uint64_t, struct SRow *, void **);
-enum mapistore_error mapistore_folder_delete(struct mapistore_context *, uint32_t, void *, uint8_t);
+enum mapistore_error mapistore_folder_delete(struct mapistore_context *, uint32_t, void *, uint8_t, TALLOC_CTX *, uint64_t **, uint32_t *);
 enum mapistore_error mapistore_folder_open_message(struct mapistore_context *, uint32_t, void *, TALLOC_CTX *, uint64_t, bool, void **);
 enum mapistore_error mapistore_folder_create_message(struct mapistore_context *, uint32_t, void *, TALLOC_CTX *, uint64_t, uint8_t, void **);
 enum mapistore_error mapistore_folder_delete_message(struct mapistore_context *, uint32_t, void *, uint64_t, uint8_t);

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
@@ -339,6 +339,7 @@ struct emsmdbp_object *emsmdbp_object_mailbox_init(TALLOC_CTX *, struct emsmdbp_
 struct emsmdbp_object *emsmdbp_object_folder_init(TALLOC_CTX *, struct emsmdbp_context *, uint64_t, struct emsmdbp_object *);
 enum MAPISTATUS      emsmdbp_folder_get_folder_count(struct emsmdbp_context *, struct emsmdbp_object *, uint32_t *);
 enum MAPISTATUS emsmdbp_folder_get_recursive_folder_count(struct emsmdbp_context *, struct emsmdbp_object *, uint32_t *);
+enum mapistore_error emsmdbp_folder_delete_indexing_records(struct mapistore_context *, uint32_t, char *, uint64_t, uint64_t *, uint32_t, uint8_t);
 enum mapistore_error emsmdbp_folder_delete(struct emsmdbp_context *, struct emsmdbp_object *, uint64_t, uint8_t);
 enum mapistore_error emsmdbp_folder_move_folder(struct emsmdbp_context *, struct emsmdbp_object *, struct emsmdbp_object *, TALLOC_CTX *, const char *);
 struct emsmdbp_object *emsmdbp_folder_open_table(TALLOC_CTX *, struct emsmdbp_object *, uint32_t, uint32_t);

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -1539,12 +1539,6 @@ _PUBLIC_ enum mapistore_error emsmdbp_folder_delete(struct emsmdbp_context *emsm
 			goto end;
 		}
 
-		retval = openchangedb_delete_folder(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, fid);
-		if (retval != MAPI_E_SUCCESS) {
-			ret = MAPISTORE_ERR_NOT_FOUND;
-			goto end;
-		}
-
 		if (mapistoreURL) {	/* fid is mapistore root */
 			ret = mapistore_search_context_by_uri(emsmdbp_ctx->mstore_ctx, mapistoreURL, &context_id, &subfolder);
 			if (ret == MAPISTORE_SUCCESS) {
@@ -1573,6 +1567,12 @@ _PUBLIC_ enum mapistore_error emsmdbp_folder_delete(struct emsmdbp_context *emsm
 			if (ret != MAPISTORE_SUCCESS) {
 				goto end;
 			}
+		}
+
+		retval = openchangedb_delete_folder(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, fid);
+		if (retval != MAPI_E_SUCCESS) {
+			ret = MAPISTORE_ERR_NOT_FOUND;
+			goto end;
 		}
 	}
 

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -1446,15 +1446,63 @@ _PUBLIC_ enum mapistore_error emsmdbp_folder_move_folder(struct emsmdbp_context 
 	return ret;
 }
 
+/**
+   \details  Delete the fmids from a folder in the indexing database.
+
+   \param mstore_ctx pointer to the mapistore context
+   \param context_id the context identifier
+   \param username the owner of the folder to delete its entries
+   \param fid the folder identifier
+   \param deleted_fmid the array of child fmids from the folder
+   \param deleted_fmid_count the number of deleted_fmids
+   \param flags the delete flags. See emsmdbp_folder_delete for details.
+
+   \return MAPISTORE_SUCCESS on success, otherwise MAPISTORE error.
+*/
+_PUBLIC_ enum mapistore_error emsmdbp_folder_delete_indexing_records(struct mapistore_context *mstore_ctx, uint32_t context_id, char *username, uint64_t fid, uint64_t *deleted_fmids, uint32_t deleted_fmids_count, uint8_t flags)
+{
+        enum mapistore_error    ret;
+        uint8_t                 delete_type_flag;
+        uint32_t                i;
+
+        delete_type_flag = (flags & DELETE_HARD_DELETE) ? MAPISTORE_PERMANENT_DELETE : MAPISTORE_SOFT_DELETE;
+        ret = mapistore_indexing_record_del_fid(mstore_ctx, context_id, username, fid, delete_type_flag);
+        MAPISTORE_RETVAL_IF(ret != MAPISTORE_SUCCESS, ret, NULL);
+
+        for (i = 0; i < deleted_fmids_count; i++) {
+                ret = mapistore_indexing_record_del_fid(mstore_ctx, context_id, username,
+                                                        deleted_fmids[i], delete_type_flag);
+                MAPISTORE_RETVAL_IF(ret != MAPISTORE_SUCCESS, ret, NULL);
+        }
+
+        return MAPISTORE_SUCCESS;
+}
+
+/**
+   \details Delete a folder.
+
+   \param emsmdbp_ctx pointer to the emsmdbp context
+   \param parent_folder the parent folder
+   \param fid the folder identifier to delete from parent_folder
+   \param flags the delete flags.
+
+   Possible values for flags are:
+   -# DEL_MESSAGES Delete all the messages in the folder
+   -# DEL_FOLDERS Delete the subfolder and all of its subfolders
+   -# DELETE_HARD_DELETE Hard delete the folder
+
+   \return MAPISTORE_SUCCESS on success, otherwise MAPISTORE error.
+*/
 _PUBLIC_ enum mapistore_error emsmdbp_folder_delete(struct emsmdbp_context *emsmdbp_ctx, struct emsmdbp_object *parent_folder, uint64_t fid, uint8_t flags)
 {
 	enum mapistore_error	ret;
-	enum MAPISTATUS		mapiret;
+	enum MAPISTATUS		retval;
 	TALLOC_CTX		*mem_ctx;
 	bool			mailboxstore;
-	uint32_t		context_id;
+	uint32_t		context_id, deleted_fmids_count;
 	void			*subfolder;
 	char			*mapistoreURL;
+	uint64_t		*deleted_fmids;
 
 	mem_ctx = talloc_new(NULL);
 	MAPISTORE_RETVAL_IF(!mem_ctx, MAPISTORE_ERR_NO_MEMORY, NULL);
@@ -1470,20 +1518,29 @@ _PUBLIC_ enum mapistore_error emsmdbp_folder_delete(struct emsmdbp_context *emsm
 			goto end;
 		}
 
-		ret = mapistore_folder_delete(emsmdbp_ctx->mstore_ctx, context_id, subfolder, flags);
+		ret = mapistore_folder_delete(emsmdbp_ctx->mstore_ctx, context_id, subfolder, flags, mem_ctx, &deleted_fmids, &deleted_fmids_count);
+		if (ret != MAPISTORE_SUCCESS) {
+			goto end;
+		}
+
+		/* Update indexing entries */
+		ret = emsmdbp_folder_delete_indexing_records(emsmdbp_ctx->mstore_ctx, context_id,
+							     emsmdbp_get_owner(parent_folder),
+							     fid, deleted_fmids, deleted_fmids_count,
+							     flags);
 		if (ret != MAPISTORE_SUCCESS) {
 			goto end;
 		}
 	}
 	else {
-		mapiret = openchangedb_get_mapistoreURI(mem_ctx, emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, fid, &mapistoreURL, mailboxstore);
-		if (mapiret != MAPI_E_SUCCESS) {
+		retval = openchangedb_get_mapistoreURI(mem_ctx, emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, fid, &mapistoreURL, mailboxstore);
+		if (retval != MAPI_E_SUCCESS) {
 			ret = MAPISTORE_ERR_NOT_FOUND;
 			goto end;
 		}
 
-		mapiret = openchangedb_delete_folder(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, fid);
-		if (mapiret != MAPI_E_SUCCESS) {
+		retval = openchangedb_delete_folder(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, fid);
+		if (retval != MAPI_E_SUCCESS) {
 			ret = MAPISTORE_ERR_NOT_FOUND;
 			goto end;
 		}
@@ -1499,12 +1556,23 @@ _PUBLIC_ enum mapistore_error emsmdbp_folder_delete(struct emsmdbp_context *emsm
 				}
 			}
 
-			ret = mapistore_folder_delete(emsmdbp_ctx->mstore_ctx, context_id, subfolder, flags);
+			ret = mapistore_folder_delete(emsmdbp_ctx->mstore_ctx, context_id,
+						      subfolder, flags, mem_ctx, &deleted_fmids,
+						      &deleted_fmids_count);
 			if (ret != MAPISTORE_SUCCESS) {
 				goto end;
 			}
 
-			 mapistore_del_context(emsmdbp_ctx->mstore_ctx, context_id);
+			mapistore_del_context(emsmdbp_ctx->mstore_ctx, context_id);
+
+			/* Update indexing entries */
+			ret = emsmdbp_folder_delete_indexing_records(emsmdbp_ctx->mstore_ctx, context_id,
+								     emsmdbp_get_owner(parent_folder),
+								     fid, deleted_fmids, deleted_fmids_count,
+								     flags);
+			if (ret != MAPISTORE_SUCCESS) {
+				goto end;
+			}
 		}
 	}
 

--- a/mapiproxy/servers/default/emsmdb/oxcfold.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfold.c
@@ -821,11 +821,12 @@ static enum MAPISTATUS RopEmptyFolder_GenericFolder(TALLOC_CTX *mem_ctx,
 {
 	enum MAPISTATUS		ret = MAPI_E_SUCCESS;
 	void                    *folder_priv;
-	struct emsmdbp_object   *folder_object = NULL;
-	uint32_t                context_id;
+	char			*owner;
+	struct emsmdbp_object	*folder_object = NULL;
+	uint32_t		context_id;
 	enum mapistore_error	retval;
-	uint64_t		*childFolders;
-	uint32_t		childFolderCount;
+	uint64_t		*childFolders, *deleted_fmids;
+	uint32_t		childFolderCount, deleted_fmids_count;
 	uint32_t		i;
 	uint8_t			flags = DELETE_HARD_DELETE| DEL_MESSAGES | DEL_FOLDERS;
 	TALLOC_CTX		*local_mem_ctx;
@@ -864,9 +865,22 @@ static enum MAPISTATUS RopEmptyFolder_GenericFolder(TALLOC_CTX *mem_ctx,
 			goto end;
 		}
 
-		retval = mapistore_folder_delete(emsmdbp_ctx->mstore_ctx, context_id, subfolder, flags);
+		owner = emsmdbp_get_owner(folder_object);
+		retval = mapistore_folder_delete(emsmdbp_ctx->mstore_ctx, context_id,
+						 subfolder, flags, local_mem_ctx,
+						 &deleted_fmids, &deleted_fmids_count);
 		if (retval) {
 			OC_DEBUG(4, "exchange_emsmdb: [OXCFOLD] EmptyFolder failed to delete fid 0x%.16"PRIx64" (0x%x)", childFolders[i], retval);
+			ret = MAPI_E_NOT_FOUND;
+			goto end;
+		}
+
+		/* Update indexing entries */
+		retval = emsmdbp_folder_delete_indexing_records(emsmdbp_ctx->mstore_ctx, context_id,
+								owner, childFolders[i], deleted_fmids,
+								deleted_fmids_count, flags);
+		if (retval) {
+			OC_DEBUG(4, "exchange_emsmdb: [OXCFOLD] EmptyFolder failed to delete indexing entries for fid 0x%.16"PRIx64" (0x%x)", childFolders[i], retval);
 			ret = MAPI_E_NOT_FOUND;
 			goto end;
 		}

--- a/utils/mapitest/module.c
+++ b/utils/mapitest/module.c
@@ -94,6 +94,7 @@ _PUBLIC_ uint32_t module_oxcfold_init(struct mapitest *mt)
 	mapitest_suite_add_test(suite, "CREATE-DELETE", "Do a basic create / delete cycle on a folder", mapitest_oxcfold_CreateDeleteFolder);
 	mapitest_suite_add_test(suite, "CREATE", "Create a folder", mapitest_oxcfold_CreateFolder);
 	mapitest_suite_add_test(suite, "CREATE-VARIANTS", "More folder creation variations", mapitest_oxcfold_CreateFolderVariants);
+	mapitest_suite_add_test(suite, "DELETE-VARIANTS", "More folder deletion variations", mapitest_oxcfold_DeleteFolderVariants);
 	mapitest_suite_add_test(suite, "GET-HIERARCHY-TABLE", "Retrieve the hierarchy table", mapitest_oxcfold_GetHierarchyTable);
 	mapitest_suite_add_test(suite, "GET-CONTENTS-TABLE", "Retrieve the contents table", mapitest_oxcfold_GetContentsTable);
 	mapitest_suite_add_test(suite, "SET-SEARCHCRITERIA", "Set a search criteria on a container", mapitest_oxcfold_SetSearchCriteria);

--- a/utils/mapitest/modules/module_oxcfold.c
+++ b/utils/mapitest/modules/module_oxcfold.c
@@ -5,6 +5,7 @@
 
    Copyright (C) Julien Kerihuel 2008
    Copyright (C) Brad Hards 2009-2010
+   Copyright (C) Enrique J. Hernández 2015
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -558,6 +559,173 @@ cleanup:
 	mapi_object_release(&obj_top3);
 	mapi_object_release(&obj_top2);
 	mapi_object_release(&obj_top1);
+	mapi_object_release(&obj_folder);
+	mapi_object_release(&obj_store);
+
+	return ret;
+}
+
+/**
+   \details Test the DeleteFolder (0x1c) operations
+
+   This tests different combinations of folder deletion.
+
+   This function:
+	-# Log on the user private mailbox
+	-# Open the top information folder
+	-# Create a test directory (or open the directory if it already exists)
+	-# Create two messages in it
+	-# Create a generic child subfolder
+	-# Create a generic grandchild subfolder
+	-# Try to delete the child subfolder without flags
+	-# Try to delete the child subfolder without DEL_FOLDERS flag
+	-# Delete the child subfolder
+	-# Try to delete the generic folder without flags
+	-# Try to delete the generic folder without DEL_MESSAGES flag
+	-# Delete the generic subfolder
+	-# Delete the test directory
+   \param mt the top-level mapitest structure
+
+   \return true on success, otherwise false
+ */
+_PUBLIC_ bool mapitest_oxcfold_DeleteFolderVariants(struct mapitest *mt)
+{
+	bool			ret = true;
+	bool			common_result, partial_completion;
+	int			i;
+	mapi_object_t		obj_store;
+	mapi_object_t		obj_folder;
+	mapi_object_t		obj_top, obj_child, obj_grandchild;
+	mapi_object_t		obj_message;
+	mapi_id_t		id_folder;
+	enum MAPISTATUS		retval;
+
+	mapi_object_init(&obj_store);
+	mapi_object_init(&obj_folder);
+	mapi_object_init(&obj_top);
+	mapi_object_init(&obj_child);
+	mapi_object_init(&obj_grandchild);
+
+	/* Step 1. Logon */
+	retval = OpenMsgStore(mt->session, &obj_store);
+	mapitest_print_retval_clean(mt, "OpenMsgStore", retval);
+	if (retval != MAPI_E_SUCCESS) {
+		ret = false;
+		goto cleanup;
+	}
+
+	/* Step 2. Open Top Information Store folder */
+	retval = GetDefaultFolder(&obj_store, &id_folder, olFolderTopInformationStore);
+	mapitest_print_retval_clean(mt, "GetDefaultFolder", retval);
+	if (retval != MAPI_E_SUCCESS) {
+		ret = false;
+		goto cleanup;
+	}
+	retval = OpenFolder(&obj_store, id_folder, &obj_folder);
+	mapitest_print_retval_clean(mt, "OpenFolder", retval);
+	if (retval != MAPI_E_SUCCESS) {
+		ret = false;
+		goto cleanup;
+	}
+
+	/* Step 3. Create the top test folder */
+	mapitest_print(mt, "* Create GENERIC \"%s\" folder\n", MT_DIRNAME_TOP);
+	retval = CreateFolder(&obj_folder, FOLDER_GENERIC, MT_DIRNAME_TOP, NULL,
+			      OPEN_IF_EXISTS, &obj_top);
+	mapitest_print_retval_clean(mt, "CreateFolder - top", retval);
+	if (retval != MAPI_E_SUCCESS) {
+		ret = false;
+		goto cleanup;
+	}
+
+	/* Step 4. Create two messages in it */
+	for (i = 0; i < 2; i++) {
+		mapi_object_init(&obj_message);
+		common_result = mapitest_common_message_create(mt, &obj_top, &obj_message, MT_MAIL_SUBJECT);
+		if (!common_result) {
+			mapitest_print(mt, "* mapitest_common_message_create() failed\n");
+			ret = false;
+		} else {
+			retval = SaveChangesMessage(&obj_top, &obj_message, KeepOpenReadOnly);
+			mapitest_print_retval(mt, "SaveChangesMessage");
+			if (retval != MAPI_E_SUCCESS) {
+				ret = false;
+			}
+		}
+		mapi_object_release(&obj_message);
+	}
+
+	/* Step 5. Create child folder */
+	mapitest_print(mt, "* Create GENERIC child folder\n");
+	retval = CreateFolder(&obj_top, FOLDER_GENERIC, "MT Child folder", NULL,
+			      0, &obj_child);
+	mapitest_print_retval_clean(mt, "CreateFolder - child", retval);
+	if (retval != MAPI_E_SUCCESS) {
+		ret = false;
+	}
+
+	/* Step 6. Create grandchild folder */
+	mapitest_print(mt, "* Create GENERIC grandchild folder\n");
+	retval = CreateFolder(&obj_child, FOLDER_GENERIC, "MT Grand Child folder", NULL,
+			      0, &obj_grandchild);
+	mapitest_print_retval_clean(mt, "CreateFolder - grandchild", retval);
+	if (retval != MAPI_E_SUCCESS) {
+		ret = false;
+	}
+
+	/* Step 7. Delete child folder without flags */
+	retval = DeleteFolder(&obj_top, mapi_object_get_id(&obj_child),
+			      0, &partial_completion);
+	mapitest_print_retval_clean(mt, "DeleteFolder - child no flags", retval);
+	if (retval != MAPI_E_SUCCESS || !partial_completion) {
+		ret = false;
+	}
+
+	/* Step 8. Delete child folder without DEL_FOLDERS flag */
+	retval = DeleteFolder(&obj_top, mapi_object_get_id(&obj_child),
+			      DEL_MESSAGES, &partial_completion);
+	mapitest_print_retval_clean(mt, "DeleteFolder - child DEL_MESSAGES flag", retval);
+	if (retval != MAPI_E_SUCCESS || !partial_completion) {
+		ret = false;
+	}
+
+	/* Step 9. Delete the child folder*/
+	retval = DeleteFolder(&obj_top, mapi_object_get_id(&obj_child),
+			      DELETE_HARD_DELETE|DEL_MESSAGES|DEL_FOLDERS, &partial_completion);
+	mapitest_print_retval_clean(mt, "DeleteFolder - child", retval);
+	if (retval != MAPI_E_SUCCESS || partial_completion) {
+		ret = false;
+	}
+
+	/* Step 10. Delete folder without flags */
+	retval = DeleteFolder(&obj_folder, mapi_object_get_id(&obj_top),
+			      0, &partial_completion);
+	mapitest_print_retval_clean(mt, "DeleteFolder - top no flags", retval);
+	if (retval != MAPI_E_SUCCESS || !partial_completion) {
+		ret = false;
+	}
+
+	/* Step 11. Delete folder without DEL_MESSAGES flag */
+	retval = DeleteFolder(&obj_folder, mapi_object_get_id(&obj_top),
+			      DEL_FOLDERS, &partial_completion);
+	mapitest_print_retval_clean(mt, "DeleteFolder - top DEL_FOLDERS flag", retval);
+	if (retval != MAPI_E_SUCCESS || !partial_completion) {
+		ret = false;
+	}
+
+	/* Step 12. DeleteFolder on the top folder */
+	retval = DeleteFolder(&obj_folder, mapi_object_get_id(&obj_top),
+			      DEL_MESSAGES|DEL_FOLDERS|DELETE_HARD_DELETE, &partial_completion);
+	mapitest_print_retval_clean(mt, "DeleteFolder - top", retval);
+	if (retval != MAPI_E_SUCCESS || partial_completion) {
+		ret = false;
+	}
+
+cleanup:
+	/* Release */
+	mapi_object_release(&obj_grandchild);
+	mapi_object_release(&obj_child);
+	mapi_object_release(&obj_top);
 	mapi_object_release(&obj_folder);
 	mapi_object_release(&obj_store);
 


### PR DESCRIPTION
* It honors the HARD_DELETE flag as described.

Another things done in this PR:

* libmapi: Give support to not send any flag
* Delete mapistore first on mapistore root folders
    * As this honors when it is unable to delete due to flags
* Added new mapitest to test DeleteFolder ROP flags
    * Tested against OpenChange and Exchange 2010
