### PR TITLE
Set postmaster proxyAddresses entry as secondary in groups

### DIFF
--- a/python/openchange/migration/directory.py
+++ b/python/openchange/migration/directory.py
@@ -187,9 +187,8 @@ add: proxyAddresses
 proxyAddresses: smtp:postmaster@{mail_domain}
 """
 
-        base_dn = "CN=Users,%s" % names.domaindn
         ldb_filter = "(proxyAddresses=*)"
-        res = db.search(base=base_dn, scope=ldb.SCOPE_SUBTREE, expression=ldb_filter)
+        res = db.search(base=names.domaindn, scope=ldb.SCOPE_SUBTREE, expression=ldb_filter)
         for element in res:
             if 'proxyAddresses' in element:
                 for entry in element['proxyAddresses']:
@@ -222,9 +221,8 @@ add: proxyAddresses
 proxyAddresses: SMTP:postmaster@{mail_domain}
 """
 
-        base_dn = "CN=Users,%s" % names.domaindn
         ldb_filter = "(proxyAddresses=*)"
-        res = db.search(base=base_dn, scope=ldb.SCOPE_SUBTREE, expression=ldb_filter)
+        res = db.search(base=names.domaindn, scope=ldb.SCOPE_SUBTREE, expression=ldb_filter)
         for element in res:
             if 'proxyAddresses' in element:
                 for entry in element['proxyAddresses']:

--- a/python/openchange/provision.py
+++ b/python/openchange/provision.py
@@ -744,7 +744,7 @@ legacyExchangeDN: /o=%(firstorg)s/ou=%(firstou)s/cn=Recipients/cn=%(groupname)s
 add: proxyAddresses
 proxyAddresses: SMTP:%(smtp_user)s
 proxyAddresses: =EX:/o=%(firstorg)s/ou=%(firstou)s/cn=Recipients/cn=%(groupname)s
-proxyAddresses: SMTP:postmaster@%(mail_domain)s
+proxyAddresses: smtp:postmaster@%(mail_domain)s
 proxyAddresses: X400:c=US;a= ;p=%(firstorg_x400)s;o=%(firstou_x400)s;s=%(groupname)s
 add: msExchRecipientTypeDetails
 msExchRecipientTypeDetails: %(recipient_type_details)s


### PR DESCRIPTION
This completes changeset [e92b1a5b19] setting postmaster address
as secondary SMTP address for group accounts.

See https://github.com/openchange/openchange/pull/306 for details