### PR TITLE
Set postmaster proxyAddresses entry as secondary

### DIFF
--- a/python/openchange/migration/directory.py
+++ b/python/openchange/migration/directory.py
@@ -3,6 +3,7 @@
 
 # OpenChangeDB migration for directory schema and contents
 # Copyright (C) Javier Amor Garcia <jamor@zentyal.com> 2015
+#               Enrique J. Hernández <ejhernandez@zentyal.com> 2015
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,6 +23,7 @@ Migration for OpenChange directory schema and data
 """
 from openchange.migration import migration, Migration
 import ldb
+import sys
 
 
 @migration('directory', 1)
@@ -161,3 +163,77 @@ msExchRecipientDisplayType: 0
         # The schema migration cannot be rolled back because AD cannot
         # remove schema entries to avoid replication problems
         print "Schema migration cannot be rolled back\n"
+
+
+@migration('directory', 2)
+class SetPostmansterSecondaryProxyAddressesEntry(Migration):
+    description = 'Set postmaster as secondary SMTP ProxyAddresses entry'
+
+    @classmethod
+    def apply(cls, cur, **kwargs):
+        from openchange.provision import get_local_samdb
+
+        names = kwargs['names']
+        db = get_local_samdb(names, kwargs['lp'], kwargs['creds'])
+
+        # Set postmaster proxyAddress attribute as secondary entry
+        modify_postmaster_ldif_template = """
+dn: {user_dn}
+changetype: modify
+delete: proxyAddresses
+proxyAddresses: SMTP:postmaster@{mail_domain}
+-
+add: proxyAddresses
+proxyAddresses: smtp:postmaster@{mail_domain}
+"""
+
+        base_dn = "CN=Users,%s" % names.domaindn
+        ldb_filter = "(proxyAddresses=*)"
+        res = db.search(base=base_dn, scope=ldb.SCOPE_SUBTREE, expression=ldb_filter)
+        for element in res:
+            if 'proxyAddresses' in element:
+                for entry in element['proxyAddresses']:
+                    if entry.startswith('SMTP:postmaster@'):
+                        mail_domain = entry[len('SMTP:postmaster@'):]
+                        dn = element.dn.get_linearized()
+                        ldif = modify_postmaster_ldif_template.format(user_dn=dn,
+                                                                      mail_domain=mail_domain)
+                        try:
+                            db.modify_ldif(ldif)
+                        except Exception, ex:
+                            sys.stderr.write("Error migrating user %s: %s\n" % (dn, ex))
+
+    @classmethod
+    def unapply(cls, cur, **kwargs):
+        # Do nothing by now
+        from openchange.provision import get_local_samdb
+
+        names = kwargs['names']
+        db = get_local_samdb(names, kwargs['lp'], kwargs['creds'])
+
+        # Set postmaster proxyAddress attribute as secondary entry
+        modify_postmaster_ldif_template = """
+dn: {user_dn}
+changetype: modify
+delete: proxyAddresses
+proxyAddresses: smtp:postmaster@{mail_domain}
+-
+add: proxyAddresses
+proxyAddresses: SMTP:postmaster@{mail_domain}
+"""
+
+        base_dn = "CN=Users,%s" % names.domaindn
+        ldb_filter = "(proxyAddresses=*)"
+        res = db.search(base=base_dn, scope=ldb.SCOPE_SUBTREE, expression=ldb_filter)
+        for element in res:
+            if 'proxyAddresses' in element:
+                for entry in element['proxyAddresses']:
+                    if entry.startswith('smtp:postmaster@'):
+                        mail_domain = entry[len('smtp:postmaster@'):]
+                        dn = element.dn.get_linearized()
+                        ldif = modify_postmaster_ldif_template.format(user_dn=dn,
+                                                                      mail_domain=mail_domain)
+                        try:
+                            db.modify_ldif(ldif)
+                        except Exception, ex:
+                            sys.stderr.write("Error unmigrating user %s: %s\n" % (dn, ex))

--- a/python/openchange/migration/directory.py
+++ b/python/openchange/migration/directory.py
@@ -104,7 +104,7 @@ objectCategory: CN=Attribute-Schema,%(schema_dn)s
         try:
             db.add_ldif(add_schema_attr_ldif, ['relax:0'])
         except Exception, ex:
-            print "Error adding msExchRecipientTypeDetails and msExchRecipientDisplayType atributes to schema: %s" % str(ex)
+            sys.stderr.write("Error adding msExchRecipientTypeDetails and msExchRecipientDisplayType atributes to schema: %s\n" % str(ex))
 
         force_schemas_update(db, setup_path)
 
@@ -119,7 +119,7 @@ mayContain: msExchRecipientTypeDetails
         try:
             db.modify_ldif(upgrade_schema_ldif)
         except Exception, ex:
-            print "Error adding msExchRecipientTypeDetails and msExchRecipientDisplayType to Mail-Recipient schema: %s" % str(ex)
+            sys.stderr.write("Error adding msExchRecipientTypeDetails and msExchRecipientDisplayType to Mail-Recipient schema: %s\n" % str(ex))
 
         force_schemas_update(db, setup_path)
 
@@ -156,13 +156,13 @@ msExchRecipientDisplayType: 0
                 try:
                     db.modify_ldif(ldif)
                 except Exception, ex:
-                    print "Error migrating user %s: %s. Skipping user" % (dn, str(ex))
+                    sys.stderr.write("Error migrating user %s: %s. Skipping user\n" % (dn, str(ex)))
 
     @classmethod
     def unapply(cls, cur, **kwargs):
         # The schema migration cannot be rolled back because AD cannot
         # remove schema entries to avoid replication problems
-        print "Schema migration cannot be rolled back\n"
+        sys.stderr.write("Schema migration cannot be rolled back\n")
 
 
 @migration('directory', 2)

--- a/python/openchange/provision.py
+++ b/python/openchange/provision.py
@@ -648,7 +648,7 @@ add: proxyAddresses
 proxyAddresses: SMTP:%(smtp_user)s
 proxyAddresses: =EX:/o=%(firstorg)s/ou=%(firstou)s/cn=Recipients/cn=%(username)s
 proxyAddresses: X400:c=US;a= ;p=%(firstorg_x400)s;o=%(firstou_x400)s;s=%(username)s
-proxyAddresses: SMTP:postmaster@%(mail_domain)s
+proxyAddresses: smtp:postmaster@%(mail_domain)s
 replace: msExchUserAccountControl
 msExchUserAccountControl: 0
 add: msExchRecipientTypeDetails
@@ -656,6 +656,10 @@ msExchRecipientTypeDetails: 6
 add: msExchRecipientDisplayType
 msExchRecipientDisplayType: 0
 """
+        # According to [MS-OXCMAIL] Section 1.1, the primary
+        # proxyAddresses entry is the SMTP one and the secondaries
+        # proxyAddresses entries are the smtp ones
+
         ldif_value = extended_user % {"user_dn": user_dn,
                                       "username": username,
                                       "netbiosname": names.netbiosname,


### PR DESCRIPTION
According to [MS-OXCMAIL] Section 1.1, the primary
proxyAddresses entry is the SMTP one and the secondaries
proxyAddresses entries are the smtp ones.

This fixes a regression introduced in #240 in OOF support in Outlook 2007 as it was taking the secondary entry as primary to set OOF. As it is fixes a regression, no CHANGES are needed as the version is not yet published