### PR TITLE
Provision all group and other provision fixes

### DIFF
--- a/python/openchange/provision.py
+++ b/python/openchange/provision.py
@@ -5,6 +5,7 @@
 # Copyright (C) Jelmer Vernooij <jelmer@openchange.org> 2008-2009
 # Copyright (C) Julien Kerihuel <j.kerihuel@openchange.org> 2009
 # Copyright (C) Enrique J. Hernández <ejhernandez@zentyal.com> 2015
+# Copyright (C) Javier Amor Garcia <jamor@zentyal.com> 2015
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -732,7 +733,7 @@ def delete_user(names, lp, creds, username=None):
         print "[!] User '%s' not found" % username
         return
 
-    to_delete = ['mailNickName', 'homeMDB', 'homeMTA',' legacyExchangeDN',
+    to_delete = ['mailNickName', 'homeMDB', 'homeMTA', 'legacyExchangeDN',
                  'proxyAddresses', 'msExchUserAccountControl',
                  'msExchRecipientTypeDetails', 'msExchRecipientDisplayType']
     _delete_attrs_ignore_nonexistent(db, user_dn, to_delete)
@@ -788,7 +789,12 @@ def enable_all_groups_in_organization(names, lp, creds, org_name):
     """enable all groups in the given organization
 
     Groups without mail atrtibute are ignored
-    This methods only works in schemas where the groups reside under "CN=Groups,CN=%s,CN=Users,%s" % (org_name, domain_dn)
+    This method only works in schemas where the groups reside under "CN=Groups,CN=%s,CN=Users,%s" % (org_name, domain_dn)
+
+    :param names: provision names object.
+    :param lp: Loadparm context
+    :param creds: Credentials context
+    :param org_name: Name of the organization where the groups reside
     """
     basedn = "CN=Groups,CN=%s,CN=Users,%s" % (org_name, names.domaindn)
     ldap_filter = "(&(objectClass=group)(mail=*))"
@@ -804,7 +810,7 @@ def enable_all_groups_in_organization(names, lp, creds, org_name):
         _enable_group(db, names, dn, cn, mail)
 
 
-def _enable_group(db, names, group_dn, groupname, mail=None,):
+def _enable_group(db, names, group_dn, groupname, mail=None):
     smtp_user, mail_domain = _smtp_user_and_domain_by_dn(group_dn, groupname, mail, names)
     (recipient_type_details, recipient_display_type) = _group_recipient_type_details(db, group_dn)
     extended_group = """

--- a/setup/openchange_group
+++ b/setup/openchange_group
@@ -43,30 +43,39 @@ parser.add_option("--delete", action="store_true", metavar="DISABLE",
                   help="Delete OpenChange attributes for group")
 parser.add_option("--update", action="store_true", metavar="DISABLE",
                   help="Update OpenChange attributes for group after switching between ditribution and security group")
+parser.add_option("--enable-all-groups", action="store_true",
+                  help="Enable all groups when provisioning organization")
 parser.add_option("--mail", type="string", metavar="MAIL",
                   help="Group email address. If not specified, the email "
                        "will be samaccountname@realm")
+
 opts, args = parser.parse_args()
 
-if len(args) != 1:
+if len(args) != 1 and not opts.enable_all_groups:
     parser.print_usage()
     sys.exit(1)
 
-action_options = filter(lambda(x): x, [opts.create, opts.delete, opts.update])
+action_options = filter(lambda(x): x, [opts.create, opts.delete, opts.update, opts.enable_all_groups])
 if len(action_options) == 0:
-    parser.error("missing action option: --create, --delete and --update")
+    parser.error("missing action option: --create, --delete, --update or --enable-all-groups")
 elif len(action_options) > 1:
-    parser.error("--create, delete and update options are incompatible")
+    parser.error("--create, delete, update and enable-all-groups options are incompatible")
 
-groupname = args[0]
 lp = sambaopts.get_loadparm()
 creds = credopts.get_credentials(lp)
 provisionnames = provision.guess_names_from_smbconf(
     lp, creds, opts.firstorg, opts.firstou)
 
 if opts.create:
+    groupname = args[0]
     provision.newgroup(provisionnames, lp, creds, groupname, mail=opts.mail)
 elif opts.delete:
+    groupname = args[0]
     provision.delete_group(provisionnames, lp, creds, groupname)
 elif opts.update:
+    groupname = args[0]
     provision.update_group(provisionnames, lp, creds, groupname)
+elif opts.enable_all_groups:
+    if not opts.firstorg:
+        parser.error("--firstorg parameter is required for --enable-all-groups option")
+    provision.enable_all_groups_in_organization(provisionnames, lp, creds, provisionnames.firstorg)

--- a/setup/openchange_neworganization
+++ b/setup/openchange_neworganization
@@ -41,7 +41,12 @@ parser.add_option("--firstorg", type="string", metavar="FIRSTORG",
 parser.add_option("--firstou", type="string", metavar="FIRSTOU",
                   default="First Administrative Group",
                   help="set OpenChange Administrative Group (otherwise 'First Administrative Group')")
+parser.add_option("--ignore-already-exists", action="store_true",
+                  help="Ignore errors when installing schemas that already exists")
+parser.add_option("--enable-all-groups", action="store_true",
+                  help="Enable all groups when provisioning organization")
 parser.add_option("--deprovision", action="store_true", help="Deprovision the organization")
+
 
 opts, args = parser.parse_args()
 if len(args) != 0:
@@ -55,7 +60,6 @@ _setupdir = os.path.dirname(__file__)
 if not os.path.exists(os.path.join(_setupdir, "AD")):
     _setupdir = samba.param.setup_dir()
 
-
 def setup_path(*args):
     global _setupdir
     return os.path.join(_setupdir, *args)
@@ -67,6 +71,8 @@ if opts.deprovision:
     openchange.deprovision_organization(setup_path, provisionnames, lp, creds)
     openchange.unregister(setup_path, provisionnames, lp, creds)
 else:
-    if openchange.provision_organization(setup_path, provisionnames, lp, creds):
-        openchange.register(setup_path, provisionnames, lp, creds)
+    if openchange.provision_organization(setup_path, provisionnames, lp, creds, ignore_already_exists=opts.ignore_already_exists):
+        openchange.register(setup_path, provisionnames, lp, creds, ignore_already_exists=opts.ignore_already_exists)
         openchange.openchangedb_new_organization(provisionnames, lp)
+    if opts.enable_all_groups:
+        openchange.enable_all_groups_in_organization(provisionnames, lp, creds, provisionnames.firstorg)

--- a/setup/openchange_neworganization
+++ b/setup/openchange_neworganization
@@ -43,8 +43,7 @@ parser.add_option("--firstou", type="string", metavar="FIRSTOU",
                   help="set OpenChange Administrative Group (otherwise 'First Administrative Group')")
 parser.add_option("--ignore-already-exists", action="store_true",
                   help="Ignore errors when installing schemas that already exists")
-parser.add_option("--enable-all-groups", action="store_true",
-                  help="Enable all groups when provisioning organization")
+parser.add_option("--provision", action="store_true", help="Provision the organization")
 parser.add_option("--deprovision", action="store_true", help="Deprovision the organization")
 
 
@@ -53,6 +52,12 @@ if len(args) != 0:
     parser.print_help()
     sys.exit(1)
 
+if not opts.provision and not opts.deprovision:
+    # TODO: this defaults to true for backwards compability. Remove on the future.
+    opts.provision = True
+elif opts.provision and opts.deprovision:
+    parser.error("--provision and --deprovision actions are incompatible")
+
 lp = sambaopts.get_loadparm()
 creds = credopts.get_credentials(lp)
 
@@ -60,19 +65,24 @@ _setupdir = os.path.dirname(__file__)
 if not os.path.exists(os.path.join(_setupdir, "AD")):
     _setupdir = samba.param.setup_dir()
 
+
 def setup_path(*args):
     global _setupdir
     return os.path.join(_setupdir, *args)
 
+
 provisionnames = openchange.guess_names_from_smbconf(
     lp, creds, opts.firstorg, opts.firstou)
 
-if opts.deprovision:
-    openchange.deprovision_organization(setup_path, provisionnames, lp, creds)
-    openchange.unregister(setup_path, provisionnames, lp, creds)
-else:
-    if openchange.provision_organization(setup_path, provisionnames, lp, creds, ignore_already_exists=opts.ignore_already_exists):
+if opts.provision:
+    provisioned = openchange.provision_organization(setup_path,
+                                                    provisionnames,
+                                                    lp,
+                                                    creds,
+                                                    ignore_already_exists=opts.ignore_already_exists)
+    if provisioned:
         openchange.register(setup_path, provisionnames, lp, creds, ignore_already_exists=opts.ignore_already_exists)
         openchange.openchangedb_new_organization(provisionnames, lp)
-    if opts.enable_all_groups:
-        openchange.enable_all_groups_in_organization(provisionnames, lp, creds, provisionnames.firstorg)
+elif opts.deprovision:
+    openchange.deprovision_organization(setup_path, provisionnames, lp, creds)
+    openchange.unregister(setup_path, provisionnames, lp, creds)

--- a/setup/openchange_newuser
+++ b/setup/openchange_newuser
@@ -45,6 +45,8 @@ parser.add_option("--create", action="store_true", metavar="CREATE",
                   help="Create the OpenChange user account")
 parser.add_option("--mailbox", action="store_true", metavar="MAILBOX",
                   help="Create the OpenChange user mailbox")
+parser.add_option("--delete", action="store_true", metavar="DELETE",
+                  help="Delete OpenChange user LDAP data")
 parser.add_option("--mail", type="string", metavar="MAIL",
                   help="User email address. If not specified, the email "
                        "will be samaccountname@realm")
@@ -53,10 +55,12 @@ opts, args = parser.parse_args()
 if len(args) != 1:
     parser.print_usage()
     sys.exit(1)
-elif not opts.create and not opts.enable and not opts.disable:
-    parser.error("missing action option: --create, --enable or --disable")
+elif not opts.create and not opts.enable and not opts.disable and not opts.delete:
+    parser.error("missing action option: --create, --enable, --disable or --delete")
 elif opts.enable and opts.disable:
     parser.error("--enable and --disable options are incompatible")
+elif opts.delete and (opts.create or opts.enable or opts.disable):
+    parser.error("--delete is incompatible with any other action option")
 
 
 username = args[0]
@@ -67,6 +71,8 @@ provisionnames = provision.guess_names_from_smbconf(
 
 if opts.create:
     provision.newuser(provisionnames, lp, creds, username=username, mail=opts.mail)
+elif opts.delete:
+    provision.delete_user(provisionnames, lp, creds, username=username)
 
 if opts.mailbox:
     print "Mailbox provisioning is now performed automatically at user logon"


### PR DESCRIPTION
This PR contains:

1. Enable all groups option when provisioning organization
2. Allow to remove openchange attributes from a user
3. Users and groups can now be in any part of the LDAP tree, this removes special code for Zental server. Unfortunately the 'enable all groups' option is dependent on a specific location.