### PR TITLE
Free mapistore context and [async]emsmdb_sessions

### DIFF
--- a/mapiproxy/libmapistore/mapistore_interface.c
+++ b/mapiproxy/libmapistore/mapistore_interface.c
@@ -129,8 +129,10 @@ _PUBLIC_ struct mapistore_context *mapistore_init(TALLOC_CTX *mem_ctx, struct lo
 
    \param mstore_ctx pointer to the mapistore context
 
-   \note The function needs to rely on talloc destructors which is not
-   implemented in code yet.
+   \note Right now nothing is released because mapistore_init
+   creates all members in the same memory context tree, so when
+   you free the mapistore_context everything will be freed and
+   no further action is required in this method.
 
    \return MAPISTORE_SUCCESS on success, otherwise MAPISTORE error
  */
@@ -140,11 +142,6 @@ _PUBLIC_ enum mapistore_error mapistore_release(struct mapistore_context *mstore
 	MAPISTORE_RETVAL_IF(!mstore_ctx, MAPISTORE_ERR_NOT_INITIALIZED, NULL);
 
 	OC_DEBUG(5, "freeing up mstore_ctx ref: %p", mstore_ctx);
-
-	talloc_free(mstore_ctx->nprops_ctx);
-	talloc_free(mstore_ctx->processing_ctx);
-	talloc_free(mstore_ctx->context_list);
-	talloc_free(mstore_ctx->indexing_list);
 
 	return MAPISTORE_SUCCESS;
 }

--- a/mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.c
+++ b/mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.c
@@ -100,10 +100,10 @@ static int asyncemsmdb_mapistore_destructor(void *data)
 	enum mapistore_error		retval;
 
 	retval = mapistore_release(mstore_ctx);
-	if (retval != MAPISTORE_SUCCESS) return false;
+	if (retval != MAPISTORE_SUCCESS) return -1;
 
-	OC_DEBUG(0, "MAPIStore context released");
-	return true;
+	OC_DEBUG(5, "MAPIStore context released");
+	return 0;
 }
 
 

--- a/mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.c
+++ b/mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.c
@@ -1152,8 +1152,8 @@ static NTSTATUS dcerpc_server_asyncemsmdb_unbind(struct dcesrv_connection_contex
 		OC_DEBUG(0, "[asyncemsmdb] unable to delete resolver entry %s from record %s", session->bind_addr, session->cn);
 	}
 
-	mapistore_release(session->mstore_ctx);
 	DLIST_REMOVE(asyncemsmdb_session, session);
+	talloc_free(session);
 
 	/* flush pending call on connection */
 	context->conn->pending_call_list = NULL;

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
@@ -210,14 +210,14 @@ static enum MAPISTATUS dcesrv_EcDoConnect(struct dcesrv_call_state *dce_call,
 	}
 	else {
 		/* Step 7. Associate this emsmdbp context to the session */
-		session = talloc((TALLOC_CTX *)emsmdb_session, struct exchange_emsmdb_session);
+		session = talloc_zero(emsmdb_session, struct exchange_emsmdb_session);
 		OPENCHANGE_RETVAL_IF(!session, MAPI_E_NOT_ENOUGH_RESOURCES, emsmdbp_ctx);
 
 		session->pullTimeStamp = *r->out.pullTimeStamp;
-		session->session = mpm_session_init((TALLOC_CTX *)emsmdb_session, dce_call);
+		session->session = mpm_session_init(session, dce_call);
 		OPENCHANGE_RETVAL_IF(!session->session, MAPI_E_NOT_ENOUGH_RESOURCES, emsmdbp_ctx);
 
-                session->uuid = handle->wire_handle.uuid;
+		session->uuid = handle->wire_handle.uuid;
 
 		mpm_session_set_private_data(session->session, (void *) emsmdbp_ctx);
 		mpm_session_set_destructor(session->session, emsmdbp_destructor);
@@ -1345,11 +1345,11 @@ static enum MAPISTATUS dcesrv_EcDoConnectEx(struct dcesrv_call_state *dce_call,
 	}
 	else {
 		/* Step 7. Associate this emsmdbp context to the session */
-		session = talloc((TALLOC_CTX *)emsmdb_session, struct exchange_emsmdb_session);
+		session = talloc_zero(emsmdb_session, struct exchange_emsmdb_session);
 		OPENCHANGE_RETVAL_IF(!session, MAPI_E_NOT_ENOUGH_RESOURCES, emsmdbp_ctx);
 
 		session->pullTimeStamp = *r->out.pulTimeStamp;
-		session->session = mpm_session_init((TALLOC_CTX *)emsmdb_session, dce_call);
+		session->session = mpm_session_init(session, dce_call);
 		OPENCHANGE_RETVAL_IF(!session->session, MAPI_E_NOT_ENOUGH_RESOURCES, emsmdbp_ctx);
 		
 		session->uuid = handle->wire_handle.uuid;

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
@@ -264,6 +264,7 @@ static enum MAPISTATUS dcesrv_EcDoDisconnect(struct dcesrv_call_state *dce_call,
 			ret = mpm_session_release(session->session);
 			if (ret == true) {
 				DLIST_REMOVE(emsmdb_session, session);
+				talloc_free(session);
 				OC_DEBUG(5, "Session found and released\n");
 			} else {
 				OC_DEBUG(5, "Session found and ref_count decreased\n");


### PR DESCRIPTION
* Fixed crash in asyncemsmdb double free of mstore_ctx members because mapistore_release called twice (on unbind and as destructor).
* mapistore context destructor removed because is not needed: all their members are created inside the same memory context tree.
* Free both asyncemsmdb_session and emsmdb_session: they are now created within different memory context and freed when they are removed from our list of active sessions.