### PR TITLE
Open a shared calendar from address list in Outlook 2013

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 
 ### Fixes
 
+* Open a shared calendar from address list in Outlook 2013
 * Send event invitation mails to several attendees, mixing internal and external recipients
 
 ## [2.3]

--- a/exchange.idl
+++ b/exchange.idl
@@ -576,7 +576,7 @@ System Attendant Private Interface
 	/* Function 0x05 */
 	MAPISTATUS NspiGetMatches(
 		[in]		policy_handle		*handle,
-		[in]		uint32			Reserved,
+		[in]		uint32			Reserved1,
 		[in,out]	STAT			*pStat,
 		[in][unique]	SPropTagArray		*pReserved,
 		[in]		uint32			Reserved2,

--- a/libmapi/nspi.c
+++ b/libmapi/nspi.c
@@ -442,7 +442,7 @@ _PUBLIC_ enum MAPISTATUS nspi_GetMatches(struct nspi_context *nspi_ctx,
 	OPENCHANGE_RETVAL_IF(!ppOutMIds, MAPI_E_INVALID_PARAMETER, NULL);
 
 	r.in.handle = &nspi_ctx->handle;
-	r.in.Reserved = 0;
+	r.in.Reserved1 = 0;
 	
 	r.in.pStat = nspi_ctx->pStat;
 	r.in.pStat->ContainerID = 0x0;

--- a/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
+++ b/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
@@ -371,6 +371,7 @@ static void dcesrv_NspiUpdateStat(struct dcesrv_call_state *dce_call, TALLOC_CTX
 		DCESRV_NSP_RETURN(r, MAPI_E_LOGON_FAILED, NULL);
 	}
 
+	/* Step 0. Sanity checks from Server Processing Rules */
 	DCESRV_NSP_RETURN_IF(r->in.pStat->CodePage == CP_UNICODE, r, MAPI_E_NO_SUPPORT, NULL);
 
 	emsabp_ctx = dcesrv_find_emsabp_context(&r->in.handle->uuid);
@@ -381,12 +382,13 @@ static void dcesrv_NspiUpdateStat(struct dcesrv_call_state *dce_call, TALLOC_CTX
 		DCESRV_NSP_RETURN_IF(!container_exists, r, MAPI_E_INVALID_BOOKMARK, NULL);
 	}
 
+	/* Step 1. Search in the directory */
 	mids = talloc_zero(mem_ctx, struct PropertyTagArray_r);
 	DCESRV_NSP_RETURN_IF(!mids, r, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
 	retval = emsabp_search(mem_ctx, emsabp_ctx, mids, NULL, r->in.pStat, 0);
 	DCESRV_NSP_RETURN_IF(retval != MAPI_E_SUCCESS, r, retval, NULL);
 
-	/* After the checks and the retrieval do the update stat */
+	/* Step 2. Do the update stat with the result */
 	dcesrv_do_NspiUpdateStat(r, mids);
 }
 

--- a/mapiproxy/servers/default/nspi/emsabp.c
+++ b/mapiproxy/servers/default/nspi/emsabp.c
@@ -1141,21 +1141,6 @@ _PUBLIC_ enum MAPISTATUS emsabp_search(TALLOC_CTX *mem_ctx, struct emsabp_contex
 	struct ldb_server_sort_control	**ldb_sort_controls = NULL;
 	struct ldb_request		*ldb_req;
 
-	/* Step 0. Sanity Checks (MS-NSPI Server Processing Rules) */
-	if (pStat->SortType == SortTypePhoneticDisplayName) {
-		return MAPI_E_CALL_FAILED;
-	}
-
-	if (((pStat->SortType == SortTypeDisplayName) || (pStat->SortType == SortTypePhoneticDisplayName)) &&
-	    (pStat->ContainerID && (emsabp_tdb_lookup_MId(emsabp_ctx->tdb_ctx, pStat->ContainerID) == false))) {
-		return MAPI_E_INVALID_BOOKMARK;
-	}
-
-	if (restriction && (pStat->SortType != SortTypeDisplayName) &&
-	    (pStat->SortType != SortTypePhoneticDisplayName)) {
-		return MAPI_E_CALL_FAILED;
-	}
-
 	local_mem_ctx = talloc_new(NULL);
 	OPENCHANGE_RETVAL_IF(local_mem_ctx == NULL, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
 


### PR DESCRIPTION
By complying a little more the spec from [MS-OXNSPI].

Namely, we have followed strictly which checks are required for every operation related with a `emsabp_search` and added some easy-to-add sanity checks. Check every individual commit for details on which server processing rule has been included in which operation.

With these fixes, no more `MAPI_E_INVALID_BOOKMARK` is returned on requesting opening a shared calendar from the address list.