### PR TITLE
Allow test suite verbosity to be set with the `CK_VERBOSITY` environment...

### DIFF
--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -7,12 +7,12 @@
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -117,7 +117,7 @@ int main(int argc, const char *argv[])
 	srunner_add_suite(sr, mapiproxy_util_mysql_suite());
 	srunner_add_suite(sr, mapiproxy_util_schema_migration_suite());
 
-	srunner_run_all(sr, CK_NORMAL);
+	srunner_run_all(sr, CK_ENV);
 	nf = srunner_ntests_failed(sr);
 	srunner_free(sr);
 


### PR DESCRIPTION
... variable

With this change we can modify the test suite verbosity like this `CK_VERBOSITY="verbose" bin/openchange-testsuite`