### PR TITLE
[oxcnotif] Support SOGo URLs with the mail address as username

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 
 ### Fixes
 
+* Support notifications when the username is a mail address (e.g. Zentyal Cloud)
 * Open a shared calendar from address list in Outlook 2013
 * Send event invitation mails to several attendees, mixing internal and external recipients
 


### PR DESCRIPTION
When building the MAPIStore SOGo URLs, the `username` part can be a mail
address. In that case, we need to replace the `'@'` character in it by
`"%40"`.