### PR TITLE
[nspi] Do not raise invalid bookmark error in addresses container withou...

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 * Fixed `Too many connections to ldap` when openchange runs on samba as member of a domain.
 * Fixed `Mark All as Read` feature regression bug introduced by 7737bdf6
 * Address book working much better than before
+* Fixed `Invalid bookmark` error when clicking on `All address lists` entry in recipient selection dialog box
 
 ### Improvements
 * More records returned when searching for ambiguous names.


### PR DESCRIPTION
...t purported search

The "All address list" container is meant to be only used as organizer and do not contains
the purportedSearch attribute.
This case was not take in account so it always gived a 'Invalid bookmark' error instead of
a empty list. This behaviour can be checked in Outlook selecting 'All address list' in the dropdown at
the 'Select names' dialog.

To take it in account the functions dcesrv_do_NspiQueryRows, emsabp_ab_container_enum and emsabp_ab_fetch_filter has been modified.

The functions dcesrv_NspiResolveNames and dcesrv_NspiResolveNamesW have been modified to take in account that emsabp_ab_fetch_filter can now return a NULL filter but they continue to return 'Invalid bookmark' if called on'All address list'. I have not changed them to return empty lists because I was not able to reproduce this situation with them. This two functions also need to be reviewed in the future.