### PR TITLE
Reuse a folder as special folder if one already exists on Logon

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 * Sharing request and invitation of folders among different Outlook versions
 
 ### Fixes
+* No more `Deleted Items (1)`-like duplicated folders
 * Fixed creation of root folders on online mode and some special folders such as Sync Issues.
 * Fixed `Too many connections to ldap` when openchange runs on samba as member of a domain.
 * Fixed `Mark All as Read` feature regression bug introduced by 7737bdf6

--- a/mapiproxy/libmapiproxy/backends/openchangedb_backends.h
+++ b/mapiproxy/libmapiproxy/backends/openchangedb_backends.h
@@ -52,6 +52,7 @@ struct openchangedb_context {
 	enum MAPISTATUS (*get_folder_count)(struct openchangedb_context *, const char *, uint64_t, uint32_t *);
 	enum MAPISTATUS (*get_message_count)(struct openchangedb_context *, const char *, uint64_t, uint32_t *, bool);
 	enum MAPISTATUS (*get_system_idx)(struct openchangedb_context *, const char *, uint64_t, int *);
+	enum MAPISTATUS (*set_system_idx)(struct openchangedb_context *, const char *, uint64_t, int);
 	enum MAPISTATUS (*get_table_property)(TALLOC_CTX *, struct openchangedb_context *, const char *, uint32_t, uint32_t, void **);
 	enum MAPISTATUS (*get_fid_by_name)(struct openchangedb_context *, const char *, uint64_t, const char*, uint64_t *);
 	enum MAPISTATUS (*get_mid_by_subject)(struct openchangedb_context *, const char *, uint64_t, const char *, bool, uint64_t *);

--- a/mapiproxy/libmapiproxy/backends/openchangedb_logger.c
+++ b/mapiproxy/libmapiproxy/backends/openchangedb_logger.c
@@ -558,6 +558,23 @@ static enum MAPISTATUS get_system_idx(struct openchangedb_context *self,
 	OC_DEBUG(priv_data->log_level, "%s[in]: username=[%s]",
 					priv_data->log_prefix, username);
 	retval = priv_data->backend->get_system_idx(priv_data->backend, username, fid, system_idx_p);
+	OC_DEBUG(priv_data->log_level, "%s[out]: retval=[%s], system_idx=[%d]",
+		 priv_data->log_prefix, mapi_get_errstr(retval),
+		 retval == MAPI_E_SUCCESS ? *system_idx_p : -1);
+
+	return retval;
+}
+
+static enum MAPISTATUS set_system_idx(struct openchangedb_context *self,
+				      const char *username, uint64_t fid,
+				      int system_idx)
+{
+	enum MAPISTATUS retval;
+	struct ocdb_logger_data *priv_data = _ocdb_logger_data_get(self);
+
+	OC_DEBUG(priv_data->log_level, "%s[in]: username=[%s] system_idx=[%d]",
+		 priv_data->log_prefix, username, system_idx);
+	retval = priv_data->backend->set_system_idx(priv_data->backend, username, fid, system_idx);
 	OC_DEBUG(priv_data->log_level, "%s[out]: retval=[%s]",
 					priv_data->log_prefix, mapi_get_errstr(retval));
 
@@ -839,6 +856,7 @@ _PUBLIC_ enum MAPISTATUS openchangedb_logger_initialize(TALLOC_CTX *mem_ctx,
 	oc_ctx->get_folder_count = get_folder_count;
 	oc_ctx->get_message_count = get_message_count;
 	oc_ctx->get_system_idx = get_system_idx;
+	oc_ctx->set_system_idx = set_system_idx;
 	oc_ctx->get_table_property = get_table_property;
 	oc_ctx->get_fid_by_name = get_fid_by_name;
 	oc_ctx->get_mid_by_subject = get_mid_by_subject;

--- a/mapiproxy/libmapiproxy/backends/openchangedb_mysql.c
+++ b/mapiproxy/libmapiproxy/backends/openchangedb_mysql.c
@@ -2048,6 +2048,37 @@ static enum MAPISTATUS get_system_idx(struct openchangedb_context *self,
 	return retval;
 }
 
+static enum MAPISTATUS set_system_idx(struct openchangedb_context *self,
+				      const char *username, uint64_t fid,
+				      int system_idx)
+{
+	TALLOC_CTX	*mem_ctx;
+	MYSQL		*conn;
+	enum MAPISTATUS	retval;
+	char		*sql;
+
+	mem_ctx = talloc_named(NULL, 0, "set_system_idx");
+	OPENCHANGE_RETVAL_IF(!mem_ctx, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
+	conn = self->data;
+	OPENCHANGE_RETVAL_IF(!conn, MAPI_E_BAD_VALUE, mem_ctx);
+
+	sql = talloc_asprintf(mem_ctx,
+		"UPDATE folders f "
+		"JOIN mailboxes m ON m.id = f.mailbox_id AND m.name = '%s' "
+		"SET f.SystemIdx = %d "
+		"WHERE f.folder_id = %"PRIu64,
+		_sql(mem_ctx, username), system_idx, fid);
+	OPENCHANGE_RETVAL_IF(!sql, MAPI_E_NOT_ENOUGH_MEMORY, mem_ctx);
+
+	retval = status(execute_query(conn, sql));
+	if (mysql_affected_rows(conn) == 0) {
+		retval = MAPI_E_NOT_FOUND;
+	}
+
+	talloc_free(mem_ctx);
+	return retval;
+}
+
 static enum MAPISTATUS transaction_start(struct openchangedb_context *self)
 {
 	MYSQL	*conn;
@@ -3727,6 +3758,7 @@ enum MAPISTATUS openchangedb_mysql_initialize(TALLOC_CTX *mem_ctx,
 	oc_ctx->get_folder_count = get_folder_count;
 	oc_ctx->get_message_count = get_message_count;
 	oc_ctx->get_system_idx = get_system_idx;
+	oc_ctx->set_system_idx = set_system_idx;
 	oc_ctx->get_table_property = get_table_property;
 	oc_ctx->get_fid_by_name = get_fid_by_name;
 	oc_ctx->get_mid_by_subject = get_mid_by_subject;

--- a/mapiproxy/libmapiproxy/libmapiproxy.h
+++ b/mapiproxy/libmapiproxy/libmapiproxy.h
@@ -224,6 +224,7 @@ enum MAPISTATUS openchangedb_get_folder_property(TALLOC_CTX *, struct openchange
 enum MAPISTATUS openchangedb_get_folder_count(struct openchangedb_context *, const char *, uint64_t, uint32_t *);
 enum MAPISTATUS openchangedb_get_message_count(struct openchangedb_context *, const char *, uint64_t, uint32_t *, bool);
 enum MAPISTATUS openchangedb_get_system_idx(struct openchangedb_context *, const char *, uint64_t, int *);
+enum MAPISTATUS openchangedb_set_system_idx(struct openchangedb_context*, const char *, uint64_t, int);
 enum MAPISTATUS openchangedb_get_table_property(TALLOC_CTX *, struct openchangedb_context *, const char *, uint32_t, uint32_t, void **);
 enum MAPISTATUS openchangedb_get_fid_by_name(struct openchangedb_context *, const char *, uint64_t, const char*, uint64_t *);
 enum MAPISTATUS openchangedb_get_mid_by_subject(struct openchangedb_context *, const char *, uint64_t, const char *, bool, uint64_t *);

--- a/mapiproxy/libmapiproxy/openchangedb.c
+++ b/mapiproxy/libmapiproxy/openchangedb.c
@@ -282,6 +282,29 @@ _PUBLIC_ enum MAPISTATUS openchangedb_set_mapistoreURI(struct openchangedb_conte
 }
 
 /**
+   \details Store the system index associated to a mailbox system folder.
+
+   \param oc_ctx pointer to the openchange DB context
+   \param username current user
+   \param fid the Folder identifier to search for
+   \param system_idx the system index
+
+   \return MAPI_E_SUCCESS on success, otherwise MAPI error
+ */
+_PUBLIC_ enum MAPISTATUS openchangedb_set_system_idx(struct openchangedb_context *oc_ctx,
+                                                     const char *username,
+                                                     uint64_t fid,
+                                                     int system_idx)
+{
+	OPENCHANGE_RETVAL_IF(!oc_ctx, MAPI_E_NOT_INITIALIZED, NULL);
+	OPENCHANGE_RETVAL_IF(!username, MAPI_E_INVALID_PARAMETER, NULL);
+	OPENCHANGE_RETVAL_IF(!fid, MAPI_E_INVALID_PARAMETER, NULL);
+	OPENCHANGE_RETVAL_IF(system_idx < -1, MAPI_E_INVALID_PARAMETER, NULL);
+
+	return oc_ctx->set_system_idx(oc_ctx, username, fid, system_idx);
+}
+
+/**
    \details Retrieve the parent fid associated to a mailbox system
    folder.
 

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_provisioning.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_provisioning.c
@@ -520,8 +520,6 @@ FolderId: 0x67ca828f02000001      Display Name: "                        ";  Con
 				inbox_fid = current_fid;
 			}
 		} else {
-			mapistore_indexing_get_new_folderID_as_user(emsmdbp_ctx->mstore_ctx, username, &current_fid);
-			openchangedb_get_new_changeNumber(emsmdbp_ctx->oc_ctx, username, &current_cn);
 			current_name = folder_names[i];
 
 			switch (i) {
@@ -552,15 +550,43 @@ FolderId: 0x67ca828f02000001      Display Name: "                        ";  Con
 				mapistore_url = talloc_asprintf(mem_ctx, "%s0x%"PRIx64"/", fallback_url, current_fid);
 			}
 
-			/* Ensure the name is unique */
-			base_name = current_name;
-			j = 1;
-			while (openchangedb_get_fid_by_name(emsmdbp_ctx->oc_ctx, username, ipm_fid, current_name, &found_fid) == MAPI_E_SUCCESS) {
-				current_name = talloc_asprintf(mem_ctx, "%s (%d)", base_name, j);
-				j++;
+			/* According to [MS-OXOSFLD] Section 3.1.4.1, the special folder must be reused
+			   if one already exists by that name */
+			ret = openchangedb_get_fid_by_name(emsmdbp_ctx->oc_ctx, username, ipm_fid, current_name, &found_fid);
+			if (ret == MAPI_E_NOT_FOUND) {
+				retval = mapistore_indexing_get_new_folderID_as_user(emsmdbp_ctx->mstore_ctx, username, &current_fid);
+				if (retval != MAPISTORE_SUCCESS) {
+					OC_DEBUG(1, "Error getting new folder id: %s", mapistore_errstr(retval));
+					goto error;
+				}
+				ret = openchangedb_get_new_changeNumber(emsmdbp_ctx->oc_ctx, username, &current_cn);
+				if (ret != MAPI_E_SUCCESS) {
+					OC_DEBUG(1, "Error getting new change number: %s", mapi_get_errstr(ret));
+					goto error;
+				}
+				ret = openchangedb_create_folder(emsmdbp_ctx->oc_ctx, username, ipm_fid, current_fid, current_cn, mapistore_url, i);
+				if (ret != MAPI_E_SUCCESS) {
+					OC_DEBUG(1, "Error creating OpenChangeDB folder: %s", mapi_get_errstr(ret));
+					goto error;
+				}
+			} else if (ret == MAPI_E_SUCCESS) {
+				current_fid = found_fid;
+				ret = openchangedb_set_mapistoreURI(emsmdbp_ctx->oc_ctx, username, current_fid, mapistore_url);
+				if (ret != MAPI_E_SUCCESS) {
+					OC_DEBUG(1, "Error setting new MAPIStore URI %s: %s", mapistore_url, mapi_get_errstr(ret));
+					goto error;
+				}
+				ret = openchangedb_set_system_idx(emsmdbp_ctx->oc_ctx, username, current_fid, i);
+				if (ret != MAPI_E_SUCCESS) {
+					OC_DEBUG(1, "Error setting new system index %d: %s", i, mapi_get_errstr(ret));
+					goto error;
+				}
+				/* change number is updated by set_folder_properties */
+			} else {
+				OC_DEBUG(1, "Error trying to get fid by name (%s): %s", current_name, mapi_get_errstr(ret));
+				goto error;
 			}
 
-			openchangedb_create_folder(emsmdbp_ctx->oc_ctx, username, ipm_fid, current_fid, current_cn, mapistore_url, i);
 			property_row.lpProps[0].value.lpszW = current_name;
 			openchangedb_set_folder_properties(emsmdbp_ctx->oc_ctx, username, current_fid, &property_row);
 
@@ -595,9 +621,6 @@ FolderId: 0x67ca828f02000001      Display Name: "                        ";  Con
 			property_row.cValues = 2;
 			property_row.lpProps[0].ulPropTag = PR_DISPLAY_NAME_UNICODE;
 
-			mapistore_indexing_get_new_folderID_as_user(emsmdbp_ctx->mstore_ctx, username, &current_fid);
-			openchangedb_get_new_changeNumber(emsmdbp_ctx->oc_ctx, username, &current_cn);
-
 			current_name = current_folder->name;
 			current_entry = main_entries[current_folder->role];
 			if (current_entry) {
@@ -610,17 +633,45 @@ FolderId: 0x67ca828f02000001      Display Name: "                        ";  Con
 				mapistore_url = talloc_asprintf(mem_ctx, "%s0x%"PRIx64"/", fallback_url, current_fid);
 			}
 
-			/* Ensure the name is unique */
-			base_name = current_name;
-			j = 1;
-			while (openchangedb_get_fid_by_name(emsmdbp_ctx->oc_ctx, username, ipm_fid, current_name, &found_fid) == MAPI_E_SUCCESS) {
-				current_name = talloc_asprintf(mem_ctx, "%s (%d)", base_name, j);
-				j++;
+			/* According to [MS-OXOSFLD] Section 3.1.4.1, the special folder must be reused
+			   if one already exists by that name */
+			ret = openchangedb_get_fid_by_name(emsmdbp_ctx->oc_ctx, username, ipm_fid, current_name, &found_fid);
+			if (ret == MAPI_E_NOT_FOUND) {
+				retval = mapistore_indexing_get_new_folderID_as_user(emsmdbp_ctx->mstore_ctx, username, &current_fid);
+				if (retval != MAPISTORE_SUCCESS) {
+					OC_DEBUG(1, "Error getting new folder id: %s", mapistore_errstr(retval));
+					goto error;
+				}
+				ret = openchangedb_get_new_changeNumber(emsmdbp_ctx->oc_ctx, username, &current_cn);
+				if (ret != MAPI_E_SUCCESS) {
+					OC_DEBUG(1, "Error getting new change number: %s", mapi_get_errstr(ret));
+					goto error;
+				}
+				ret = openchangedb_create_folder(emsmdbp_ctx->oc_ctx, username, ipm_fid, current_fid, current_cn, mapistore_url, i);
+				if (ret != MAPI_E_SUCCESS) {
+					OC_DEBUG(1, "Error creating OpenChangeDB folder: %s", mapi_get_errstr(ret));
+					goto error;
+				}
+			} else if (ret == MAPI_E_SUCCESS) {
+				current_fid = found_fid;
+				ret = openchangedb_set_mapistoreURI(emsmdbp_ctx->oc_ctx, username, current_fid, mapistore_url);
+				if (ret != MAPI_E_SUCCESS) {
+					OC_DEBUG(1, "Error setting new MAPIStore URI %s: %s", mapistore_url, mapi_get_errstr(ret));
+					goto error;
+				}
+				ret = openchangedb_set_system_idx(emsmdbp_ctx->oc_ctx, username, current_fid, i);
+				if (ret != MAPI_E_SUCCESS) {
+					OC_DEBUG(1, "Error setting new system index %d: %s", i, mapi_get_errstr(ret));
+					goto error;
+				}
+				/* change number is updated by set_folder_properties */
+			} else {
+				OC_DEBUG(1, "Error trying to get fid by name (%s): %s", current_name, mapi_get_errstr(ret));
+				goto error;
 			}
 
 			property_row.lpProps[0].value.lpszW = current_name;
 			property_row.lpProps[1].value.lpszW = container_classes[current_folder->role];
-			openchangedb_create_folder(emsmdbp_ctx->oc_ctx, username, ipm_fid, current_fid, current_cn, mapistore_url, i);
 			openchangedb_set_folder_properties(emsmdbp_ctx->oc_ctx, username, current_fid, &property_row);
 
 			/* instantiate the new folder in the backend to make sure it is initialized properly */
@@ -689,6 +740,7 @@ FolderId: 0x67ca828f02000001      Display Name: "                        ";  Con
 				while (openchangedb_get_fid_by_name(emsmdbp_ctx->oc_ctx, username, ipm_fid, current_name, &found_fid) == MAPI_E_SUCCESS) {
 					current_name = talloc_asprintf(mem_ctx, "%s (%d)", base_name, j);
 					j++;
+					OC_DEBUG(5, "Secondary entry collides in its name (%s) with 0x%"PRIx64, base_name, found_fid);
 				}
 				property_row.lpProps[0].value.lpszW = current_name;
 

--- a/mapiproxy/util/mysql.c
+++ b/mapiproxy/util/mysql.c
@@ -543,7 +543,7 @@ bool convert_string_to_ull(const char *str, uint64_t *ret)
 	bool retval = false;
 	char *aux = NULL;
 
-	if (ret != NULL) {
+	if (ret != NULL && str != NULL) {
 		*ret = strtoull(str, &aux, 10);
 		if (aux != NULL && *aux == '\0') {
 			retval = true;

--- a/testsuite/libmapiproxy/openchangedb.c
+++ b/testsuite/libmapiproxy/openchangedb.c
@@ -1,3 +1,24 @@
+/*
+   OpenChange Unit Testing
+
+   OpenChange Project
+
+   Copyright (C) Jesús García Sáez 2013-2014
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "testsuite.h"
 #include "testsuite_common.h"
 #include "mapiproxy/libmapiproxy/libmapiproxy.h"
@@ -835,6 +856,33 @@ START_TEST (test_get_system_idx) {
 	ck_assert_int_eq(15, system_idx);
 } END_TEST
 
+START_TEST (test_set_system_idx) {
+        int initial_system_idx, system_idx;
+	uint64_t fid = 13980299143264862209ul;
+
+	retval = openchangedb_get_system_idx(g_oc_ctx, USER1, fid, &initial_system_idx);
+	if (retval == MAPI_E_SUCCESS) {
+                ck_assert_int_eq(initial_system_idx, -1);
+        } else {
+                /* MAPI_E_CALL_FAILED is returned when system_idx is NULL in MySQL backend */
+                initial_system_idx = -1;
+        }
+
+	retval = openchangedb_set_system_idx(g_oc_ctx, USER1, fid, 3);
+	CHECK_SUCCESS;
+
+	retval = openchangedb_get_system_idx(g_oc_ctx, USER1, fid, &system_idx);
+	CHECK_SUCCESS;
+	ck_assert_int_eq(system_idx, 3);
+
+	retval = openchangedb_set_system_idx(g_oc_ctx, USER1, fid, initial_system_idx);
+	CHECK_SUCCESS;
+
+	retval = openchangedb_get_system_idx(g_oc_ctx, USER1, fid, &system_idx);
+	CHECK_SUCCESS;
+	ck_assert_int_eq(system_idx, initial_system_idx);
+} END_TEST
+
 START_TEST (test_get_system_idx_from_public_folder) {
 	int system_idx = 0;
 	uint64_t fid = 504403158265495553ul;
@@ -1300,6 +1348,7 @@ static Suite *openchangedb_create_suite(const char *backend_name,
 	tcase_add_test(tc, test_get_message_count);
 	tcase_add_test(tc, test_get_message_count_from_public_folder);
 	tcase_add_test(tc, test_get_system_idx);
+	tcase_add_test(tc, test_set_system_idx);
 	tcase_add_test(tc, test_get_system_idx_from_public_folder);
 
 	tcase_add_test(tc, test_create_and_edit_message);


### PR DESCRIPTION
This is a tentative fix for Deleted Items (1) duplicated folders...

It also adds the following low level changes:
* Add `set_system_idx` call to a OpenChangeDB folder
* Fix on getting unsigned long long from a NULL string