### PR TITLE
[oxocal] Fix TZRule flags

### DIFF
--- a/property.idl
+++ b/property.idl
@@ -281,8 +281,8 @@ interface property
 	} TimeZoneStruct;
 
 	typedef [enum16bit] enum {
-		TZRULE_FLAG_RECUR_CURRENT_TZREG	= 0x8000,
-		TZRULE_FLAG_EFFECTIVE_TZREG	= 0x4000
+		TZRULE_FLAG_RECUR_CURRENT_TZREG	= 0x0001,
+		TZRULE_FLAG_EFFECTIVE_TZREG	= 0x0002
 	} TZRuleFlag;
 
 	/* pidLidAppointmentTimeZoneDefinitionRecur,


### PR DESCRIPTION
Although these changes don't produce any visible behaviour change, they fix a typo in the TZRule flag definitions. The specification can be found in [MS-OXOCAL] 2.2.1.41.1