### PR TITLE
Drop kernel information from version header and mapitest.

### DIFF
--- a/script/mkversion.sh
+++ b/script/mkversion.sh
@@ -73,20 +73,6 @@ fi
 
 echo "#define OPENCHANGE_VERSION_STRING \"${OPENCHANGE_VERSION_STRING}\"" >> $TMPFILE
 
-##
-## Add some System related information (useful for debug and report)
-##
-echo "" >> $TMPFILE
-echo "/* System related information */" >> $TMPFILE
-
-OPENCHANGE_SYS_KERNEL_NAME=`uname -s`
-OPENCHANGE_SYS_KERNEL_RELEASE=`uname -r`
-OPENCHANGE_SYS_PROCESSOR=`uname -p`
-
-echo "#define OPENCHANGE_SYS_KERNEL_NAME \"${OPENCHANGE_SYS_KERNEL_NAME}\"" >> $TMPFILE
-echo "#define OPENCHANGE_SYS_KERNEL_RELEASE \"${OPENCHANGE_SYS_KERNEL_RELEASE}\"" >> $TMPFILE
-echo "#define OPENCHANGE_SYS_PROCESSOR \"${OPENCHANGE_SYS_PROCESSOR}\"" >> $TMPFILE
-
 mv "$TMPFILE" "$OUTPUT_FILE"
 
 echo "$0: '$OUTPUT_FILE' created for OpenChange libmapi(\"${OPENCHANGE_VERSION_STRING}\")"

--- a/utils/mapitest/mapitest_print.c
+++ b/utils/mapitest/mapitest_print.c
@@ -287,16 +287,8 @@ _PUBLIC_ void mapitest_print_headers_info(struct mapitest *mt)
 	mapitest_print(mt, MT_HDR_FMT_DATE, "Date", date);
 	mapitest_print(mt, MT_HDR_FMT, "Confidential mode", 
 		       (mt->confidential == true) ? MT_YES : MT_NO);
-	mapitest_print(mt, MT_HDR_FMT, "Samba Information", SAMBA_VERSION_STRING);
+	mapitest_print(mt, MT_HDR_FMT, "Samba Version (Build Time)", SAMBA_VERSION_STRING);
 	mapitest_print(mt, MT_HDR_FMT, "OpenChange Information", OPENCHANGE_VERSION_STRING);
-
-	mapitest_print_newline(mt, 1);
-	mapitest_print(mt, MT_HDR_FMT_SECTION, "System Information");
-	mapitest_indent();
-	mapitest_print(mt, MT_HDR_FMT_SUBSECTION, "Kernel name", OPENCHANGE_SYS_KERNEL_NAME);
-	mapitest_print(mt, MT_HDR_FMT_SUBSECTION, "Kernel release", OPENCHANGE_SYS_KERNEL_RELEASE);
-	mapitest_print(mt, MT_HDR_FMT_SUBSECTION, "Processor", OPENCHANGE_SYS_PROCESSOR);
-	mapitest_deindent();
 }
 
 /**


### PR DESCRIPTION
Including this information prevents openchange's build from being
reproducible.

Build-time kernel information is also of limited value,
as the kernel OpenChange is built on is likely different from the
kernel it is run on.

See also https://wiki.debian.org/ReproducibleBuilds/About