### PR TITLE
provision: Fixed first directory migration

### DIFF
--- a/python/openchange/migration/directory.py
+++ b/python/openchange/migration/directory.py
@@ -137,9 +137,10 @@ add: msExchRecipientDisplayType
 msExchRecipientDisplayType: 0
 """
 
-        base_dn = "CN=Users,%s" % names.domaindn
         ldb_filter = "(&(objectClass=user)(proxyAddresses=*))"
-        res = db.search(base=base_dn, scope=ldb.SCOPE_SUBTREE, expression=ldb_filter)
+        res = db.search(base=names.domaindn,
+                        scope=ldb.SCOPE_SUBTREE,
+                        expression=ldb_filter)
         for element in res:
             # check if intrnal user
             if 'showInAdvancedViewOnly' in element:


### PR DESCRIPTION
The base dn of the first migration provision was too restrictive.
Depending on the naming schema this could trigger that old users
has not the msExchRecipientTypeDetails and msExchRecipientDisplayType
attributes added.