### PR TITLE
Improve mapitest over oxcfxics downloading

### DIFF
--- a/utils/mapitest/mapitest_print.c
+++ b/utils/mapitest/mapitest_print.c
@@ -674,3 +674,28 @@ _PUBLIC_ void mapitest_print_PAB_entry(struct mapitest *mt, struct PropertyRow_r
 
 	mapidump_PAB_entry(aRow);
 }
+
+/**
+   \details Print assert result
+
+   \param mt pointer to the top-level mapitest structure
+   \param name the test name
+   \param assert_result the assert result to output
+
+ */
+_PUBLIC_ void mapitest_print_assert(struct mapitest *mt, char *name, bool assert_result)
+{
+	const char	*retstr = NULL;
+
+	if (mt->subunit_output) {
+		return;
+	}
+
+	retstr = assert_result ? "TRUE" : "FALSE";
+
+	if (mt->color == true) {
+                mapitest_print(mt, "* %-35s: %s %s %s \n", name, (assert_result ? MT_RED : MT_GREEN), retstr, MT_WHITE);
+	} else {
+                mapitest_print(mt, "* %-35s: %s\n", name, retstr);
+	}
+}

--- a/utils/mapitest/module.c
+++ b/utils/mapitest/module.c
@@ -300,7 +300,8 @@ _PUBLIC_ uint32_t module_oxcfxics_init(struct mapitest *mt)
 	mapitest_suite_add_test(suite, "COPYTO", "Test CopyTo operation", mapitest_oxcfxics_CopyTo);
 	mapitest_suite_add_test(suite, "COPYPROPS", "Test CopyProperties operation", mapitest_oxcfxics_CopyProperties);
 	mapitest_suite_add_test(suite, "DEST-CONFIGURE", "Test Destination Configure operation", mapitest_oxcfxics_DestConfigure);
-	mapitest_suite_add_test(suite, "SYNC-CONFIGURE", "Configure ICS context for download", mapitest_oxcfxics_SyncConfigure);
+	mapitest_suite_add_test(suite, "SYNC-CONFIGURE-HIERARCHY", "Configure ICS hierarchy context for download", mapitest_oxcfxics_SyncConfigureHierarchy);
+	mapitest_suite_add_test(suite, "SYNC-CONFIGURE-CONTENTS", "Configure ICS contents context for download", mapitest_oxcfxics_SyncConfigureContents);
 	mapitest_suite_add_test(suite, "SET-LOCAL-REPLICA-MIDSET-DELETED", "Reserve a range of local replica IDs", mapitest_oxcfxics_SetLocalReplicaMidsetDeleted);
 	mapitest_suite_add_test(suite, "SYNC-OPEN-COLLECTOR", "Test opening ICS upload collector", mapitest_oxcfxics_SyncOpenCollector);
 


### PR DESCRIPTION
* Hierarchy synchronisation
    * Over the parent folder to include data
    * Download the configured Fast Transfer buffer
    * Check the transfer is done (Fixed in #331)
    * Parse the buffer to see it is correct

* Include Contents synchronisation