### PR TITLE
Fix creation of root folders using CreateFolder ROP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 * Sharing request and invitation of folders among different Outlook versions
 
 ### Fixes
+* Fixed creation of root folders on online mode and some special folders such as Sync Issues.
 * Fixed `Too many connections to ldap` when openchange runs on samba as member of a domain.
 * Fixed `Mark All as Read` feature regression bug introduced by 7737bdf6
 * Address book working much better than before

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
@@ -330,7 +330,7 @@ const char **emsmdbp_get_special_folders(TALLOC_CTX *, struct emsmdbp_context *)
 
 /* With emsmdbp_object_create_folder and emsmdbp_object_open_folder, the parent object IS the direct parent */
 enum mapistore_error  emsmdbp_object_get_fid_by_name(struct emsmdbp_context *, struct emsmdbp_object *, const char *, uint64_t *);
-enum MAPISTATUS       emsmdbp_object_create_folder(struct emsmdbp_context *, struct emsmdbp_object *, TALLOC_CTX *, uint64_t, struct SRow *, struct emsmdbp_object **);
+enum MAPISTATUS       emsmdbp_object_create_folder(struct emsmdbp_context *, struct emsmdbp_object *, TALLOC_CTX *, uint64_t, struct SRow *, bool, struct emsmdbp_object **);
 enum mapistore_error  emsmdbp_object_open_folder(TALLOC_CTX *, struct emsmdbp_context *, struct emsmdbp_object *, uint64_t, struct emsmdbp_object **);
 enum MAPISTATUS       emsmdbp_object_open_folder_by_fid(TALLOC_CTX *, struct emsmdbp_context *, struct emsmdbp_object *, uint64_t, struct emsmdbp_object **);
 

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -308,21 +308,21 @@ static enum mapistore_error emsmdbp_object_folder_commit_creation(struct emsmdbp
 	value = get_SPropValue_SRow(new_folder->object.folder->postponed_props, PidTagChangeNumber);
 	retval = openchangedb_create_folder(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, parent_fid, fid, value->value.d, mapistore_uri, -1);
 	if (retval != MAPI_E_SUCCESS) {
-		if (retval == MAPI_E_COLLISION) {
-			ret = MAPISTORE_ERR_EXIST;
-		}
-		else {
-			ret = MAPISTORE_ERR_NOT_FOUND;
-		}
-		OC_DEBUG(0, "openchangedb folder creation failed: 0x%.8x\n", retval);
+		OC_DEBUG(0, "OpenChangeDB folder creation failed: %s\n", mapi_get_errstr(retval));
+		ret = mapi_error_to_mapistore(retval);
 		goto end;
 	}
 
-	new_folder->object.folder->contextID = context_id;
+	retval = openchangedb_set_folder_properties(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, fid, new_folder->object.folder->postponed_props);
+	if (retval != MAPI_E_SUCCESS) {
+		OC_DEBUG(0, "OpenChangeDB folder set properties failed: %s", mapi_get_errstr(retval));
+		ret = mapi_error_to_mapistore(retval);
+		goto end;
+	}
 
-	openchangedb_set_folder_properties(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, fid, new_folder->object.folder->postponed_props);
 	mapistore_indexing_record_add_fmid_for_uri(emsmdbp_ctx->mstore_ctx, context_id, owner, fid,
 						   mapistore_uri);
+
 	mapistore_properties_set_properties(emsmdbp_ctx->mstore_ctx, context_id, new_folder->backend_object, new_folder->object.folder->postponed_props);
 
 	talloc_unlink(new_folder, new_folder->object.folder->postponed_props);
@@ -336,7 +336,23 @@ end:
 	return ret;
 }
 
