### PR TITLE
Remove dependency on testtools.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ compiler:
 install:
   - sudo apt-add-repository -y ppa:openchange/travis-deps
   - sudo apt-get update
-  - sudo apt-get install -qq autoconf automake bison doxygen flex libboost-system-dev libboost-thread-dev libical-dev libldb-dev libmagic-dev libpopt-dev libsqlite3-dev libsubunit-dev libtalloc-dev libtevent-dev pkg-config python-all-dev python-samba samba-dev zlib1g-dev python-twisted-core python-testtools python-subunit check python-mysqldb libpcap-dev libmemcached-dev libnanomsg0
-services: 
+  - sudo apt-get install -qq autoconf automake bison doxygen flex libboost-system-dev libboost-thread-dev libical-dev libldb-dev libmagic-dev libpopt-dev libsqlite3-dev libsubunit-dev libtalloc-dev libtevent-dev pkg-config python-all-dev python-samba samba-dev zlib1g-dev python-twisted-core python-subunit check python-mysqldb libpcap-dev libmemcached-dev libnanomsg0
+services:
   - mysql
   - memcached
 

--- a/testprogs/blackbox/test_openchangeclient.py
+++ b/testprogs/blackbox/test_openchangeclient.py
@@ -1,11 +1,7 @@
-import testtools
 import unittest
 import subprocess
-import subunit
-from testtools.matchers import DocTestMatches
-import sys
 
-class TestProgram(testtools.TestCase):
+class TestProgram(unittest.TestCase):
 
     def get_output(self, args, retcode=0):
         proc = subprocess.Popen(args, stdin=None, stdout=subprocess.PIPE, 
@@ -21,9 +17,9 @@ class OpenChangeTestCase(TestProgram):
 
     def verify_command_noerrors(self, command, expectedStandardOutput):
         out, err = self.get_output(command)
-        self.assertThat(err, DocTestMatches(""))
-        self.assertThat(out, DocTestMatches(expectedStandardOutput))
-        
+        self.assertEquals(err, "")
+        self.assertEquals(out, expectedStandardOutput)
+
     def test_help(self):
         refout = open("expected_output--help.txt").read()
         self.verify_command_noerrors([self.progpath, "--help"], refout)


### PR DESCRIPTION
testtools is no longer used or installed by Samba.