### PR TITLE
Introduce mapistore_indexing_record_add_fmid_for_uri

### DIFF
--- a/mapiproxy/libmapistore/mapistore.h
+++ b/mapiproxy/libmapistore/mapistore.h
@@ -389,6 +389,7 @@ enum mapistore_error mapistore_indexing_record_add_fid(struct mapistore_context 
 enum mapistore_error mapistore_indexing_record_del_fid(struct mapistore_context *, uint32_t, const char *, uint64_t, uint8_t);
 enum mapistore_error mapistore_indexing_record_add_mid(struct mapistore_context *, uint32_t, const char *, uint64_t);
 enum mapistore_error mapistore_indexing_record_del_mid(struct mapistore_context *, uint32_t, const char *, uint64_t, uint8_t);
+enum mapistore_error mapistore_indexing_record_add_fmid_for_uri(struct mapistore_context *, uint32_t, const char *, uint64_t, const char *);
 enum mapistore_error mapistore_indexing_record_get_uri(struct mapistore_context *, const char *, TALLOC_CTX *, uint64_t, char **, bool *);
 enum mapistore_error mapistore_indexing_record_get_fmid(struct mapistore_context *, const char *, const char *, bool, uint64_t *, bool *);
 

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -318,10 +318,11 @@ static enum mapistore_error emsmdbp_object_folder_commit_creation(struct emsmdbp
 		goto end;
 	}
 
-	mapistore_indexing_record_add_fid(emsmdbp_ctx->mstore_ctx, context_id, owner, fid);
 	new_folder->object.folder->contextID = context_id;
 
 	openchangedb_set_folder_properties(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, fid, new_folder->object.folder->postponed_props);
+	mapistore_indexing_record_add_fmid_for_uri(emsmdbp_ctx->mstore_ctx, context_id, owner, fid,
+						   mapistore_uri);
 	mapistore_properties_set_properties(emsmdbp_ctx->mstore_ctx, context_id, new_folder->backend_object, new_folder->object.folder->postponed_props);
 
 	talloc_unlink(new_folder, new_folder->object.folder->postponed_props);

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_provisioning.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_provisioning.c
@@ -468,7 +468,8 @@ FolderId: 0x67ca828f02000001      Display Name: "                        ";  Con
 
 			/* instantiate the new folder in the backend to make sure it is initialized properly */
 			retval = mapistore_add_context(emsmdbp_ctx->mstore_ctx, username, mapistore_url, current_fid, &context_id, &backend_object);
-			mapistore_indexing_record_add_fid(emsmdbp_ctx->mstore_ctx, context_id, username, current_fid);
+			mapistore_indexing_record_add_fmid_for_uri(emsmdbp_ctx->mstore_ctx, context_id,
+								   username, current_fid, mapistore_url);
 			mapistore_del_context(emsmdbp_ctx->mstore_ctx, context_id);
 		}
 	}
@@ -565,7 +566,8 @@ FolderId: 0x67ca828f02000001      Display Name: "                        ";  Con
 
 			/* instantiate the new folder in the backend to make sure it is initialized properly */
 			retval = mapistore_add_context(emsmdbp_ctx->mstore_ctx, username, mapistore_url, current_fid, &context_id, &backend_object);
-			mapistore_indexing_record_add_fid(emsmdbp_ctx->mstore_ctx, context_id, username, current_fid);
+			mapistore_indexing_record_add_fmid_for_uri(emsmdbp_ctx->mstore_ctx, context_id,
+								   username, current_fid, mapistore_url);
 			mapistore_del_context(emsmdbp_ctx->mstore_ctx, context_id);
 
 			if (i == EMSMDBP_INBOX) {
@@ -623,7 +625,8 @@ FolderId: 0x67ca828f02000001      Display Name: "                        ";  Con
 
 			/* instantiate the new folder in the backend to make sure it is initialized properly */
 			retval = mapistore_add_context(emsmdbp_ctx->mstore_ctx, username, mapistore_url, current_fid, &context_id, &backend_object);
-			mapistore_indexing_record_add_fid(emsmdbp_ctx->mstore_ctx, context_id, username, current_fid);
+			mapistore_indexing_record_add_fmid_for_uri(emsmdbp_ctx->mstore_ctx, context_id,
+								   username, current_fid, mapistore_url);
 			mapistore_del_context(emsmdbp_ctx->mstore_ctx, context_id);
 
 			/* set entryid on mailbox and inbox */
@@ -694,7 +697,9 @@ FolderId: 0x67ca828f02000001      Display Name: "                        ";  Con
 
 				/* instantiate the new folder in the backend to make sure it is initialized properly */
 				retval = mapistore_add_context(emsmdbp_ctx->mstore_ctx, username, mapistore_url, current_fid, &context_id, &backend_object);
-				mapistore_indexing_record_add_fid(emsmdbp_ctx->mstore_ctx, context_id, username, current_fid);
+				mapistore_indexing_record_add_fmid_for_uri(emsmdbp_ctx->mstore_ctx,
+									   context_id, username,
+									   current_fid, mapistore_url);
 				mapistore_del_context(emsmdbp_ctx->mstore_ctx, context_id);
 			}
 			else {
@@ -731,7 +736,8 @@ FolderId: 0x67ca828f02000001      Display Name: "                        ";  Con
 
 			/* instantiate the new folder in the backend to make sure it is initialized properly */
 			mapistore_add_context(emsmdbp_ctx->mstore_ctx, username, mapistore_url, current_fid, &context_id, &backend_object);
-			mapistore_indexing_record_add_fid(emsmdbp_ctx->mstore_ctx, context_id, username, current_fid);
+			mapistore_indexing_record_add_fmid_for_uri(emsmdbp_ctx->mstore_ctx, context_id,
+								   username, current_fid, mapistore_url);
 			mapistore_properties_set_properties(emsmdbp_ctx->mstore_ctx, context_id, backend_object, &property_row);
 		}
 		else {


### PR DESCRIPTION
This gives the possibility to set an indexing record with
a given MAPIStore URI without asking the backend to get
this URI as it is already set by OpenChange level.

This specially applies to special folders on provisioning
but also on creation of MAPIStore root folders.