### PR TITLE
mapitest: Add ModifyRecipients call that now crashes

### DIFF
--- a/utils/mapitest/module.c
+++ b/utils/mapitest/module.c
@@ -454,6 +454,7 @@ _PUBLIC_ uint32_t module_zentyal_init(struct mapitest *mt)
 	mapitest_suite_add_test(suite, "OXCMSG-1804", "Test multi-value properties in ModifyRecipients", mapitest_zentyal_1804);
 	mapitest_suite_add_test(suite, "OXCMSG-4872", "Test different prop count in Recipient Row and ModifyRecipients", mapitest_zentyal_4872);
 	mapitest_suite_add_test(suite, "OXCTABL-6723", "Test Backward Read on QueryRows", mapitest_zentyal_6723);
+	mapitest_suite_add_test(suite, "OXCMSG-8174", "Test only mandatory props in ModifyRecipients Row", mapitest_zentyal_8174);
 
 	mapitest_suite_register(mt, suite);
 


### PR DESCRIPTION
Additional non-mandatory property PidTagObjectType was treated
as mandatory in backend code. This test make sure no crash
is hit when only mandatory properties are sent for one recipient
and other one has some additional properties such as PidTagObjectType.

This is crashing using OpenChange + SOGo backend if https://github.com/Zentyal/sogo/pull/100 is applied and https://github.com/Zentyal/sogo/pull/154 is not.