### PR TITLE
Migration: add new attributes only to users with account enabled

### DIFF
--- a/python/openchange/migration/directory.py
+++ b/python/openchange/migration/directory.py
@@ -138,7 +138,7 @@ msExchRecipientDisplayType: 0
 """
 
         base_dn = "CN=Users,%s" % names.domaindn
-        ldb_filter = "(objectClass=user)"
+        ldb_filter = "(&(objectClass=user)(proxyAddresses=*))"
         res = db.search(base=base_dn, scope=ldb.SCOPE_SUBTREE, expression=ldb_filter)
         for element in res:
             # check if intrnal user


### PR DESCRIPTION
The msExchRecipientTypeDetails and  msExchRecipientDiplayType
attributes should only be added to users with openchange enabled
otherwise we will get error later when enabling them.