### PR TITLE
Fix property pull from data blobs in parse_ModifyRecipientRow

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 
 ## [Unreleased]
 
+### Fixes
+
+* Send event invitation mails to several attendees, mixing internal and external recipients
+
 ## [2.3]
 
 ### Added


### PR DESCRIPTION
When the data blob had a layout, errors were being checked at the first byte instead of at the second one.