-_PUBLIC_ enum MAPISTATUS emsmdbp_object_create_folder(struct emsmdbp_context *emsmdbp_ctx, struct emsmdbp_object *parent_folder, TALLOC_CTX *mem_ctx, uint64_t fid, struct SRow *rowp, struct emsmdbp_object **new_folderp)
+
+/**
+   \details Create a folder
+
+   \param emsmdbp_ctx pointer to the emsmdbp context
+   \param parent_folder pointer to parent folder where to create the new folder
+   \param mem_ctx pointer to the memory context
+   \param fid Folder Identifier to assign the new folder object
+   \param rowp the properties to set to the new folder
+   \param force_container_class force the usage of Fallback role if we are
+          creating a mapistore root folder and the container class is not
+          available at rowp parameter
+   \param [out] new_folderp location to store new emsmdbp object on success
+
+   \return MAPISTATUS error code
+ */
+_PUBLIC_ enum MAPISTATUS emsmdbp_object_create_folder(struct emsmdbp_context *emsmdbp_ctx, struct emsmdbp_object *parent_folder, TALLOC_CTX *mem_ctx, uint64_t fid, struct SRow *rowp, bool force_container_class, struct emsmdbp_object **new_folderp)
 {
 	uint64_t			parentFolderID, testFolderID;
 	struct SPropValue		*value;
@@ -356,6 +372,7 @@ _PUBLIC_ enum MAPISTATUS emsmdbp_object_create_folder(struct emsmdbp_context *em
 			talloc_free(new_folder);
 			return mapistore_error_to_mapi(retval);
 		}
+		/* FIXME: Add indexing entry */
 	}
 	else {
 		parentFolderID = parent_folder->object.folder->folderID;
@@ -384,7 +401,7 @@ _PUBLIC_ enum MAPISTATUS emsmdbp_object_create_folder(struct emsmdbp_context *em
 			new_folder->object.folder->postponed_props = postponed_props;
 			new_folder->object.folder->mapistore_root = true;
 
-			retval = emsmdbp_object_folder_commit_creation(emsmdbp_ctx, new_folder, false);
+			retval = emsmdbp_object_folder_commit_creation(emsmdbp_ctx, new_folder, force_container_class);
 			if (retval != MAPISTORE_SUCCESS) {
 				talloc_free(new_folder);
 				return mapistore_error_to_mapi(retval);
@@ -1611,7 +1628,7 @@ _PUBLIC_ struct emsmdbp_object *emsmdbp_folder_open_table(TALLOC_CTX *mem_ctx,
 	if (parent_object->type == EMSMDBP_OBJECT_FOLDER && parent_object->object.folder->postponed_props) {
 		ret = emsmdbp_object_folder_commit_creation(parent_object->emsmdbp_ctx, parent_object, true);
 		if (ret != MAPISTORE_SUCCESS) {
-			OC_DEBUG(0, "folder_commit_creatin failed with error: 0x%.8X", ret);
+			OC_DEBUG(0, "folder_commit_creation failed with error: 0x%.8X", ret);
 			return NULL;
 		}
 	}
@@ -3083,15 +3100,93 @@ end:
         return data_pointers;
 }
 
+/* Delete a mapistore root folder, create again with new role and
+   update the mapistoreURI in OpenChange DB */
+static enum mapistore_error emsmdbp_object_root_mapistore_folder_set(struct emsmdbp_context *emsmdbp_ctx, struct emsmdbp_object *folder, struct SRow *rowp, const char *container_class)
+{
+	char				*mapistore_uri;
+	char				*folder_name, *owner;
+	enum MAPISTATUS			retval;
+	enum mapistore_context_role	role;
+	enum mapistore_error		ret;
+	TALLOC_CTX			*local_mem_ctx;
+	uint32_t			context_id, deleted_fmids_count;
+	uint64_t			fid, *deleted_fmids;
+
+	/* Sanity checks */
+	MAPISTORE_RETVAL_IF(!emsmdbp_ctx, MAPISTORE_ERR_INVALID_PARAMETER, NULL);
+	MAPISTORE_RETVAL_IF(!folder, MAPISTORE_ERR_INVALID_PARAMETER, NULL);
+	MAPISTORE_RETVAL_IF(!rowp, MAPISTORE_ERR_INVALID_PARAMETER, NULL);
+	MAPISTORE_RETVAL_IF(!container_class, MAPISTORE_ERR_INVALID_PARAMETER, NULL);
+
+	local_mem_ctx = talloc_new(NULL);
+	MAPISTORE_RETVAL_IF(!local_mem_ctx, MAPISTORE_ERR_NO_MEMORY, NULL);
+
+	/* 1. Delete current mapistore folder */
+	context_id = emsmdbp_get_contextID(folder);
+	owner = emsmdbp_get_owner(folder);
+	ret = mapistore_folder_delete(emsmdbp_ctx->mstore_ctx, context_id,
+				      folder->backend_object, DELETE_HARD_DELETE,
+				      local_mem_ctx, &deleted_fmids, &deleted_fmids_count);
+	if (ret == MAPISTORE_ERR_EXIST) {
+		/* Known limitation */
+		OC_DEBUG(1, "There are messages or subfolders while changing the role of a mapistore root folder which is unsupported");
+	}
+	MAPISTORE_RETVAL_IF(ret != MAPISTORE_SUCCESS, ret, local_mem_ctx);
+
+	ret = mapistore_indexing_record_del_fid(emsmdbp_ctx->mstore_ctx, context_id,
+						owner, folder->object.folder->folderID,
+						MAPISTORE_PERMANENT_DELETE);
+	MAPISTORE_RETVAL_IF(ret != MAPISTORE_SUCCESS, ret, local_mem_ctx);
+
+	/* 2. Create the mapistore folder with the new role */
+	role = emsmdbp_container_class_to_role(container_class);
+
+	fid = folder->object.folder->folderID;
+
+	retval = openchangedb_get_folder_property(local_mem_ctx, emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username,
+						  PR_DISPLAY_NAME, fid, (void **)&folder_name);
+	MAPISTORE_RETVAL_IF(retval != MAPI_E_SUCCESS, MAPISTORE_ERROR, local_mem_ctx);
+
+	/* 3. Create mapistore root folder */
+	ret = mapistore_create_root_folder(owner, role, fid, folder_name, local_mem_ctx, &mapistore_uri);
+	MAPISTORE_RETVAL_IF(ret != MAPISTORE_SUCCESS, ret, local_mem_ctx);
+
+	ret = mapistore_add_context(emsmdbp_ctx->mstore_ctx, owner, mapistore_uri, fid, &context_id, &folder->backend_object);
+	if (ret != MAPISTORE_SUCCESS) {
+		OC_PANIC(false,
+			 ("mapistore_add_context() failed with 0x%.8x, mapistore_uri = [%s].\n",
+			  ret, mapistore_uri));
+		goto end;
+	}
+	folder->object.folder->contextID = context_id;
+
+	/* 4. Set the new MAPIStore URI in OpenChangeDB */
+	retval = openchangedb_set_mapistoreURI(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, fid, mapistore_uri);
+	MAPISTORE_RETVAL_IF(retval != MAPI_E_SUCCESS, MAPISTORE_ERROR, local_mem_ctx);
+
+	/* 5. Set indexing */
+	ret = mapistore_indexing_record_add_fmid_for_uri(emsmdbp_ctx->mstore_ctx, context_id, owner, fid,
+							 mapistore_uri);
+	MAPISTORE_RETVAL_IF(ret != MAPISTORE_SUCCESS, ret, local_mem_ctx);
+
+end:
+	talloc_free(local_mem_ctx);
+	return ret;
+}
+
 /* TODO: handling of "property problems" */
 _PUBLIC_ int emsmdbp_object_set_properties(struct emsmdbp_context *emsmdbp_ctx, struct emsmdbp_object *object, struct SRow *rowp)
 {
 	TALLOC_CTX		*mem_ctx;
 	uint32_t		contextID, new_cvalues;
+	char			*db_container_class;
 	char			*mapistore_uri, *new_uri;
 	size_t			mapistore_uri_len, new_uri_len;
 	bool			mapistore;
+	enum MAPISTATUS		retval;
 	enum mapistore_error	ret;
+	struct SPropValue	*container_class;
 	struct SRow		*postponed_props;
 	bool			soft_deleted;
 
@@ -3134,8 +3229,39 @@ _PUBLIC_ int emsmdbp_object_set_properties(struct emsmdbp_context *emsmdbp_ctx, 
 		mem_ctx = talloc_new(NULL);
 		OPENCHANGE_RETVAL_IF(!mem_ctx, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
 
+		/* Check if we have to change the type of MAPIStore folder
+		   as now we have a container class or it has changed.
+		   This is happening when CreateFolder + SetProps ROPs are done */
+		retval = openchangedb_get_folder_property(mem_ctx, emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username,
+							  PR_CONTAINER_CLASS_UNICODE, object->object.folder->folderID,
+							  (void **)&db_container_class);
+		if (retval == MAPI_E_NOT_FOUND) {
+			retval = openchangedb_get_folder_property(mem_ctx, emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username,
+								  PR_CONTAINER_CLASS, object->object.folder->folderID,
+								  (void **)&db_container_class);
+		}
+		container_class = get_SPropValue_SRow(rowp, PR_CONTAINER_CLASS_UNICODE);
+		if (!container_class) {
+			/* Sometimes Outlook does pass non-unicode values. */
+			container_class = get_SPropValue_SRow(rowp, PR_CONTAINER_CLASS);
+		}
+
+		if (container_class
+		    && (retval == MAPI_E_NOT_FOUND
+                        || strncmp(db_container_class, container_class->value.lpszW, strlen(db_container_class)) != 0)) {
+			/* Replace the MAPIStore folder now we have a role to set for it */
+			ret = emsmdbp_object_root_mapistore_folder_set(emsmdbp_ctx, object, rowp, container_class->value.lpszW);
+			/* MAPISTORE_ERR_EXIST happens when the folder was set with the right role in the
+			   provisioning code so we have to let the current flow work. This happens with
+			   special folders such as INBOX, Sent, Personal Calendar, RSS Feeds, Conversation
+			   Action Settings, etc... */
+			OPENCHANGE_RETVAL_IF(ret != MAPISTORE_SUCCESS && ret != MAPISTORE_ERR_EXIST,
+					     mapistore_error_to_mapi(ret), mem_ctx);
+		}
+
 		mapistore_uri = NULL;
 		openchangedb_get_mapistoreURI(mem_ctx, emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, object->object.folder->folderID, &mapistore_uri, true);
+
 		openchangedb_set_folder_properties(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, object->object.folder->folderID, rowp);
 		contextID = emsmdbp_get_contextID(object);
 		mapistore_properties_set_properties(emsmdbp_ctx->mstore_ctx, contextID, object->backend_object, rowp);

--- a/mapiproxy/servers/default/emsmdb/oxcfold.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfold.c
@@ -428,6 +428,11 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopCreateFolder(TALLOC_CTX *mem_ctx,
 	if (ret == MAPISTORE_SUCCESS) {
 		if (request->ulFlags != OPEN_IF_EXISTS) {
 			mapi_repl->error_code = MAPI_E_COLLISION;
+			if (emsmdbp_is_mapistore(parent_object)) {
+				OC_DEBUG(5, "Folder %s exists in MAPIStore", request->FolderName.lpszW);
+			} else {
+				OC_DEBUG(5, "Folder %s exists in OpenChangeDB", request->FolderName.lpszW);
+			}
 			goto end;
 		}
 		response->IsExistingFolder = true;
@@ -469,7 +474,8 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopCreateFolder(TALLOC_CTX *mem_ctx,
 		cnValue.value.d = cn;
 		SRow_addprop(aRow, cnValue);
 
-		retval = emsmdbp_object_create_folder(emsmdbp_ctx, parent_object, rec, fid, aRow, &object);
+		retval = emsmdbp_object_create_folder(emsmdbp_ctx, parent_object, rec, fid,
+						      aRow, true, &object);
 		if (retval != MAPI_E_SUCCESS) {
 			OC_DEBUG(5, "folder creation failed\n");
 			mapi_handles_delete(emsmdbp_ctx->handles_ctx, rec->handle);

--- a/mapiproxy/servers/default/emsmdb/oxcfxics.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfxics.c
@@ -2379,7 +2379,8 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncImportHierarchyChange(TALLOC_CTX *mem_ct
 		aRow.lpProps[aRow.cValues].ulPropTag = PidTagChangeNumber;
 		aRow.lpProps[aRow.cValues].value.d = cn;
 		aRow.cValues++;
-		retval = emsmdbp_object_create_folder(emsmdbp_ctx, parent_folder, NULL, folderID, &aRow, &folder_object);
+		retval = emsmdbp_object_create_folder(emsmdbp_ctx, parent_folder, NULL,
+						      folderID, &aRow, false, &folder_object);
 		if (retval) {
 			mapi_repl->error_code = retval;
 			OC_DEBUG(5, "folder creation failed\n");

--- a/utils/mapitest/module.c
+++ b/utils/mapitest/module.c
@@ -95,6 +95,7 @@ _PUBLIC_ uint32_t module_oxcfold_init(struct mapitest *mt)
 	mapitest_suite_add_test(suite, "CREATE", "Create a folder", mapitest_oxcfold_CreateFolder);
 	mapitest_suite_add_test(suite, "CREATE-VARIANTS", "More folder creation variations", mapitest_oxcfold_CreateFolderVariants);
 	mapitest_suite_add_test(suite, "DELETE-VARIANTS", "More folder deletion variations", mapitest_oxcfold_DeleteFolderVariants);
+	mapitest_suite_add_test(suite, "CREATE-SIMPLE", "Simple folder creation", mapitest_oxcfold_CreateDeleteSimpleFolder);
 	mapitest_suite_add_test(suite, "GET-HIERARCHY-TABLE", "Retrieve the hierarchy table", mapitest_oxcfold_GetHierarchyTable);
 	mapitest_suite_add_test(suite, "GET-CONTENTS-TABLE", "Retrieve the contents table", mapitest_oxcfold_GetContentsTable);
 	mapitest_suite_add_test(suite, "SET-SEARCHCRITERIA", "Set a search criteria on a container", mapitest_oxcfold_SetSearchCriteria);

--- a/utils/mapitest/modules/module_oxcfold.c
+++ b/utils/mapitest/modules/module_oxcfold.c
@@ -1818,3 +1818,115 @@ cleanup:
 
 	return ret;
 }
+
+/**
+    \details Test the CreateFolder (0x1C) operation along with
+    DeleteFolder (0x1D) and SetProps (0x0A)
+
+    This function:
+	-# Log on the user private mailbox
+	-# Open the top information store folder
+	-# Create a test folder
+	-# Check the PidTagContainerClass property value (It shouldn't exist)
+	-# Set properties to this folder to change the PidTagContainerClass
+	-# Delete this folder
+	-# Check the folder has dissappeared
+
+    \param mt pointer to the top level mapitest structure
+
+    \return true on success, otherwise false
+*/
+_PUBLIC_ bool mapitest_oxcfold_CreateDeleteSimpleFolder(struct mapitest *mt)
+{
+	bool			test_result = true;
+	enum MAPISTATUS		retval;
+	mapi_id_t		id_folder;
+	mapi_object_t		obj_tis_folder, obj_folder, obj_store;
+	struct SPropTagArray	*sPropTagArray;
+	struct SPropValue	lpProp[1], *lpProps;
+	uint32_t		cValues = 0;
+
+	mapi_object_init(&obj_store);
+	mapi_object_init(&obj_tis_folder);
+
+	/* Step 1. Logon */
+	retval = OpenMsgStore(mt->session, &obj_store);
+	mapitest_print_retval(mt, "OpenMsgStore");
+	if (GetLastError() != MAPI_E_SUCCESS) {
+		test_result = false;
+		goto cleanup;
+	}
+
+	/* Step 2. Open Top Information Store folder */
+	retval = GetDefaultFolder(&obj_store, &id_folder, olFolderTopInformationStore);
+	mapitest_print_retval(mt, "GetDefaultFolder");
+	if (GetLastError() != MAPI_E_SUCCESS) {
+		test_result = false;
+		goto cleanup;
+	}
+
+	retval = OpenFolder(&obj_store, id_folder, &obj_tis_folder);
+	mapitest_print_retval(mt, "OpenFolder");
+	if (GetLastError() != MAPI_E_SUCCESS) {
+		test_result = false;
+		goto cleanup;
+	}
+
+	/* Step 3. Create the test folder */
+	mapi_object_init(&obj_folder);
+	mapitest_print(mt, "* Create GENERIC \"%s\" folder\n", MT_DIRNAME_TOP);
+	retval = CreateFolder(&obj_tis_folder, FOLDER_GENERIC, MT_DIRNAME_TOP, NULL,
+			      NONE, &obj_folder);
+	mapitest_print_retval_clean(mt, "CreateFolder", retval);
+	if (retval != MAPI_E_SUCCESS) {
+		test_result = false;
+		mapi_object_release(&obj_folder);
+		goto cleanup;
+	}
+
+	/* Step 4.1 Get PidTagContainerClass property from the test folder */
+	sPropTagArray = set_SPropTagArray(mt->mem_ctx, 0x1, PR_CONTAINER_CLASS);
+	retval = GetProps(&obj_folder, 0, sPropTagArray, &lpProps, &cValues);
+	if (cValues && (lpProps->ulPropTag & 0xFFFF) != PT_ERROR) {
+		mapitest_print(mt, "* GetProps Container Class = %s\n", get_SPropValue_data(&lpProps[0]));
+		test_result = false;
+	} else {
+		mapitest_print(mt, "* GetProps no container class set yet\n");
+	}
+
+	/* Step 4.2 Set properties to the test folder */
+	set_SPropValue_proptag(&lpProp[0], PR_CONTAINER_CLASS, (const void *) IPF_NOTE);
+	retval = SetProps(&obj_folder, 0, lpProp, 1);
+	mapitest_print_retval_fmt(mt, "SetProps", "(%s)", MT_DIRNAME_TOP);
+	if (retval != MAPI_E_SUCCESS) {
+		test_result = false;
+	}
+
+	/* Step 5. Delete the test folder */
+	retval = DeleteFolder(&obj_tis_folder, mapi_object_get_id(&obj_folder),
+			      DEL_MESSAGES|DEL_FOLDERS|DELETE_HARD_DELETE, NULL);
+	mapitest_print_retval(mt, "DeleteFolder");
+	if (retval != MAPI_E_SUCCESS) {
+		test_result = false;
+		mapi_object_release(&obj_folder);
+		goto cleanup;
+	}
+
+	/* Step 6: Check the folder has dissappeared */
+	retval = DeleteFolder(&obj_tis_folder, mapi_object_get_id(&obj_folder),
+			      DEL_MESSAGES|DEL_FOLDERS|DELETE_HARD_DELETE, NULL);
+	mapitest_print_retval(mt, "DeleteFolder");
+	/* Exchange 2010 returns SUCCESS instead of NOT_FOUND... */
+	if (retval != MAPI_E_NOT_FOUND && retval != MAPI_E_SUCCESS) {
+		test_result = false;
+	}
+
+	mapi_object_release(&obj_folder);
+
+cleanup:
+	/* Release */
+	mapi_object_release(&obj_tis_folder);
+	mapi_object_release(&obj_store);
+
+	return test_result;
+}


### PR DESCRIPTION
This happens on online mode and on the creation of special
folders such Sync Issues during first logon.

The implementation does the following:

* Create the folder using Fallback role (as we don't have more information)
* Replace the folder with the correct role once the first
  SetProps operation is done

We have added a new mapitest to test this specific path implemented
during first logon by Outlook.

This also fixes other mapitests from OXCFOLD testsuite. See the current status:

```
[STAT] FAILED TEST CASES
        * OXCFOLD                            : OXCFOLD-MOVECOPY-MESSAGES (Unexpected Fail)
        * OXCFOLD                            : OXCFOLD-HARDDELETEMESSAGES (Unexpected Fail)
        * OXCFOLD                            : OXCFOLD-HARDDELETEMESSAGESANDSUBFOLDERS (Unexpected Fail)
------------------------------------------------------------------------
[STAT] TEST SUMMARY
        Number of passing tests: 12
        Number of failing tests: 3
```

This requires the following PR to work:

* #272
* #273