### PR TITLE
Ignore Memcached errors and fall back to MySQL

### DIFF
--- a/mapiproxy/libmapistore/backends/indexing_mysql.c
+++ b/mapiproxy/libmapistore/backends/indexing_mysql.c
@@ -598,9 +598,9 @@ static enum mapistore_error mysql_record_del(struct indexing_context *ictx,
 	}
 
 	retval = mysql_record_get_uri(ictx, username, mem_ctx, fmid, &uri, &IsSoftDeleted);
-	MAPISTORE_RETVAL_IF(retval, retval, mem_ctx);
+	MAPISTORE_RETVAL_IF(retval != MAPISTORE_SUCCESS, retval, mem_ctx);
 
-	execute_query(MYSQL(ictx), sql);
+	ret = execute_query(MYSQL(ictx), sql);
 	MAPISTORE_RETVAL_IF(ret != MYSQL_SUCCESS, MAPISTORE_ERR_DATABASE_OPS, mem_ctx);
 
 	retval = _memcached_delete_record(ictx, uri);

--- a/mapiproxy/libmapistore/backends/indexing_mysql.c
+++ b/mapiproxy/libmapistore/backends/indexing_mysql.c
@@ -387,7 +387,7 @@ static enum mapistore_error mysql_record_add(struct indexing_context *ictx,
 					   uint64_t fmid,
 					   const char *mapistore_URI)
 {
-	enum mapistore_error	retval = MAPISTORE_SUCCESS;
+	enum mapistore_error	retval;
 	TALLOC_CTX		*mem_ctx;
 	int			ret;
 	bool			IsSoftDeleted = false;
@@ -415,9 +415,13 @@ static enum mapistore_error mysql_record_add(struct indexing_context *ictx,
 	MAPISTORE_RETVAL_IF(ret != MYSQL_SUCCESS, MAPISTORE_ERR_DATABASE_OPS, mem_ctx);
 
 	retval = _memcached_add_record(ictx, mapistore_URI, fmid);
+	if (retval != MAPISTORE_SUCCESS) {
+		OC_DEBUG(0, "[indexing] Failed to add record `%s: %"PRIu64"` on memcached (%s)",
+			 mapistore_URI, fmid, mapistore_errstr(retval));
+	}
 
 	talloc_free(mem_ctx);
-	return retval;
+	return MAPISTORE_SUCCESS;
 }
 
 /**
@@ -439,7 +443,7 @@ static enum mapistore_error mysql_record_update(struct indexing_context *ictx,
 						uint64_t fmid,
 						const char *mapistore_URI)
 {
-	enum mapistore_error	retval = MAPISTORE_SUCCESS;
+	enum mapistore_error	retval;
 	int			ret;
 	char			*sql;
 	TALLOC_CTX		*mem_ctx;
@@ -463,19 +467,18 @@ static enum mapistore_error mysql_record_update(struct indexing_context *ictx,
 	ret = execute_query(MYSQL(ictx), sql);
 	MAPISTORE_RETVAL_IF(ret != MYSQL_SUCCESS, MAPISTORE_ERR_DATABASE_OPS, mem_ctx);
 
-
 	/* did we updated anything? */
 	/* TODO: Move mysql_affected_rows() in execute_query() */
-	if (mysql_affected_rows(MYSQL(ictx)) == 0) {
-		retval = MAPISTORE_ERR_NOT_FOUND;
-		goto end;
-	}
+	MAPISTORE_RETVAL_IF(mysql_affected_rows(MYSQL(ictx)) == 0, MAPISTORE_ERR_NOT_FOUND, mem_ctx);
 
 	retval = _memcached_update_record(ictx, mapistore_URI, fmid);
+	if (retval != MAPISTORE_SUCCESS) {
+		OC_DEBUG(0, "[indexing] Failed to update record `%s` with `%"PRIu64"` on memcached (%s)",
+			 mapistore_URI, fmid, mapistore_errstr(retval));
+	}
 
-end:
 	talloc_free(mem_ctx);
-	return retval;
+	return MAPISTORE_SUCCESS;
 }
 
 
@@ -601,7 +604,10 @@ static enum mapistore_error mysql_record_del(struct indexing_context *ictx,
 	MAPISTORE_RETVAL_IF(ret != MYSQL_SUCCESS, MAPISTORE_ERR_DATABASE_OPS, mem_ctx);
 
 	retval = _memcached_delete_record(ictx, uri);
-	MAPISTORE_RETVAL_IF(retval, retval, mem_ctx);
+	if (retval != MAPISTORE_SUCCESS) {
+		OC_DEBUG(0, "[indexing] Failed to delete record `%s` on memcached (%s)",
+			 uri, mapistore_errstr(retval));
+	}
 
 	talloc_free(mem_ctx);
 	return MAPISTORE_SUCCESS;


### PR DESCRIPTION
* Assume Memcached keys can be missing (falling back to MySQL in that case) instead of relying on them.
* Include a cleanup of Memcached in the user cleanup script. This will flush the Memcached keys of other users that are logged in, but this won't cause OpenChange crash anymore.

The code in this PR is by @blaxter, excepting a couple minor corrections in some parentheses to fit the `OC_DEBUG` macro and a return value.