### PR TITLE
Fix hierarchy synchronization issues / Improve FastTransfer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 
 * Open a shared calendar from address list in Outlook 2013
 * Send event invitation mails to several attendees, mixing internal and external recipients
+* Fix folder hierarchy synchronization issues on mailbox subfolders
 
 ## [2.3]
 

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
@@ -336,7 +336,7 @@ enum MAPISTATUS       emsmdbp_object_open_folder_by_fid(TALLOC_CTX *, struct ems
 
 struct emsmdbp_object *emsmdbp_object_init(TALLOC_CTX *, struct emsmdbp_context *, struct emsmdbp_object *parent_object);
 int emsmdbp_object_copy_properties(struct emsmdbp_context *, struct emsmdbp_object *, struct emsmdbp_object *, struct SPropTagArray *, bool);
-int emsmdbp_object_copy_properties_submit(struct emsmdbp_context *, struct emsmdbp_object *, struct emsmdbp_object *, struct SPropTagArray *, bool);
+enum MAPISTATUS emsmdbp_object_copy_properties_submit(struct emsmdbp_context *, struct emsmdbp_object *, struct emsmdbp_object *, struct SPropTagArray *, bool);
 struct emsmdbp_object *emsmdbp_object_mailbox_init(TALLOC_CTX *, struct emsmdbp_context *, const char *, bool);
 struct emsmdbp_object *emsmdbp_object_folder_init(TALLOC_CTX *, struct emsmdbp_context *, uint64_t, struct emsmdbp_object *);
 enum MAPISTATUS      emsmdbp_folder_get_folder_count(struct emsmdbp_context *, struct emsmdbp_object *, uint32_t *);

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
@@ -336,6 +336,7 @@ enum MAPISTATUS       emsmdbp_object_open_folder_by_fid(TALLOC_CTX *, struct ems
 
 struct emsmdbp_object *emsmdbp_object_init(TALLOC_CTX *, struct emsmdbp_context *, struct emsmdbp_object *parent_object);
 int emsmdbp_object_copy_properties(struct emsmdbp_context *, struct emsmdbp_object *, struct emsmdbp_object *, struct SPropTagArray *, bool);
+int emsmdbp_object_copy_properties_submit(struct emsmdbp_context *, struct emsmdbp_object *, struct emsmdbp_object *, struct SPropTagArray *, bool);
 struct emsmdbp_object *emsmdbp_object_mailbox_init(TALLOC_CTX *, struct emsmdbp_context *, const char *, bool);
 struct emsmdbp_object *emsmdbp_object_folder_init(TALLOC_CTX *, struct emsmdbp_context *, uint64_t, struct emsmdbp_object *);
 enum MAPISTATUS      emsmdbp_folder_get_folder_count(struct emsmdbp_context *, struct emsmdbp_object *, uint32_t *);

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -868,7 +868,11 @@ static int emsmdbp_copy_properties(struct emsmdbp_context *emsmdbp_ctx, struct e
 	}
 
 	needed_properties = talloc_zero(mem_ctx, struct SPropTagArray);
+	OPENCHANGE_RETVAL_IF(!needed_properties, MAPI_E_NOT_ENOUGH_MEMORY, mem_ctx);
+
 	needed_properties->aulPropTag = talloc_zero(needed_properties, void);
+	OPENCHANGE_RETVAL_IF(!needed_properties->aulPropTag, MAPI_E_NOT_ENOUGH_MEMORY, mem_ctx);
+
 	for (i = 0; i < properties->cValues; i++) {
 		if (!properties_exclusion[(uint16_t) (properties->aulPropTag[i] >> 16)]) {
 			SPropTagArray_add(mem_ctx, needed_properties, properties->aulPropTag[i]);
@@ -878,6 +882,8 @@ static int emsmdbp_copy_properties(struct emsmdbp_context *emsmdbp_ctx, struct e
 	data_pointers = emsmdbp_object_get_properties(mem_ctx, emsmdbp_ctx, source_object, needed_properties, &retvals);
 	if (data_pointers) {
 		aRow = talloc_zero(mem_ctx, struct SRow);
+		OPENCHANGE_RETVAL_IF(!aRow, MAPI_E_NOT_ENOUGH_MEMORY, mem_ctx);
+
 		for (i = 0; i < needed_properties->cValues; i++) {
 			if (retvals[i] == MAPI_E_SUCCESS) {
 				/* _PUBLIC_ enum MAPISTATUS SRow_addprop(struct SRow *aRow, struct SPropValue spropvalue) */
@@ -958,7 +964,11 @@ static int emsmdbp_copy_properties_submit(struct emsmdbp_context *emsmdbp_ctx, s
 	}
 
 	needed_properties = talloc_zero(mem_ctx, struct SPropTagArray);
+	OPENCHANGE_RETVAL_IF(!needed_properties, MAPI_E_NOT_ENOUGH_MEMORY, mem_ctx);
+
 	needed_properties->aulPropTag = talloc_zero(needed_properties, void);
+	OPENCHANGE_RETVAL_IF(!needed_properties->aulPropTag, MAPI_E_NOT_ENOUGH_MEMORY, mem_ctx);
+
 	for (i = 0; i < properties->cValues; i++) {
 		if (!properties_exclusion[(uint16_t) (properties->aulPropTag[i] >> 16)]) {
 			SPropTagArray_add(mem_ctx, needed_properties, properties->aulPropTag[i]);
@@ -968,6 +978,8 @@ static int emsmdbp_copy_properties_submit(struct emsmdbp_context *emsmdbp_ctx, s
 	data_pointers = emsmdbp_object_get_properties(mem_ctx, emsmdbp_ctx, source_object, needed_properties, &retvals);
 	if (data_pointers) {
 		aRow = talloc_zero(mem_ctx, struct SRow);
+		OPENCHANGE_RETVAL_IF(!aRow, MAPI_E_NOT_ENOUGH_MEMORY, mem_ctx);
+
 		for (i = 0; i < needed_properties->cValues; i++) {
 			if (retvals[i] == MAPI_E_SUCCESS) {
 				set_SPropValue_proptag(&newValue, needed_properties->aulPropTag[i], data_pointers[i]);

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -833,6 +833,7 @@ static int emsmdbp_copy_properties(struct emsmdbp_context *emsmdbp_ctx, struct e
 	struct SRow		*aRow;
 	struct SPropValue	newValue;
 	uint32_t		i;
+	int			ret;
 
 	mem_ctx = talloc_new(NULL);
 	OPENCHANGE_RETVAL_IF(!mem_ctx, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
@@ -891,7 +892,10 @@ static int emsmdbp_copy_properties(struct emsmdbp_context *emsmdbp_ctx, struct e
 				SRow_addprop(aRow, newValue);
 			}
 		}
-		if (emsmdbp_object_set_properties(emsmdbp_ctx, dest_object, aRow) != MAPISTORE_SUCCESS) {
+
+		ret = emsmdbp_object_set_properties(emsmdbp_ctx, dest_object, aRow);
+		if (ret != MAPISTORE_SUCCESS) {
+			OC_DEBUG(5, "emsmdbp_object_set_properties failed with error code 0x%x", ret);
 			talloc_free(mem_ctx);
 			return MAPI_E_NO_SUPPORT;
 		}
@@ -930,6 +934,7 @@ static enum MAPISTATUS emsmdbp_copy_properties_submit(struct emsmdbp_context *em
 	enum MAPISTATUS         *retvals = NULL;
 	struct SRow		*aRow;
 	struct SPropValue	newValue;
+	int			ret;
 	uint32_t		i;
 
 	mem_ctx = talloc_new(NULL);
@@ -986,7 +991,10 @@ static enum MAPISTATUS emsmdbp_copy_properties_submit(struct emsmdbp_context *em
 				SRow_addprop(aRow, newValue);
 			}
 		}
-		if (emsmdbp_object_set_properties(emsmdbp_ctx, dest_object, aRow) != MAPISTORE_SUCCESS) {
+
+		ret = emsmdbp_object_set_properties(emsmdbp_ctx, dest_object, aRow);
+		if (ret != MAPISTORE_SUCCESS) {
+			OC_DEBUG(5, "emsmdbp_object_set_properties failed with error code 0x%x", ret);
 			talloc_free(mem_ctx);
 			return MAPI_E_NO_SUPPORT;
 		}

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -921,7 +921,7 @@ static int emsmdbp_copy_properties(struct emsmdbp_context *emsmdbp_ctx, struct e
 
    \return MAPI_E_SUCCESS on success, otherwise MAPI error.
  */
-static int emsmdbp_copy_properties_submit(struct emsmdbp_context *emsmdbp_ctx, struct emsmdbp_object *source_object, struct emsmdbp_object *dest_object, struct SPropTagArray *excluded_tags)
+static enum MAPISTATUS emsmdbp_copy_properties_submit(struct emsmdbp_context *emsmdbp_ctx, struct emsmdbp_object *source_object, struct emsmdbp_object *dest_object, struct SPropTagArray *excluded_tags)
 {
 	TALLOC_CTX		*mem_ctx;
 	bool			properties_exclusion[65536];
@@ -1162,9 +1162,9 @@ static inline int emsmdbp_copy_message_attachments_mapistore(struct emsmdbp_cont
 
    \return Allocated emsmdbp object on success, otherwise NULL
  */
-_PUBLIC_ int emsmdbp_object_copy_properties_submit(struct emsmdbp_context *emsmdbp_ctx, struct emsmdbp_object *source_object, struct emsmdbp_object *target_object, struct SPropTagArray *excluded_properties, bool deep_copy)
+_PUBLIC_ enum MAPISTATUS emsmdbp_object_copy_properties_submit(struct emsmdbp_context *emsmdbp_ctx, struct emsmdbp_object *source_object, struct emsmdbp_object *target_object, struct SPropTagArray *excluded_properties, bool deep_copy)
 {
-	int ret;
+	enum MAPISTATUS ret;
 
 	if (!(source_object->type == EMSMDBP_OBJECT_FOLDER
 	      || source_object->type == EMSMDBP_OBJECT_MAILBOX

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -920,8 +920,8 @@ static int emsmdbp_copy_properties_submit(struct emsmdbp_context *emsmdbp_ctx, s
 	TALLOC_CTX		*mem_ctx;
 	bool			properties_exclusion[65536];
 	struct SPropTagArray	*properties, *needed_properties;
-        void                    **data_pointers;
-        enum MAPISTATUS         *retvals = NULL;
+	void                    **data_pointers;
+	enum MAPISTATUS         *retvals = NULL;
 	struct SRow		*aRow;
 	struct SPropValue	newValue;
 	uint32_t		i;

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -900,6 +900,95 @@ static int emsmdbp_copy_properties(struct emsmdbp_context *emsmdbp_ctx, struct e
 	return MAPI_E_SUCCESS;
 }
 
+/**
+   \details Copy properties from one emsmdb object to the other within
+   the context of message submission
+
+   \param emsmdbp_ctx pointer to the emsmdbp context
+   \param source_object the source object to copy properties from
+   \param dest_object the destination object
+   \param excluded_tags the set of property tags excluded from the copy
+
+   \note This version is a copy of emsmdbp_copy_properties but which
+   removes the exclusion of PidTagChangeKey and
+   PidTagPredecessorChangeList properties.
+
+   \return MAPI_E_SUCCESS on success, otherwise MAPI error.
+ */
+static int emsmdbp_copy_properties_submit(struct emsmdbp_context *emsmdbp_ctx, struct emsmdbp_object *source_object, struct emsmdbp_object *dest_object, struct SPropTagArray *excluded_tags)
+{
+	TALLOC_CTX		*mem_ctx;
+	bool			properties_exclusion[65536];
+	struct SPropTagArray	*properties, *needed_properties;
+        void                    **data_pointers;
+        enum MAPISTATUS         *retvals = NULL;
+	struct SRow		*aRow;
+	struct SPropValue	newValue;
+	uint32_t		i;
+
+	mem_ctx = talloc_new(NULL);
+	OPENCHANGE_RETVAL_IF(!mem_ctx, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
+
+	if (emsmdbp_object_get_available_properties(mem_ctx, emsmdbp_ctx, source_object, &properties) == MAPISTORE_ERROR) {
+		OC_DEBUG(0, "mapistore support not implemented yet - shouldn't occur\n");
+		talloc_free(mem_ctx);
+		return MAPI_E_NO_SUPPORT;
+	}
+
+	/* 1. Exclusions */
+	memset(properties_exclusion, 0, 65536 * sizeof(bool));
+
+	/* 1a. Explicit exclusions */
+	properties_exclusion[(uint16_t) (PidTagRowType >> 16)] = true;
+	properties_exclusion[(uint16_t) (PidTagInstanceKey >> 16)] = true;
+	properties_exclusion[(uint16_t) (PidTagInstanceNum >> 16)] = true;
+	properties_exclusion[(uint16_t) (PidTagInstID >> 16)] = true;
+	properties_exclusion[(uint16_t) (PidTagFolderId >> 16)] = true;
+	properties_exclusion[(uint16_t) (PidTagMid >> 16)] = true;
+	properties_exclusion[(uint16_t) (PidTagSourceKey >> 16)] = true;
+	properties_exclusion[(uint16_t) (PidTagParentSourceKey >> 16)] = true;
+	properties_exclusion[(uint16_t) (PidTagParentFolderId >> 16)] = true;
+	properties_exclusion[(uint16_t) (PidTagChangeNumber >> 16)] = true;
+
+	/* 1b. Request exclusions */
+	if (excluded_tags != NULL) {
+		for (i = 0; i < excluded_tags->cValues; i++) {
+			properties_exclusion[(uint16_t) (excluded_tags->aulPropTag[i] >> 16)] = true;
+		}
+	}
+
+	needed_properties = talloc_zero(mem_ctx, struct SPropTagArray);
+	needed_properties->aulPropTag = talloc_zero(needed_properties, void);
+	for (i = 0; i < properties->cValues; i++) {
+		if (!properties_exclusion[(uint16_t) (properties->aulPropTag[i] >> 16)]) {
+			SPropTagArray_add(mem_ctx, needed_properties, properties->aulPropTag[i]);
+		}
+	}
+
+	data_pointers = emsmdbp_object_get_properties(mem_ctx, emsmdbp_ctx, source_object, needed_properties, &retvals);
+	if (data_pointers) {
+		aRow = talloc_zero(mem_ctx, struct SRow);
+		for (i = 0; i < needed_properties->cValues; i++) {
+			if (retvals[i] == MAPI_E_SUCCESS) {
+				set_SPropValue_proptag(&newValue, needed_properties->aulPropTag[i], data_pointers[i]);
+				SRow_addprop(aRow, newValue);
+			}
+		}
+		if (emsmdbp_object_set_properties(emsmdbp_ctx, dest_object, aRow) != MAPISTORE_SUCCESS) {
+			talloc_free(mem_ctx);
+			return MAPI_E_NO_SUPPORT;
+		}
+	}
+	else {
+		talloc_free(mem_ctx);
+		return MAPI_E_NO_SUPPORT;
+	}
+
+	talloc_free(mem_ctx);
+
+	return MAPI_E_SUCCESS;
+}
+
 static inline int emsmdbp_copy_message_recipients_mapistore(struct emsmdbp_context *emsmdbp_ctx, struct emsmdbp_object *source_object, struct emsmdbp_object *dest_object)
 {
 	TALLOC_CTX			*mem_ctx;
@@ -1044,6 +1133,77 @@ static inline int emsmdbp_copy_message_attachments_mapistore(struct emsmdbp_cont
 
 	return MAPI_E_SUCCESS;
 }
+
+
+/**
+   \details Copy properties from an object to another object
+
+   \param emsmdbp_ctx pointer to the emsmdb provider context
+   \param source_object pointer to the source object
+   \param target_object pointer to the target object
+   \param excluded_properties pointer to a SPropTagArray listing properties that must not be copied
+   \param deep_copy indicates whether subobjects must be copied
+
+   \note This version is a copy of emsmdbp_object_copy_properties but
+   which removes the exclusion of PidTagChangeKey and
+   PidTagPredecessorChangeList properties.
+
+   \return Allocated emsmdbp object on success, otherwise NULL
+ */
+_PUBLIC_ int emsmdbp_object_copy_properties_submit(struct emsmdbp_context *emsmdbp_ctx, struct emsmdbp_object *source_object, struct emsmdbp_object *target_object, struct SPropTagArray *excluded_properties, bool deep_copy)
+{
+	int ret;
+
+	if (!(source_object->type == EMSMDBP_OBJECT_FOLDER
+	      || source_object->type == EMSMDBP_OBJECT_MAILBOX
+	      || source_object->type == EMSMDBP_OBJECT_MESSAGE
+	      || source_object->type == EMSMDBP_OBJECT_ATTACHMENT)) {
+		OC_DEBUG(0, "object must be EMSMDBP_OBJECT_FOLDER, EMSMDBP_OBJECT_MAILBOX, EMSMDBP_OBJECT_MESSAGE or EMSMDBP_OBJECT_ATTACHMENT (type =  %d)\n", source_object->type);
+		ret = MAPI_E_NO_SUPPORT;
+		goto end;
+	}
+	if (target_object->type != source_object->type) {
+		OC_DEBUG(0, "source and destination objects type must match (type =  %d)\n", target_object->type);
+		ret = MAPI_E_NO_SUPPORT;
+		goto end;
+	}
+
+	/* copy properties (common to all object types) */
+	ret = emsmdbp_copy_properties_submit(emsmdbp_ctx, source_object, target_object, excluded_properties);
+	if (ret != MAPI_E_SUCCESS) {
+                goto end;
+	}
+
+	/* type specific ops */
+	switch (source_object->type) {
+	case EMSMDBP_OBJECT_MESSAGE:
+		if (emsmdbp_is_mapistore(source_object) && emsmdbp_is_mapistore(target_object)) {
+			ret = emsmdbp_copy_message_recipients_mapistore(emsmdbp_ctx, source_object, target_object);
+			if (ret != MAPI_E_SUCCESS) {
+				goto end;
+			}
+			if (deep_copy) {
+				ret = emsmdbp_copy_message_attachments_mapistore(emsmdbp_ctx, source_object, target_object);
+				if (ret != MAPI_E_SUCCESS) {
+					goto end;
+				}
+			}
+		}
+		else {
+			OC_DEBUG(0, "Cannot copy recipients or attachments to or from non-mapistore messages\n");
+		}
+		break;
+	default:
+		if (deep_copy) {
+			OC_DEBUG(0, "Cannot deep copy non-message objects\n");
+		}
+	}
+
+end:
+
+	return ret;
+}
+
 
 /**
    \details Copy properties from an object to another object

--- a/mapiproxy/servers/default/emsmdb/oxcfxics.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfxics.c
@@ -1438,9 +1438,9 @@ static void oxcfxics_push_folderChange(struct emsmdbp_context *emsmdbp_ctx, stru
 
 			/* change key */
 			/* work-around an issue in SOGo that generates an empty predecessor change list blob */
-			if ((retvals[sync_data->prop_index.change_key]) ||
+			if ((retvals[sync_data->prop_index.change_key] != MAPI_E_SUCCESS) ||
 			    ((retvals[sync_data->prop_index.change_key] == MAPI_E_SUCCESS) &&
-			     (retvals[sync_data->prop_index.predecessor_change_list]))) {
+			     (retvals[sync_data->prop_index.predecessor_change_list] != MAPI_E_SUCCESS))) {
 				bin_data = oxcfxics_make_gid(header_data_pointers, &sync_data->replica_guid, cn);
 			} else {
 				bin_data = data_pointers[sync_data->prop_index.change_key];
@@ -1453,7 +1453,7 @@ static void oxcfxics_push_folderChange(struct emsmdbp_context *emsmdbp_ctx, stru
 
 			/* predecessor... (already computed) */
 			query_props.aulPropTag[j] = PidTagPredecessorChangeList;
-			if (retvals[sync_data->prop_index.predecessor_change_list]) {
+			if (retvals[sync_data->prop_index.predecessor_change_list] != MAPI_E_SUCCESS) {
 				predecessors_data.cb = bin_data->cb + 1;
 				predecessors_data.lpb = talloc_array(header_data_pointers, uint8_t, predecessors_data.cb);
 				*predecessors_data.lpb = bin_data->cb & 0xff;

--- a/mapiproxy/servers/default/emsmdb/oxcfxics.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfxics.c
@@ -1437,7 +1437,14 @@ static void oxcfxics_push_folderChange(struct emsmdbp_context *emsmdbp_ctx, stru
 			RAWIDSET_push_guid_glob(sync_data->cnset_seen, &sync_data->replica_guid, cn);
 
 			/* change key */
-			/* work-around an issue in SOGo that generates an empty predecessor change list blob */
+
+			/* When the SOGo backend generates the PidTagChangeKey for folders on first synchronization,
+			   it generates a PidTagChangeKey with the replicaID part filled with zeros. This property value
+			   is then used to populate the PidTagPredecessorChangeList. Using an empty replicaID is however
+			   causing Outlook to generate Synchronization Issues. If the PidTagPredecessorChangeList property
+			   is missing, it means we are synchronizing a folder for the first time. The following condition
+			   therefore ensures that a proper PidTagChangeKey is generated to comply with Outlook requirements.
+			*/
 			if ((retvals[sync_data->prop_index.change_key] != MAPI_E_SUCCESS) ||
 			    ((retvals[sync_data->prop_index.change_key] == MAPI_E_SUCCESS) &&
 			     (retvals[sync_data->prop_index.predecessor_change_list] != MAPI_E_SUCCESS))) {

--- a/mapiproxy/servers/default/emsmdb/oxcfxics.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfxics.c
@@ -1773,11 +1773,14 @@ static inline void oxcfxics_fill_synccontext_fasttransfer_response(struct FastTr
 				OC_DEBUG(5, "synccontext buffer is %u bytes long\n", (uint32_t) synccontext->stream.buffer.length);
 			}
 			response->TransferBuffer = emsmdbp_stream_read_buffer(&synccontext->stream, buffer_size);
+
+			if (synccontext->stream.position == synccontext->stream.buffer.length) {
+				end_of_buffer = true;
+			}
 		}
 	}
 
 	response->TotalStepCount = synccontext->total_steps;
-	/* if (synccontext->stream.position == synccontext->stream.buffer.length) { */
 	if (end_of_buffer) {
 		response->TransferStatus = TransferStatus_Done;
 		response->InProgressCount = response->TotalStepCount;

--- a/mapiproxy/servers/default/emsmdb/oxomsg.c
+++ b/mapiproxy/servers/default/emsmdb/oxomsg.c
@@ -123,7 +123,8 @@ static void oxomsg_mapistore_handle_message_relocation(struct emsmdbp_context *e
 
 		/* FIXME: (from oxomsg 3.2.5.1) PidTagMessageFlags: mfUnsent and mfRead must be cleared.
 		   Note: Property not managed by any current mapistore backend */
-		emsmdbp_object_copy_properties(emsmdbp_ctx, old_message_object, message_object, &excluded_tags, true);
+		/* Copy PidTagChangeKey / PidTagPredecessorChangeList */
+		emsmdbp_object_copy_properties_submit(emsmdbp_ctx, old_message_object, message_object, &excluded_tags, true);
 
 		mapistore_message_save(emsmdbp_ctx->mstore_ctx, contextID, message_object->backend_object, mem_ctx);
 		mapistore_indexing_record_add_mid(emsmdbp_ctx->mstore_ctx, contextID, owner, messageID);


### PR DESCRIPTION
When Synchronizing Hierarchy of folders, TransferStatus was always
set to TransferPartial even if the transfer was completed. This commit
compares the position and length of the stream to determine if it is
over or not.