### PR TITLE
mapitest: Success on NspiUpdateStat with SortTypePhoneticDisplayName

### DIFF
--- a/utils/mapitest/modules/module_zentyal.c
+++ b/utils/mapitest/modules/module_zentyal.c
@@ -176,7 +176,7 @@ _PUBLIC_ bool mapitest_zentyal_1645(struct mapitest *mt)
 
 	retval = nspi_UpdateStat(nspi_ctx, mem_ctx, &plDelta);
 	mapitest_print_retval_clean(mt, "NspiUpdateStat", retval);
-	if (retval != MAPI_E_CALL_FAILED) {
+	if (retval != MAPI_E_SUCCESS) {
 		talloc_free(mem_ctx);
 		return false;
 	}


### PR DESCRIPTION
Although it can be not supported by the server, the specification
says nothing about updating STAT block with this SortType,
so we are not longer failing