### PR TITLE
ocsmanager: fix empty offline address book

### DIFF
--- a/mapiproxy/services/ocsmanager/ocsmanager/config/routing.py
+++ b/mapiproxy/services/ocsmanager/ocsmanager/config/routing.py
@@ -20,7 +20,10 @@ def make_map(config):
 
     # CUSTOM ROUTES HERE
     map.connect('/autodiscover/{action}.xml', controller="autodiscover")
-    map.connect('/ews/oab.xml', controller="oab", action="oab")
+    map.connect('/ews/oab.xml', controller="oab", action="get_oab",
+                conditions={'method': ["GET", "POST"]})
+    map.connect('/ews/oab.xml', controller="oab", action="head_oab",
+                conditions={'method': ["HEAD"]})
     map.connect('/ews/{controller}')
     map.connect('/ews/{controller}.wsdl')
     map.connect('/{controller}/{action}')

--- a/mapiproxy/services/ocsmanager/ocsmanager/controllers/oab.py
+++ b/mapiproxy/services/ocsmanager/ocsmanager/controllers/oab.py
@@ -25,11 +25,15 @@ from ocsmanager.lib.base import BaseController
 
 class OabController(BaseController):
     """The constroller class for OAB requests."""
-    @restrict('POST', 'GET')
-    def oab(self, **kwargs):
+
+    def get_oab(self, **kwargs):
+        # TODO
         response.headers["content-type"] = "application/xml"
         body = """<?xml version="1.0" encoding="UTF-8"?>
         <OAB>
-       </OAB>"""
+        </OAB>"""
         return body
 
+    def head_oab(self, **kwargs):
+        # TODO
+        pass


### PR DESCRIPTION
Allow HEAD request, otherwise I'm getting sync issues and outlook won't download the (empty) oab.