### PR TITLE
Provision: add --ignore-already-exists option

### DIFF
--- a/python/openchange/provision.py
+++ b/python/openchange/provision.py
@@ -394,7 +394,7 @@ def install_schemas(setup_path, names, lp, creds, reporter):
 
     sam_db = get_schema_master_samdb(names, lp, creds)
 
-    # Step 1. Extending the prefixmap attribute of the schema DN record
+    # Step 1. Extending the prefixMap attribute of the schema DN record
 
     reporter.reportNextStep("Register Exchange OIDs")
 
@@ -416,11 +416,9 @@ def install_schemas(setup_path, names, lp, creds, reporter):
             prefixmap_ldif += "dn:\nchangetype: modify\nreplace: schemaupdatenow\nschemaupdatenow: 1\n\n"
             dsdb._dsdb_set_schema_from_ldif(sam_db, prefixmap_ldif, schema_ldif, schemadn)
     except RuntimeError as err:
-        print ("[!] error while provisioning the prefixMap: %s"
-               % str(err))
+        print ("[!] error while provisioning the prefixMap: %s" % err)
     except LdbError as err:
-        print ("[!] error while provisioning the prefixMap: %s"
-               % str(err))
+        print ("[!] error while provisioning the prefixMap: %s" % err)
 
     schemas = [{'path': 'AD/oc_provision_schema_attributes.ldif',
                 'description': 'Add Exchange attributes to Samba schema',
@@ -457,7 +455,8 @@ def install_schemas(setup_path, names, lp, creds, reporter):
 
     for schema in schemas:
         try:
-            provision_schema(sam_db, setup_path, names, reporter, schema['path'], schema['description'], schema['modify_mode'])
+            provision_schema(sam_db, setup_path, names, reporter, schema['path'],
+                             schema['description'], schema['modify_mode'])
         except LdbError, ldb_error:
             print ("[!] error while provisioning the Exchange"
                    " schema classes (%d): %s"
@@ -465,7 +464,9 @@ def install_schemas(setup_path, names, lp, creds, reporter):
             raise
 
     try:
-        provision_schema(sam_db, setup_path, names, reporter, "AD/oc_provision_configuration.ldif", "Generic Exchange configuration objects")
+        provision_schema(sam_db, setup_path, names, reporter,
+                         "AD/oc_provision_configuration.ldif",
+                         "Generic Exchange configuration objects")
     except LdbError, ldb_error:
         print ("[!] error while provisioning the Exchange configuration"
                " objects (%d): %s" % ldb_error.args)

--- a/python/openchange/provision.py
+++ b/python/openchange/provision.py
@@ -613,7 +613,7 @@ def exists_dn(sam_db, dn):
         return len(ret) > 0
     except LdbError as ex:
         code, leftover = ex
-        if code == 32:
+        if code == ldb.ERR_NO_SUCH_OBJECT:
             return False
         else:
             raise ex

--- a/setup/openchange_provision
+++ b/setup/openchange_provision
@@ -62,6 +62,8 @@ parser.add_option("--firstou", type="string", metavar="FIRSTOU",
                   help="set OpenChange Administrative Group (otherwise 'First Administrative Group')")
 parser.add_option("--standalone", action="store_true", help="Provisioning an standalone OpenChange server")
 parser.add_option("--additional", action="store_true", help="Provisioning an additional OpenChange server")
+parser.add_option("--ignore-already-exists", action="store_true",
+                  help="Ignore errors when installing schemas that already exists")
 parser.add_option("--primary-server", action="store_true", help="Set this OpenChange server as the primary server")
 parser.add_option("--openchangedb", action="store_true", help="Initialize OpenChange dispatcher database")
 parser.add_option("--openchangedb-uri", type="string", default="ldb://openchange.ldb",
@@ -101,16 +103,23 @@ if opts.deprovision:
         print >> sys.stderr, "[!] Unable to unregister this server, it's being used for: %s" % str(e)
         sys.exit(1)
 elif opts.additional and opts.primary_server:
-    openchange.register(setup_path, provisionnames, lp, creds)
-    openchange.registerasmain(setup_path, provisionnames, lp, creds)
+    openchange.register(setup_path, provisionnames, lp, creds,
+                        ignore_already_exists=opts.ignore_already_exists)
+    openchange.registerasmain(setup_path, provisionnames, lp, creds,
+                              ignore_already_exists=opts.ignore_already_exists)
 elif opts.additional:
-    openchange.register(setup_path, provisionnames, lp, creds)
+    openchange.register(setup_path, provisionnames, lp, creds,
+                        ignore_already_exists=opts.ignore_already_exists)
 elif opts.standalone:
-    openchange.provision(setup_path, provisionnames, lp, creds)
-    openchange.register(setup_path, provisionnames, lp, creds)
-    openchange.registerasmain(setup_path, provisionnames, lp, creds)
+    openchange.provision(setup_path, provisionnames, lp, creds,
+                         ignore_already_exists=opts.ignore_already_exists)
+    openchange.register(setup_path, provisionnames, lp, creds,
+                        ignore_already_exists=opts.ignore_already_exists)
+    openchange.registerasmain(setup_path, provisionnames, lp, creds,
+                              ignore_already_exists=opts.ignore_already_exists)
 elif opts.primary_server:
-    openchange.registerasmain(setup_path, provisionnames, lp, creds)
+    openchange.registerasmain(setup_path, provisionnames, lp, creds,
+                              ignore_already_exists=opts.ignore_already_exists)
 elif opts.migrate:
     openchange.openchangedb_migrate(lp)
 elif opts.check:

--- a/setup/openchange_provision
+++ b/setup/openchange_provision
@@ -40,7 +40,7 @@ def check_incompatible_options(parser, opts):
                     continue
                 else:
                     # for the error msg put the options in their command line shape
-                    active_option = '--' + active_option.replace('_', '-')                    
+                    active_option = '--' + active_option.replace('_', '-')
                     option_name   = '--' + option_name.replace('_', '-')
                     parser.error("The options " + active_option + " and " + option_name + " are mutually exclusive")
             else:


### PR DESCRIPTION
To ignore ldap errors when inserting new schemas.

Disabled by default but really useful in some scenarios.