### PR TITLE
CreateFolder and DeleteFolder now matches [MS-OXOSFLD] spec

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 * Automatic Outlook inbox refresh when receiving new emails
 
 ### Fixes
+* Deny the removal of a special folder
+* Reuse special folders if a new one is being created with the same name
 * No more `Deleted Items (1)`-like duplicated folders
 * Fixed creation of root folders on online mode and some special folders such as Sync Issues.
 * Fixed `Too many connections to ldap` when openchange runs on samba as member of a domain.

--- a/Makefile
+++ b/Makefile
@@ -1135,6 +1135,7 @@ mapiproxy/servers/exchange_emsmdb.$(SHLIBEXT):	mapiproxy/servers/default/emsmdb/
 						mapiproxy/servers/default/emsmdb/oxcmsg.po			\
 						mapiproxy/servers/default/emsmdb/oxcnotif.po			\
 						mapiproxy/servers/default/emsmdb/oxomsg.po			\
+						mapiproxy/servers/default/emsmdb/oxosfld.po			\
 						mapiproxy/servers/default/emsmdb/oxorule.po			\
 						mapiproxy/servers/default/emsmdb/oxcperm.po
 	@echo "Linking $@"
@@ -1496,6 +1497,7 @@ bin/mapitest:	utils/mapitest/mapitest.o			\
 		utils/mapitest/modules/module_oxcfold.o		\
 		utils/mapitest/modules/module_oxcfxics.o	\
 		utils/mapitest/modules/module_oxomsg.o		\
+		utils/mapitest/modules/module_oxosfld.o		\
 		utils/mapitest/modules/module_oxcmsg.o		\
 		utils/mapitest/modules/module_oxcprpt.o		\
 		utils/mapitest/modules/module_oxctable.o	\
@@ -1524,6 +1526,7 @@ utils/mapitest/proto.h:					\
 	utils/mapitest/modules/module_oxcfold.c		\
 	utils/mapitest/modules/module_oxcfxics.c	\
 	utils/mapitest/modules/module_oxomsg.c		\
+	utils/mapitest/modules/module_oxosfld.c		\
 	utils/mapitest/modules/module_oxcmsg.c		\
 	utils/mapitest/modules/module_oxcprpt.c		\
 	utils/mapitest/modules/module_oxcfxics.c	\

--- a/libmapi/libmapi.h
+++ b/libmapi/libmapi.h
@@ -287,6 +287,8 @@ struct MessageEntryId	*get_MessageEntryId(TALLOC_CTX *, struct Binary_r *);
 struct FolderEntryId	*get_FolderEntryId(TALLOC_CTX *, struct Binary_r *);
 struct AddressBookEntryId *get_AddressBookEntryId(TALLOC_CTX *, struct Binary_r *);
 struct OneOffEntryId	*get_OneOffEntryId(TALLOC_CTX *, struct Binary_r *);
+struct PersistData      *get_PersistData(TALLOC_CTX *, struct Binary_r *);
+struct PersistDataArray *get_PersistDataArray(TALLOC_CTX *, struct Binary_r *);
 const char		*get_TypedString(struct TypedString *);
 bool			set_mapi_SPropValue(TALLOC_CTX *, struct mapi_SPropValue *, const void *);
 bool			set_mapi_SPropValue_proptag(TALLOC_CTX *, struct mapi_SPropValue *, uint32_t, const void *);

