### PR TITLE
asyncemsmdb: Fixed return value of asyncemsmdb_mapistore_destructor

### DIFF
--- a/mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.c
+++ b/mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.c
@@ -100,10 +100,10 @@ static int asyncemsmdb_mapistore_destructor(void *data)
 	enum mapistore_error		retval;
 
 	retval = mapistore_release(mstore_ctx);
-	if (retval != MAPISTORE_SUCCESS) return false;
+	if (retval != MAPISTORE_SUCCESS) return -1;
 
 	OC_DEBUG(0, "MAPIStore context released");
-	return true;
+	return 0;
 }
 
 


### PR DESCRIPTION
This function should return 0 in success and -1 in error.
Before this fix it was returning 1 in success and 0 in error.
However talloc code only checks for -1 so in success the behaviour
was correct. In the other hand a error return value was not
noticed by talloc.