### PR TITLE
[oxcnotif] make resolver cn case insensitive

### DIFF
--- a/mapiproxy/libmapistore/mapistore_notification.c
+++ b/mapiproxy/libmapistore/mapistore_notification.c
@@ -19,7 +19,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
+#include <ctype.h>
 #include "mapiproxy/libmapistore/mapistore_notification.h"
 
 /**
@@ -390,6 +390,8 @@ static enum mapistore_error mapistore_notification_resolver_set_key(TALLOC_CTX *
 								    char **_key)
 {
 	char	*key = NULL;
+	char	*_cn = NULL;
+	int	idx;
 
 	/* Sanity checks */
 	MAPISTORE_RETVAL_IF(!cn, MAPISTORE_ERR_INVALID_PARAMETER, NULL);
@@ -402,7 +404,16 @@ static enum mapistore_error mapistore_notification_resolver_set_key(TALLOC_CTX *
 		return MAPISTORE_ERR_INVALID_DATA;
 	}
 
-	key = talloc_asprintf(mem_ctx, MSTORE_MEMC_FMT_RESOLVER, cn);
+	/* lower case cn */
+	_cn = talloc_strdup(mem_ctx, cn);
+	MAPISTORE_RETVAL_IF(!cn, MAPISTORE_ERR_NO_MEMORY, NULL);
+
+	for (idx = 0; idx < strlen(_cn); idx++) {
+		_cn[idx] = tolower(_cn[idx]);
+	}
+
+	key = talloc_asprintf(mem_ctx, MSTORE_MEMC_FMT_RESOLVER, _cn);
+	talloc_free(_cn);
 	MAPISTORE_RETVAL_IF(!key, MAPISTORE_ERR_NO_MEMORY, NULL);
 
 	*_key = key;

--- a/testsuite/libmapistore/mapistore_notification.c
+++ b/testsuite/libmapistore/mapistore_notification.c
@@ -30,6 +30,7 @@
 static struct GUID	gl_async_uuid;
 static struct GUID	gl_uuid;
 static const char	*gl_cn = "FooBar";
+static const char	*gl_cn_lowercase = "foobar";
 static const char	*gl_host1 = "tcp://host1:9005";
 static const char	*gl_host2 = "tcp://host2:9006";
 static const char	*gl_host3 = "tcp://host3:9007";
@@ -395,6 +396,10 @@ START_TEST(resolver_exist) {
 
 	/* Test gl_cn existence */
 	retval = mapistore_notification_resolver_exist(&mstore_ctx, gl_cn);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+
+	/* Test gl_cn existence with different case */
+	retval = mapistore_notification_resolver_exist(&mstore_ctx, gl_cn_lowercase);
 	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
 
 	/* Test non existent key */


### PR DESCRIPTION
Fix case where case in Active Directory is different from the one querying the resolver service