--- a/libmapi/libmapi.h
+++ b/libmapi/libmapi.h
@@ -129,6 +129,7 @@ enum MAPISTATUS		GetLoadparmContext(struct mapi_context *, struct loadparm_conte
 /* The following public definitions come from libmapi/simple_mapi.c */
 enum MAPISTATUS		GetDefaultPublicFolder(mapi_object_t *, uint64_t *, const uint32_t);
 enum MAPISTATUS		GetDefaultFolder(mapi_object_t *, uint64_t *, const uint32_t);
+enum MAPISTATUS		GetSpecialAdditionalFolder(mapi_object_t *, uint64_t *, const uint32_t);
 bool			IsMailboxFolder(mapi_object_t *, uint64_t, uint32_t *);
 enum MAPISTATUS		GetFolderItemsCount(mapi_object_t *, uint32_t *, uint32_t *);
 enum MAPISTATUS		AddUserPermission(mapi_object_t *, const char *, enum ACLRIGHTS);

--- a/libmapi/libmapi_private.h
+++ b/libmapi/libmapi_private.h
@@ -69,6 +69,10 @@ enum ndr_err_code ndr_push_ExtendedException(struct ndr_push *, int, uint16_t, c
 enum ndr_err_code ndr_pull_ExtendedException(struct ndr_pull *, int, uint16_t, const struct ExceptionInfo *, struct ExtendedException *);
 enum ndr_err_code ndr_push_AppointmentRecurrencePattern(struct ndr_push *, int, const struct AppointmentRecurrencePattern *);
 enum ndr_err_code ndr_pull_AppointmentRecurrencePattern(struct ndr_pull *, int, struct AppointmentRecurrencePattern *);
+enum ndr_err_code ndr_push_PersistDataArray(struct ndr_push *ndr, int ndr_flags, const struct PersistDataArray *r);
+enum ndr_err_code ndr_pull_PersistDataArray(struct ndr_pull *ndr, int ndr_flags, struct PersistDataArray *r);
+enum ndr_err_code ndr_push_PersistElementArray(struct ndr_push *ndr, int ndr_flags, const struct PersistElementArray *r);
+enum ndr_err_code ndr_pull_PersistElementArray(struct ndr_pull *ndr, int ndr_flags, struct PersistElementArray *r);
 
 /* The following private definitions come from libmapi/nspi.c */
 int nspi_disconnect_dtor(void *);

--- a/libmapi/mapi_object.h
+++ b/libmapi/mapi_object.h
@@ -96,6 +96,11 @@ typedef struct mapi_obj_store
 	uint64_t		fid_note;
 	uint64_t		fid_task;
 	uint64_t		fid_drafts;
+	uint64_t		fid_sync_issues;
+	uint64_t		fid_conflicts;
+	uint64_t		fid_local_failures;
+	uint64_t		fid_server_failures;
+	uint64_t		fid_junk_email;
 	/* GUID */
 	struct GUID		guid;
 } mapi_object_store_t;

--- a/libmapi/property.c
+++ b/libmapi/property.c
@@ -1896,6 +1896,92 @@ _PUBLIC_ struct OneOffEntryId *get_OneOffEntryId(TALLOC_CTX *mem_ctx, struct Bin
 }
 
 /**
+   \details Retrieve a PersistData structure from a binary blob. This structure is meant
+   to contain the entryID of a special folder and other data related to a special folder.
+
+   \param mem_ctx pointer to the memory context
+   \param bin pointer to the Binary_r structure with raw PersistData data
+
+   \return Allocated PersistData structure on success, otherwise NULL
+
+   \note Developers must free the allocated PersistData when finished.
+ */
+_PUBLIC_ struct PersistData *get_PersistData(TALLOC_CTX *mem_ctx, struct Binary_r *bin)
+{
+	struct PersistData	*PersistData = NULL;
+	struct ndr_pull		*ndr;
+	enum ndr_err_code	ndr_err_code;
+
+	/* Sanity checks */
+	if (!bin) return NULL;
+	if (!bin->cb) return NULL;
+	if (!bin->lpb) return NULL;
+
+	ndr = talloc_zero(mem_ctx, struct ndr_pull);
+	if (!ndr) return NULL;
+	ndr->offset = 0;
+	ndr->data = bin->lpb;
+	ndr->data_size = bin->cb;
+
+	ndr_set_flags(&ndr->flags, LIBNDR_FLAG_NOALIGN);
+	PersistData = talloc_zero(mem_ctx, struct PersistData);
+	if (!PersistData) return NULL;
+	ndr_err_code = ndr_pull_PersistData(ndr, NDR_SCALARS, PersistData);
+
+	talloc_free(ndr);
+
+	if (ndr_err_code != NDR_ERR_SUCCESS) {
+		talloc_free(PersistData);
+		return NULL;
+	}
+
+	return PersistData;
+}
+
+/**
+   \details Retrieve a PersistData structure array from a binary blob. This structure is meant
+   to contain entryIDs from special folders and other data related to special folders.
+
+   \param mem_ctx pointer to the memory context
+   \param bin pointer to the Binary_r structure with a raw PersistData array
+
+   \return Allocated PersistDataArray on success, otherwise NULL
+
+   \note Developers must free the allocated PersistDataArray when finished.
+ */
+_PUBLIC_ struct PersistDataArray *get_PersistDataArray(TALLOC_CTX *mem_ctx, struct Binary_r *bin)
+{
+	struct PersistDataArray	*PersistDataArray = NULL;
+	struct ndr_pull		*ndr;
+	enum ndr_err_code	ndr_err_code;
+
+	/* Sanity checks */
+	if (!bin) return NULL;
+	if (!bin->cb) return NULL;
+	if (!bin->lpb) return NULL;
+
+	ndr = talloc_zero(mem_ctx, struct ndr_pull);
+	if (!ndr) return NULL;
+	ndr->offset = 0;
+	ndr->data = bin->lpb;
+	ndr->data_size = bin->cb;
+
+	ndr_set_flags(&ndr->flags, LIBNDR_FLAG_NOALIGN);
+	PersistDataArray = talloc_zero(mem_ctx, struct PersistDataArray);
+	if (!PersistDataArray) return NULL;
+	ndr_err_code = ndr_pull_PersistDataArray(ndr, NDR_SCALARS|NDR_BUFFERS, PersistDataArray);
+
+	talloc_free(ndr);
+
+	if (ndr_err_code != NDR_ERR_SUCCESS) {
+		talloc_free(PersistDataArray);
+		return NULL;
+	}
+
+	return PersistDataArray;
+}
+
+/**
    \details Return the effective value used in a TypedString
    structure.
 

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
@@ -476,6 +476,9 @@ enum MAPISTATUS EcDoRpc_RopSyncImportReadStateChanges(TALLOC_CTX *, struct emsmd
 enum MAPISTATUS EcDoRpc_RopSyncGetTransferState(TALLOC_CTX *, struct emsmdbp_context *, struct EcDoRpc_MAPI_REQ *, struct EcDoRpc_MAPI_REPL *, uint32_t *, uint16_t *);
 enum MAPISTATUS EcDoRpc_RopSetLocalReplicaMidsetDeleted(TALLOC_CTX *, struct emsmdbp_context *, struct EcDoRpc_MAPI_REQ *, struct EcDoRpc_MAPI_REPL *, uint32_t *, uint16_t *);
 
+/* definition from oxosfld.c */
+bool oxosfld_is_special_folder(struct emsmdbp_context *, uint64_t);
+
 __END_DECLS
 
 #endif	/* __DCESRV_EXCHANGE_EMSMDB_H */

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -1534,9 +1534,16 @@ _PUBLIC_ enum mapistore_error emsmdbp_folder_delete(struct emsmdbp_context *emsm
 	mem_ctx = talloc_new(NULL);
 	MAPISTORE_RETVAL_IF(!mem_ctx, MAPISTORE_ERR_NO_MEMORY, NULL);
 
+	/* Check if it is a special folder */
+	if (oxosfld_is_special_folder(emsmdbp_ctx, fid)) {
+		OC_DEBUG(1, "Attempt to delete special folder: 0x%"PRIx64, fid);
+		ret = MAPISTORE_ERR_DENIED;
+		goto end;
+	}
+
 	mailboxstore = emsmdbp_is_mailboxstore(parent_folder);
 	if (emsmdbp_is_mapistore(parent_folder)) {	/* fid is not a mapistore root */
-		OC_DEBUG(0, "Deleting mapistore folder\n");
+		OC_DEBUG(3, "Deleting mapistore folder\n");
 		/* handled by mapistore */
 		context_id = emsmdbp_get_contextID(parent_folder);
 

--- a/mapiproxy/servers/default/emsmdb/oxosfld.c
+++ b/mapiproxy/servers/default/emsmdb/oxosfld.c
@@ -1,0 +1,222 @@
+/*
+   OpenChange Server implementation
+
+   EMSMDBP: EMSMDB Provider implementation
+
+   Copyright (C) Enrique J. Hernández 2015
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+   \file oxosfld.c
+
+   \brief Server-side procedures about special folders
+ */
+
+#include "dcesrv_exchange_emsmdb.h"
+
+#include <gen_ndr/ndr_property.h>
+
+static bool fid_in_entry_id(struct Binary_r *checked_entry_id,
+                            uint64_t parent_fid,
+                            struct FolderEntryId *entry_id, uint64_t entry_id_fid)
+{
+        bool                 ret = false;
+        struct FolderEntryId *checked_folder_entry_id;
+        enum MAPISTATUS      retval;
+        uint64_t             checked_fid;
+
+        retval = GetFIDFromEntryID(checked_entry_id->cb, checked_entry_id->lpb,
+                                   parent_fid, &checked_fid);
+        if (retval != MAPI_E_SUCCESS) {
+                return false;
+        }
+
+        checked_folder_entry_id = get_FolderEntryId(NULL, checked_entry_id);
+
+        if (checked_folder_entry_id) {
+                ret = (GUID_compare(&(checked_folder_entry_id->FolderDatabaseGuid), &(entry_id->FolderDatabaseGuid)) == 0
+                       && GUID_compare(&(checked_folder_entry_id->ProviderUID), &(entry_id->ProviderUID)) == 0
+                       && (checked_fid == entry_id_fid));
+        }
+
+        talloc_free(checked_folder_entry_id);
+        return ret;
+}
+
+/**
+   \details Check if a fid is an special following [MS-OXOSFLD] Section 2.2.2 rules.
+
+   \param emsmdbp_ctx pointer to the emsmdb provider context
+   \param fid the folder identifier to check
+
+   \return true on success, otherwise false
+
+   \note An error on any call is interpreted as false
+ */
+_PUBLIC_ bool oxosfld_is_special_folder(struct emsmdbp_context *emsmdbp_ctx, uint64_t fid)
+{
+        bool                    ret = false;
+        struct Binary_r         *entry_id;
+        struct BinaryArray_r    *entries_ids;
+        struct FolderEntryId    folder_entry_id;
+        int                     i, system_idx;
+        enum MAPISTATUS         retval;
+        TALLOC_CTX              *local_mem_ctx;
+        const uint32_t          identification_properties[] = { PidTagIpmAppointmentEntryId, PidTagIpmContactEntryId,
+                                                                PidTagIpmJournalEntryId, PidTagIpmNoteEntryId,
+                                                                PidTagIpmTaskEntryId, PidTagRemindersOnlineEntryId,
+                                                                PidTagIpmDraftsEntryId };
+        const uint32_t          IDENTIFICATION_PROP_COUNT = sizeof(identification_properties)/sizeof(uint32_t);
+        const uint32_t          ADDITIONAL_REN_ENTRY_IDS_COUNT = 5, FREEBUSY_DATA_ENTRYID_IDX = 3;
+        uint64_t                inbox_fid, mailbox_fid;
+
+        /* Sanity checks */
+        if (!emsmdbp_ctx) return false;
+
+        /* 1. The fids returned in RopLogon are special folders, as they are set with SystemIdx
+           higher than -1. See emsmdbp_provisioning.c for details */
+        retval = openchangedb_get_system_idx(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username, fid,
+                                             &system_idx);
+        if (retval == MAPI_E_SUCCESS && system_idx > -1) {
+                OC_DEBUG(5, "Fid 0x%"PRIx64 " is a system special folder whose system_idx is %d", fid, system_idx);
+                return true;
+        }
+
+        retval = openchangedb_get_SystemFolderID(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username,
+                                                 EMSMDBP_MAILBOX_ROOT, &mailbox_fid);
+        if (retval == MAPI_E_SUCCESS && mailbox_fid == fid) {
+                OC_DEBUG(5, "Fid 0x%"PRIx64 " is the mailbox ID", fid);
+                return true;
+        }
+
+        /* 2. Set of binary properties on the root folder or inbox folder */
+        /* TODO: work in Delegate mode */
+        retval = openchangedb_get_SystemFolderID(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username,
+                                                 EMSMDBP_INBOX, &inbox_fid);
+        if (retval != MAPI_E_SUCCESS) {
+                return false;
+        }
+
+        memset(&folder_entry_id, 0, sizeof(struct FolderEntryId));
+        retval = openchangedb_get_MailboxGuid(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username,
+                                              &folder_entry_id.ProviderUID);
+
+        if (retval != MAPI_E_SUCCESS) {
+                return false;
+        }
+        retval = openchangedb_get_MailboxReplica(emsmdbp_ctx->oc_ctx, emsmdbp_ctx->username,
+                                                 NULL, &folder_entry_id.FolderDatabaseGuid);
+        if (retval != MAPI_E_SUCCESS) {
+                return false;
+        }
+
+        local_mem_ctx = talloc_new(NULL);
+        if (!local_mem_ctx) return false;
+
+        for (i = 0; i < IDENTIFICATION_PROP_COUNT; i++) {
+                retval = openchangedb_get_folder_property(local_mem_ctx, emsmdbp_ctx->oc_ctx,
+                                                          emsmdbp_ctx->username, identification_properties[i],
+                                                          inbox_fid, (void **) &entry_id);
+                if (retval == MAPI_E_SUCCESS
+                    && fid_in_entry_id(entry_id, inbox_fid, &folder_entry_id, fid)) {
+                        OC_DEBUG(5, "The fid 0x%"PRIx64 " found in %s property", fid, get_proptag_name(identification_properties[i]));
+                        ret = true;
+                        goto end;
+                }
+        }
+
+        /* 3. The PidTagAdditionalRenEntryIds contains an array of entry IDs with special folders */
+        retval = openchangedb_get_folder_property(local_mem_ctx, emsmdbp_ctx->oc_ctx,
+                                                  emsmdbp_ctx->username, PidTagAdditionalRenEntryIds,
+                                                  inbox_fid, (void **) &entries_ids);
+        if (retval == MAPI_E_SUCCESS && entries_ids
+            && entries_ids->cValues >= ADDITIONAL_REN_ENTRY_IDS_COUNT) {
+                for (i = 0; i < ADDITIONAL_REN_ENTRY_IDS_COUNT; i++) {
+                        if (fid_in_entry_id((entries_ids->lpbin + i), inbox_fid, &folder_entry_id, fid)) {
+                                OC_DEBUG(5, "The fid 0x%"PRIx64 " found as %d index in PidTagAdditionalRenEntryIds", fid, i);
+                                ret = true;
+                                goto end;
+                        }
+                }
+        }
+
+        /* 4. The PidTagAdditionalRenEntryIdsEx on the store object */
+        retval = openchangedb_get_folder_property(local_mem_ctx, emsmdbp_ctx->oc_ctx,
+                                                  emsmdbp_ctx->username, PidTagAdditionalRenEntryIdsEx,
+                                                  inbox_fid, (void **) &entry_id);
+        if (retval == MAPI_E_SUCCESS) {
+                int j, k;
+                struct PersistDataArray *persist_data_array;
+
+                persist_data_array = get_PersistDataArray(local_mem_ctx, entry_id);
+                if (persist_data_array && persist_data_array->cValues > 0) {
+                        struct Binary_r               checked_entry_id;
+                        DATA_BLOB                     checked_folder_entry_id;
+                        struct PersistData            persist_data;
+                        struct PersistElement         persist_element;
+                        struct PersistElementArray    persist_element_array;
+
+                        for (j = 0; j < persist_data_array->cValues; j++) {
+                                persist_data = persist_data_array->lpPersistData[j];
+                                if (persist_data.PersistID != PERSIST_SENTINEL) {
+                                        persist_element_array = persist_data.DataElements;
+                                        for (k = 0; k < persist_element_array.cValues; k++) {
+
+                                                persist_element = persist_element_array.lpPersistElement[k];
+                                                if (persist_element.ElementID == RSF_ELID_ENTRYID) {
+                                                        checked_folder_entry_id = persist_element.ElementData.rsf_elid_entryid;
+                                                        checked_entry_id.cb = checked_folder_entry_id.length;
+                                                        checked_entry_id.lpb = checked_folder_entry_id.data;
+                                                        if (fid_in_entry_id(&checked_entry_id, inbox_fid, &folder_entry_id, fid)) {
+                                                                OC_DEBUG(5, "The fid 0x%"PRIx64 " found as %d entry in PidTagAdditionalRenEntryIdsEx", fid, persist_data.PersistID);
+                                                                ret = true;
+                                                                goto end;
+                                                        }
+                                                }
+                                        }
+                                }
+                        }
+                } else {
+                        OC_DEBUG(5, "Cannot parse PersistDataArray");
+                }
+        }
+
+
+        /* 5. The entry ID indexed by 3 in PidTagFreeBusyEntryIds on the root folder stores
+           the Freebusy data folder */
+        retval = openchangedb_get_folder_property(local_mem_ctx, emsmdbp_ctx->oc_ctx,
+                                                  emsmdbp_ctx->username, PidTagFreeBusyEntryIds,
+                                                  inbox_fid, (void **) &entries_ids);
+        if (retval == MAPI_E_SUCCESS && entries_ids
+            && entries_ids->cValues >= FREEBUSY_DATA_ENTRYID_IDX
+            && fid_in_entry_id((entries_ids->lpbin + FREEBUSY_DATA_ENTRYID_IDX),
+                               mailbox_fid, &folder_entry_id, fid)) {
+                OC_DEBUG(5, "The fid 0x%"PRIx64 " found as Freebusy Data\n", fid);
+                ret = true;
+                goto end;
+        }
+
+        /* 6. The FID returned by RopGetReceiveFolder */
+        /* According to [MS-OXOSFLD] Section 2.2.7, we should search
+           for the default Receive folder for the Store object. And
+           according to [MS-OXCSTOR] Section 3.2.5.2, it should be the
+           user's inbox folder and it is already checked above. */
+
+end:
+        talloc_free(local_mem_ctx);
+
+        return ret;
+}

--- a/ndr_mapi.c
+++ b/ndr_mapi.c
@@ -2641,3 +2641,141 @@ _PUBLIC_ enum ndr_err_code ndr_pull_AppointmentRecurrencePattern(struct ndr_pull
 	}
 	return NDR_ERR_SUCCESS;
 }
+
+_PUBLIC_ enum ndr_err_code ndr_push_PersistDataArray(struct ndr_push *ndr, int ndr_flags, const struct PersistDataArray *r)
+{
+	uint32_t cntr_lpPersistData_1;
+	{
+		uint32_t _flags_save_STRUCT = ndr->flags;
+		ndr_set_flags(&ndr->flags, LIBNDR_FLAG_NOALIGN);
+		NDR_PUSH_CHECK_FLAGS(ndr, ndr_flags);
+		if (ndr_flags & NDR_BUFFERS) {
+			for (cntr_lpPersistData_1 = 0; cntr_lpPersistData_1 < r->cValues; cntr_lpPersistData_1++) {
+				NDR_CHECK(ndr_push_PersistData(ndr, NDR_SCALARS|NDR_BUFFERS,
+							       &r->lpPersistData[cntr_lpPersistData_1]));
+			}
+		}
+		ndr->flags = _flags_save_STRUCT;
+	}
+	return NDR_ERR_SUCCESS;
+}
+
+_PUBLIC_ enum ndr_err_code ndr_pull_PersistDataArray(struct ndr_pull *ndr, int ndr_flags, struct PersistDataArray *r)
+{
+	uint32_t cntr_lpPersistData_0;
+	TALLOC_CTX *_mem_save_lpPersistData_0;
+	bool sentinel_reached = false;
+	uint32_t current_size;
+	{
+		uint32_t _flags_save_STRUCT = ndr->flags;
+		ndr_set_flags(&ndr->flags, LIBNDR_FLAG_NOALIGN);
+		NDR_PULL_CHECK_FLAGS(ndr, ndr_flags);
+		if (ndr_flags & NDR_BUFFERS) {
+			NDR_PULL_ALLOC(ndr, r->lpPersistData);
+			if (r->lpPersistData) {
+				_mem_save_lpPersistData_0 = NDR_PULL_GET_MEM_CTX(ndr);
+				NDR_PULL_SET_MEM_CTX(ndr, r->lpPersistData, 0);
+				NDR_CHECK(ndr_token_store(ndr, &ndr->array_size_list,
+							  &r->lpPersistData, ndr->data_size));
+				NDR_PULL_ALLOC_N(ndr, r->lpPersistData, 1);
+				cntr_lpPersistData_0 = 0;
+				current_size = 0;
+				while (!sentinel_reached && current_size < ndr->data_size) {
+					NDR_CHECK(ndr_pull_PersistData(ndr, NDR_SCALARS|NDR_BUFFERS, &r->lpPersistData[cntr_lpPersistData_0]));
+					sentinel_reached = (r->lpPersistData[cntr_lpPersistData_0].PersistID == PERSIST_SENTINEL);
+					current_size += r->lpPersistData[cntr_lpPersistData_0].DataElementsSize + 2 + 2;
+					cntr_lpPersistData_0++;
+					r->lpPersistData = talloc_realloc(ndr->current_mem_ctx,
+									  r->lpPersistData,
+									  struct PersistData,
+									  cntr_lpPersistData_0 + 1);
+					if (!r->lpPersistData) {
+						return ndr_pull_error(ndr, NDR_ERR_ALLOC,
+								      "Alloc failed: %s\n",
+								      __location__);
+					}
+				}
+				if (current_size > 0 && cntr_lpPersistData_0 == 0 && !sentinel_reached) {
+					/* TODO: Use NDR_ERR_INCOMPLETE_BUFFER */
+					return NDR_ERR_BUFSIZE;
+				}
+				NDR_PULL_SET_MEM_CTX(ndr, _mem_save_lpPersistData_0, 0);
+				r->cValues = cntr_lpPersistData_0;
+			}
+			if (r->lpPersistData) {
+				NDR_CHECK(ndr_check_array_size(ndr, (void*)&r->lpPersistData, ndr->data_size));
+			}
+		}
+		ndr->flags = _flags_save_STRUCT;
+	}
+	return NDR_ERR_SUCCESS;
+}
+
+_PUBLIC_ enum ndr_err_code ndr_push_PersistElementArray(struct ndr_push *ndr, int ndr_flags, const struct PersistElementArray *r)
+{
+	uint32_t cntr_lpPersistElement_1;
+	{
+		uint32_t _flags_save_STRUCT = ndr->flags;
+		ndr_set_flags(&ndr->flags, LIBNDR_FLAG_NOALIGN);
+		NDR_PUSH_CHECK_FLAGS(ndr, ndr_flags);
+		if (ndr_flags & NDR_BUFFERS) {
+			for (cntr_lpPersistElement_1 = 0; cntr_lpPersistElement_1 < r->cValues; cntr_lpPersistElement_1++) {
+				NDR_CHECK(ndr_push_PersistElement(ndr, NDR_SCALARS|NDR_BUFFERS,
+								  &r->lpPersistElement[cntr_lpPersistElement_1]));
+			}
+		}
+		ndr->flags = _flags_save_STRUCT;
+	}
+	return NDR_ERR_SUCCESS;
+}
+
+_PUBLIC_ enum ndr_err_code ndr_pull_PersistElementArray(struct ndr_pull *ndr, int ndr_flags, struct PersistElementArray *r)
+{
+	uint32_t cntr_lpPersistElement_0;
+	TALLOC_CTX *_mem_save_lpPersistElement_0;
+	bool sentinel_reached = false;
+	uint32_t current_size;
+	{
+		uint32_t _flags_save_STRUCT = ndr->flags;
+		ndr_set_flags(&ndr->flags, LIBNDR_FLAG_NOALIGN);
+		NDR_PULL_CHECK_FLAGS(ndr, ndr_flags);
+		if (ndr_flags & NDR_BUFFERS) {
+			NDR_PULL_ALLOC(ndr, r->lpPersistElement);
+			if (r->lpPersistElement) {
+				_mem_save_lpPersistElement_0 = NDR_PULL_GET_MEM_CTX(ndr);
+				NDR_PULL_SET_MEM_CTX(ndr, r->lpPersistElement, 0);
+				NDR_CHECK(ndr_token_store(ndr, &ndr->array_size_list,
+							  &r->lpPersistElement, ndr->data_size));
+				NDR_PULL_ALLOC_N(ndr, r->lpPersistElement, 1);
+				cntr_lpPersistElement_0 = 0;
+				current_size = 0;
+				while (!sentinel_reached && current_size < ndr->data_size) {
+					NDR_CHECK(ndr_pull_PersistElement(ndr, NDR_SCALARS, &r->lpPersistElement[cntr_lpPersistElement_0]));
+					sentinel_reached = (r->lpPersistElement[cntr_lpPersistElement_0].ElementID == ELEMENT_SENTINEL);
+					current_size += r->lpPersistElement[cntr_lpPersistElement_0].ElementDataSize + 2 + 2;
+					cntr_lpPersistElement_0++;
+					r->lpPersistElement = talloc_realloc(ndr->current_mem_ctx,
+									     r->lpPersistElement,
+									     struct PersistElement,
+									     cntr_lpPersistElement_0 + 1);
+					if (!r->lpPersistElement) {
+						return ndr_pull_error(ndr, NDR_ERR_ALLOC,
+								      "Alloc failed: %s\n",
+								      __location__);
+					}
+				}
+				if (current_size > 0 && cntr_lpPersistElement_0 == 0 && !sentinel_reached) {
+					/* TODO: Use NDR_ERR_INCOMPLETE_BUFFER */
+					return NDR_ERR_BUFSIZE;
+				}
+				NDR_PULL_SET_MEM_CTX(ndr, _mem_save_lpPersistElement_0, 0);
+				r->cValues = cntr_lpPersistElement_0;
+			}
+			if (r->lpPersistElement) {
+				NDR_CHECK(ndr_check_array_size(ndr, (void*)&r->lpPersistElement, ndr->data_size));
+			}
+		}
+		ndr->flags = _flags_save_STRUCT;
+	}
+	return NDR_ERR_SUCCESS;
+}

--- a/property.idl
+++ b/property.idl
@@ -411,4 +411,52 @@ interface property
                 SHARING_REQUEST                   = 0x20400
         } sharing_flavor_type;
 
+	/* PersistElement [MS-OXOSFLD] 2.2.5.2 */
+	typedef [enum16bit] enum {
+		RSF_ELID_HEADER	 = 0x2,
+		RSF_ELID_ENTRYID = 0x1,
+		ELEMENT_SENTINEL = 0x0
+	} ElementID;
+
+	typedef [nodiscriminant, flag(NDR_NOALIGN|NDR_REMAINING)] union {
+		[case(0x1)] DATA_BLOB		  rsf_elid_entryid;
+		[case(0x2)] uint32		  rsf_elid_header;
+		[default];
+	} PersistElementData;
+
+	typedef [public,flag(NDR_NOALIGN)] struct {
+		ElementID							      ElementID;
+		uint16								      ElementDataSize;
+		[subcontext(0),subcontext_size(ElementDataSize),switch_is(ElementID)] PersistElementData	ElementData;
+	} PersistElement;
+
+	typedef [nopull,nopush,flag(NDR_NOALIGN)] struct {
+		[range(0, 10000)] uint32	    cValues;
+		[size_is(cValues)] PersistElement   lpPersistElement[];
+	} PersistElementArray;
+
+	/* PersistData [MS-OXOSFLD] 2.2.5.1 */
+	typedef [enum16bit] enum {
+		RSF_PID_RSS_SUBSCRIPTION   = 0x8001,
+		RSF_PID_SEND_AND_TRACK	   = 0x8002,
+		RSF_PID_TODO_SEARCH	   = 0x8004,
+		RSF_PID_CONV_ACTIONS	   = 0x8006,
+		RSF_PID_COMBINED_ACTIONS   = 0x8007,
+		RSF_PID_SUGGESTED_CONTACTS = 0x8008,
+		RSF_PID_CONTACT_SEARCH	   = 0x8009,
+		RSF_PID_BUDDYLIST_PDLS	   = 0x800A,
+		RSF_PID_BUDDYLIST_CONTACTS = 0x800B,
+		PERSIST_SENTINEL	   = 0x0000
+	} PersistID;
+
+	typedef [public,flag(NDR_NOALIGN)] struct {
+		PersistID							       PersistID;
+		uint16								       DataElementsSize;
+		[subcontext(0), subcontext_size(DataElementsSize)] PersistElementArray DataElements;
+	} PersistData;
+
+	typedef [nopull,nopush,noprint,flag(NDR_NOALIGN)] struct {
+		[range(0, 100000)] uint32      cValues;
+		[size_is(cValues)] PersistData *lpPersistData;
+	} PersistDataArray;
 }

