### PR TITLE
oxcfxics: Fill MetaTagCnsetSeenFAI property only with FAI messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 * Open a shared calendar from address list in Outlook 2013
 * Send event invitation mails to several attendees, mixing internal and external recipients
 * Fix folder hierarchy synchronization issues on mailbox subfolders
+* Old mails are now synchronized after account cleanup
 
 ### Performances
 * Optimize the download of contents when you were in the middle of the first synchronization process in a business size mailbox.

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -3704,10 +3704,7 @@ _PUBLIC_ struct emsmdbp_object *emsmdbp_object_synccontext_init(TALLOC_CTX *mem_
 
    \param mem_ctx pointer to the memory context
    \param emsmdbp_ctx pointer to the emsmdb provider cotnext
-   \param whole_store whether the subscription applies to the specified change on the entire store or stricly on the specified folder/message
-   \param folderID the folder identifier
-   \param messageID the message identifier
-   \param parent emsmdbp object of the parent
+   \param parent emsmdbp object (synccontext) of the parent
  */
 _PUBLIC_ struct emsmdbp_object *emsmdbp_object_ftcontext_init(TALLOC_CTX *mem_ctx,
 							      struct emsmdbp_context *emsmdbp_ctx,


### PR DESCRIPTION
And not with normal messages information in SyncGetTransferState ROP.

According to [MS-OXCFXICS] Section 2.2.1.1.3, the meta-property must
contain only information from FAI messages and the MetaTagCnsetSeen
has information from normal messages and folders depending on the type
of the synchronisation.

This ROP is used by the client to get the latest state of synchronisation
after uploading and it is used by subsequently calls to sync contents/hierarchy.

The most common use case that is fixed:

* Old mails are now synchronized after the account cleanup

Other sync issues in folders with FAI messages (INBOX) should have
less number of sync issues.

Along with the fix, I clean it up the code:

* Return error instead of aborting when it is not necessary
* Remove dead and incorrect code
* Add more checks on returned values