--- a/utils/mapitest/module.c
+++ b/utils/mapitest/module.c
@@ -43,6 +43,7 @@ _PUBLIC_ uint32_t mapitest_register_modules(struct mapitest *mt)
 	ret += module_mapidump_init(mt);
 	ret += module_lzxpress_init(mt);
 	ret += module_zentyal_init(mt);
+	ret += module_oxosfld_init(mt);
 
 	return ret;
 }
@@ -512,6 +513,29 @@ _PUBLIC_ uint32_t module_lzxpress_init(struct mapitest *mt)
 	suite = mapitest_suite_init(mt, "LZXPRESS", "lzxpress algorithm test suite", false);
 
 	mapitest_suite_add_test_flagged(suite, "VALIDATE-001", "Validate LZXPRESS implementation using sample file 001", mapitest_lzxpress_validate_test_001, ExpectedFail);
+
+	mapitest_suite_register(mt, suite);
+
+	return MAPITEST_SUCCESS;
+}
+
+/**
+   \details Register the Special Folders Protocol test suite
+
+   \param mt pointer on the top-level mapitest structure
+
+   \return MAPITEST_SUCCESS on success, otherwise MAPITEST_ERROR
+ */
+_PUBLIC_ uint32_t module_oxosfld_init(struct mapitest *mt)
+{
+	struct mapitest_suite	*suite = NULL;
+
+	suite = mapitest_suite_init(mt, "OXOSFLD", "Special Folders Protocol", true);
+
+	mapitest_suite_add_test(suite, "CREATE-FOLDER", "Create special folders",
+				mapitest_oxosfld_CreateFolder);
+	mapitest_suite_add_test(suite, "DELETE-FOLDER", "Delete special folders",
+				mapitest_oxosfld_DeleteFolder);
 
 	mapitest_suite_register(mt, suite);
 

--- a/utils/mapitest/modules/module_oxosfld.c
+++ b/utils/mapitest/modules/module_oxosfld.c
@@ -1,0 +1,313 @@
+/*
+   Stand-alone MAPI testsuite
+
+   OpenChange Project - SPECIAL FOLDERS PROTOCOL
+
+   Copyright (C) Enrique J. Hernández 2015
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "utils/mapitest/mapitest.h"
+
+/*
+static const char * root_special_folders[] = {
+        "Finder",
+        "Reminders",
+        "Tracked Mail Processing",
+        "To-Do",
+        "Common Views",
+        "Personal Views",
+        "Top of Information Store",
+        "Freebusy Data",
+        "Spooler Queue",
+        "Document Libraries"
+};
+*/
+
+struct folders {
+        uint32_t     idx;
+        const char   *name;
+        uint32_t     id;
+        bool         additional_ren_entry_ids;
+};
+
+static struct folders personal_special_folders[] = {
+        { 0x0, "Deleted Items", olFolderDeletedItems, false },
+        { 0x1, "Outbox", olFolderOutbox, false },
+        { 0x2, "Sent", olFolderSentMail, false },
+        { 0x3, "Inbox", olFolderInbox, false },
+        { 0x4, "Personal Calendar (c)", olFolderCalendar, false },
+        { 0x5, "Personal Address Book", olFolderContacts, false },
+        /* This special folders are not working in all supported
+           versions, so we skip by now [MS-OXOSFLD] Section 6 <1>
+        { 0x6, "Suggested Contacts", 0xFFFFFFFF, true },
+        { 0x7, "Quick Contacts", 0xFFFFFFFF },
+        { 0x8, "IM Contacts List", 0xFFFFFFFF },
+        { 0x9, "Contacts Search", 0xFFFFFFFF },
+        */
+        { 0x6, "Journal", olFolderJournal, false },
+        { 0x7, "Notes", olFolderNotes, false },
+        { 0x8, "Personal Calendar (t)", olFolderTasks, false },
+        { 0x9, "Drafts", olFolderDrafts, false },
+        { 0x10, "Sync Issues", olFolderSyncIssues, true },
+        { 0x11, "Junk E-mail", olFolderJunk, true },
+        { 0x12, "RSS Feeds", 0xFFFFFFFF, true },
+        { 0x13, "Conversation Action Settings", 0xFFFFFFFF, true },
+        { 0x14, NULL, 0xFFFFFFFF, true }
+};
+
+static struct folders sync_issues_special_folders[] = {
+        { 0x0, "Conflicts", olFolderConflicts },
+        { 0x1, "Local Failures", olFolderLocalFailures },
+        { 0x2, "Server Failures", olFolderServerFailures },
+        { 0x3, NULL, 0xFFFFFFFF }
+};
+
+/* Schedule, Shortcuts? */
+
+/**
+    \details Test the creation of some special folders
+
+    This function:
+        -# Log on the user private mailbox
+        -# Open the top information store folder
+        -# Loop over every known special folder name
+           in English's locale under Top of Information Store
+        -# Try to create the folder with NONE as flag
+        -# Loop over every known special folder name
+           in English's locale under Sync Issues folder
+        -# Try to create the folder with NONE as flag
+
+    \param mt pointer to the top level mapitest structure
+
+    \return true on success, otherwise false
+*/
+_PUBLIC_ bool mapitest_oxosfld_CreateFolder(struct mapitest *mt)
+{
+        enum MAPISTATUS         additional_ren_entry_ids, retval;
+        mapi_id_t               id_folder;
+        mapi_object_t           obj_tis_folder, obj_sync_folder, obj_folder, obj_store;
+        bool                    test_result = true;
+        uint32_t                i;
+
+        mapi_object_init(&obj_store);
+        mapi_object_init(&obj_tis_folder);
+        mapi_object_init(&obj_sync_folder);
+
+        /* Step 1. Logon */
+        retval = OpenMsgStore(mt->session, &obj_store);
+        mapitest_print_retval(mt, "OpenMsgStore");
+        if (GetLastError() != MAPI_E_SUCCESS) {
+                test_result = false;
+                goto cleanup;
+        }
+
+        /* Step 2. Open Top Information Store folder */
+        retval = GetDefaultFolder(&obj_store, &id_folder, olFolderTopInformationStore);
+        mapitest_print_retval_clean(mt, "GetDefaultFolder", retval);
+        if (retval != MAPI_E_SUCCESS) {
+                test_result = false;
+                goto cleanup;
+        }
+
+        retval = OpenFolder(&obj_store, id_folder, &obj_tis_folder);
+        mapitest_print_retval(mt, "OpenFolder");
+        if (GetLastError() != MAPI_E_SUCCESS) {
+                test_result = false;
+                goto cleanup;
+        }
+
+        additional_ren_entry_ids = GetSpecialAdditionalFolder(&obj_store, &id_folder, olFolderSyncIssues);
+
+        /* Step 3. Loop over every special folder in Top Information Store folder */
+        for (i = 0; personal_special_folders[i].name; i++) {
+                if (additional_ren_entry_ids != MAPI_E_SUCCESS && personal_special_folders[i].additional_ren_entry_ids) {
+                        /* Skip test if the user has never logged on */
+                        continue;
+                }
+                mapi_object_init(&obj_folder);
+                retval = CreateFolder(&obj_tis_folder, FOLDER_GENERIC, personal_special_folders[i].name,
+                                      NULL, NONE, &obj_folder);
+                mapitest_print_retval_fmt_clean(mt, "CreateFolder", retval, "(%s)", personal_special_folders[i].name);
+                if (retval != MAPI_E_SUCCESS) {
+                        test_result = false;
+                }
+                mapi_object_release(&obj_folder);
+        }
+
+        /* Step 4. Open Sync Issues folder */
+        mapitest_print_retval_clean(mt, "GetSpecialAdditionalFolder (Sync Issues)", additional_ren_entry_ids);
+        if (additional_ren_entry_ids != MAPI_E_SUCCESS) {
+                mapitest_print(mt, "* It seems not all information about some special folders is found. Some tests skipped\n");
+                goto cleanup;
+        }
+
+        retval = OpenFolder(&obj_tis_folder, id_folder, &obj_sync_folder);
+        mapitest_print_retval(mt, "OpenFolder (Sync Issues)");
+        if (retval != MAPI_E_SUCCESS) {
+                test_result = false;
+                goto cleanup;
+        }
+
+        /* Step 5. Loop over every special folder in Sync Issues folder */
+        for (i = 0; sync_issues_special_folders[i].name; i++) {
+                mapi_object_init(&obj_folder);
+                retval = CreateFolder(&obj_sync_folder, FOLDER_GENERIC, sync_issues_special_folders[i].name,
+                                      NULL, NONE, &obj_folder);
+                mapitest_print_retval_fmt(mt, "CreateFolder", "(%s)", sync_issues_special_folders[i].name);
+                if (retval != MAPI_E_SUCCESS) {
+                        test_result = false;
+                }
+                mapi_object_release(&obj_folder);
+        }
+
+cleanup:
+        /* Release */
+        mapi_object_release(&obj_sync_folder);
+        mapi_object_release(&obj_tis_folder);
+        mapi_object_release(&obj_store);
+
+        return test_result;
+}
+
+/**
+    \details Test the deletion of some special folders
+
+    This function:
+        -# Log on the user private mailbox
+        -# Open the top information store folder
+        -# Loop over every known special folder name
+           under Top of Information Store
+        -# Try to delete the folder
+        -# Loop over every known special folder name
+           under Sync Issues folder
+        -# Try to delete the folder
+
+    \param mt pointer to the top level mapitest structure
+
+    \return true on success, otherwise false
+*/
+_PUBLIC_ bool mapitest_oxosfld_DeleteFolder(struct mapitest *mt)
+{
+        bool                    partial_completion = false;
+        bool                    test_result = true;
+        const char              *get_op_name;
+        enum MAPISTATUS         additional_ren_entry_ids, retval;
+        mapi_id_t               id_folder;
+        mapi_object_t           obj_tis_folder, obj_sync_folder, obj_store;
+        uint32_t                i;
+
+        mapi_object_init(&obj_store);
+        mapi_object_init(&obj_tis_folder);
+        mapi_object_init(&obj_sync_folder);
+
+        /* Step 1. Logon */
+        retval = OpenMsgStore(mt->session, &obj_store);
+        mapitest_print_retval(mt, "OpenMsgStore");
+        if (GetLastError() != MAPI_E_SUCCESS) {
+                test_result = false;
+                goto cleanup;
+        }
+
+        /* Step 2. Open Top Information Store folder */
+        retval = GetDefaultFolder(&obj_store, &id_folder, olFolderTopInformationStore);
+        mapitest_print_retval_clean(mt, "GetDefaultFolder", retval);
+        if (retval != MAPI_E_SUCCESS) {
+                test_result = false;
+                goto cleanup;
+        }
+
+        retval = OpenFolder(&obj_store, id_folder, &obj_tis_folder);
+        mapitest_print_retval(mt, "OpenFolder");
+        if (GetLastError() != MAPI_E_SUCCESS) {
+                test_result = false;
+                goto cleanup;
+        }
+
+        additional_ren_entry_ids = GetSpecialAdditionalFolder(&obj_store, &id_folder, olFolderSyncIssues);
+
+        /* Step 3. Loop over every special folder in Top Information Store folder */
+        for (i = 0; personal_special_folders[i].name; i++) {
+                if (personal_special_folders[i].id == 0xFFFFFFFF) {
+                        /* Not yet supported by GetDefaultFolder */
+                        continue;
+                }
+                if (additional_ren_entry_ids != MAPI_E_SUCCESS && personal_special_folders[i].additional_ren_entry_ids) {
+                        /* Skip test if the user has never logged on */
+                        continue;
+                }
+                if (personal_special_folders[i].additional_ren_entry_ids) {
+                        retval = GetSpecialAdditionalFolder(&obj_store, &id_folder,
+                                                            personal_special_folders[i].id);
+                        get_op_name = "GetSpecialAdditionalFolder";
+                } else {
+                        retval = GetDefaultFolder(&obj_store, &id_folder, personal_special_folders[i].id);
+                        get_op_name = "GetDefaultFolder";
+                }
+                mapitest_print_retval_fmt_clean(mt, (char *)get_op_name, retval,
+                                                "(%s)", personal_special_folders[i].name);
+                if (retval != MAPI_E_SUCCESS) {
+                        test_result = false;
+                        continue;
+                }
+                retval = DeleteFolder(&obj_tis_folder, id_folder,
+                                      0, &partial_completion);
+                mapitest_print_retval_fmt(mt, "DeleteFolder", "(%s)", personal_special_folders[i].name);
+                if (retval != MAPI_E_NO_ACCESS || partial_completion) {
+                        test_result = false;
+                }
+        }
+
+        /* Step 4. Open Sync Issues folder */
+        retval = GetSpecialAdditionalFolder(&obj_store, &id_folder, olFolderSyncIssues);
+        mapitest_print_retval_clean(mt, "GetDefaultFolder (Sync Issues)", retval);
+        if (retval != MAPI_E_SUCCESS) {
+                mapitest_print(mt, "* It seems not all information about some special folders is found. Some tests skipped\n");
+                goto cleanup;
+        }
+
+        retval = OpenFolder(&obj_tis_folder, id_folder, &obj_sync_folder);
+        mapitest_print_retval(mt, "OpenFolder (Sync Issues)");
+        if (retval != MAPI_E_SUCCESS) {
+                test_result = false;
+                goto cleanup;
+        }
+
+        /* Step 5. Loop over every special folder in Sync Issues folder */
+        for (i = 0; sync_issues_special_folders[i].name; i++) {
+                retval = GetSpecialAdditionalFolder(&obj_store, &id_folder,
+                                                    sync_issues_special_folders[i].id);
+                mapitest_print_retval_fmt_clean(mt, "GetSpecialAdditionalFolder", retval,
+                                                "(%s)", sync_issues_special_folders[i].name);
+                if (retval != MAPI_E_SUCCESS) {
+                        test_result = false;
+                        continue;
+                }
+                retval = DeleteFolder(&obj_tis_folder, id_folder,
+                                      0, &partial_completion);
+                mapitest_print_retval_fmt(mt, "DeleteFolder", "(%s)", sync_issues_special_folders[i].name);
+                if (retval != MAPI_E_NO_ACCESS || partial_completion) {
+                        test_result = false;
+                }
+        }
+
+cleanup:
+        /* Release */
+        mapi_object_release(&obj_sync_folder);
+        mapi_object_release(&obj_tis_folder);
+        mapi_object_release(&obj_store);
+
+        return test_result;
+}


### PR DESCRIPTION
* On [MS-OXOSFLD] Section 3.1.4.1, where a CreateFolder ROP must not fail but reuse a fid if a special folder name is trying to be set.
* On [MS-OXCFOLD] Section 3.2.5.3, where a DeleteFolder ROP must fail with ecAccessDenied if the folder to delete is a special folder

This is done by adding a new function to check if a fid belongs to a special folder following [MS-OXOSFLD] 2.2.2 section. To do this is required to implement `PersistData` and `PersistElement` structures to parse and marshal in ndr. The latter has been tested with new unit tests.

For testing this new feature, a new module has been added and it is run with the following command:
```
   $ bin/mapitest --mapi-calls=OXOSFLD-ALL
```
It requires to have this PR https://github.com/Zentyal/sogo/pull/131 ready if SOGo backend is used and the client library has been adapted as well.