### PR TITLE
Advanced NDR decoder for FastTransferSourceGetBuffer response buffers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ re:: clean install
 # IDL compilation rules
 #################################################################
 
-idl: gen_ndr gen_ndr/ndr_exchange.h gen_ndr/ndr_property.h gen_ndr/ndr_asyncemsmdb.h
+idl: gen_ndr gen_ndr/ndr_exchange.h gen_ndr/ndr_property.h gen_ndr/ndr_asyncemsmdb.h gen_ndr/ndr_exchange_debug.h
 
 exchange.idl: properties_enum.h mapicodes_enum.h
 
@@ -197,6 +197,7 @@ endif
 	rm -f gen_ndr/ndr_property*
 	rm -f gen_ndr/property.h
 	rm -f ndr_mapi.o ndr_mapi.po
+	rm -f ndr_fasttransfer.o ndr_fasttransfer.po
 	rm -f ndr_mapi.gcno ndr_mapi.gcda
 	rm -f *~
 	rm -f */*~
@@ -316,14 +317,16 @@ libmapi.$(SHLIBEXT).$(PACKAGE_VERSION): 		\
 	libmapi/fxparser.po				\
 	libmapi/notif.po				\
 	libmapi/idset.po				\
-	libmapi/oc_log.po			\
+	libmapi/oc_log.po				\
 	ndr_mapi.po					\
-	ndr_fasttransfer.po	\
 	gen_ndr/ndr_exchange.po				\
 	gen_ndr/ndr_exchange_c.po			\
+	gen_ndr/ndr_exchange_debug.po			\
+	gen_ndr/ndr_exchange_debug_c.po			\
 	gen_ndr/ndr_asyncemsmdb.po			\
 	gen_ndr/ndr_asyncemsmdb_c.po			\
 	gen_ndr/ndr_property.po				\
+	ndr_fasttransfer.po				\
 	libmapi/socket/interface.po			\
 	libmapi/socket/netif.po
 	@echo "Linking $@"
@@ -1823,7 +1826,7 @@ etags:
 ctags:
 	ctags `find $(srcdir) -name "*.[ch]"`
 
-.PRECIOUS: exchange.h gen_ndr/ndr_exchange.h gen_ndr/ndr_exchange.c gen_ndr/ndr_exchange_c.c gen_ndr/ndr_exchange_c.h mapiproxy/libmapistore/gen_ndr/ndr_mapistore_notification.c mapiproxy/libmapistore/gen_ndr/mapistore_notification.h
+.PRECIOUS: exchange.h gen_ndr/ndr_exchange.h gen_ndr/ndr_exchange.c gen_ndr/ndr_exchange_c.c gen_ndr/ndr_exchange_c.h gen_ndr/ndr_exchange_debug.h gen_ndr/ndr_exchange_debug.c gen_ndr/ndr_exchange_debug_c.c gen_ndr/ndr_exchange_debug_c.h mapiproxy/libmapistore/gen_ndr/ndr_mapistore_notification.c mapiproxy/libmapistore/gen_ndr/mapistore_notification.h
 
 test:: check
 

--- a/Makefile
+++ b/Makefile
@@ -318,6 +318,7 @@ libmapi.$(SHLIBEXT).$(PACKAGE_VERSION): 		\
 	libmapi/idset.po				\
 	libmapi/oc_log.po			\
 	ndr_mapi.po					\
+	ndr_fasttransfer.po	\
 	gen_ndr/ndr_exchange.po				\
 	gen_ndr/ndr_exchange_c.po			\
 	gen_ndr/ndr_asyncemsmdb.po			\

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ configure: configure.ac
 samba:
 	./script/installsamba4.sh all
 
-samba-git: 
+samba-git:
 	./script/installsamba4.sh git-all
 
 samba-git-update:
@@ -166,7 +166,7 @@ LIBMAPI_SO_VERSION = 0
 
 libmapi:	idl					\
 		libmapi/version.h			\
-		libmapi.$(SHLIBEXT).$(PACKAGE_VERSION)	
+		libmapi.$(SHLIBEXT).$(PACKAGE_VERSION)
 
 libmapi-install:	libmapi			\
 			libmapi-installpc	\
@@ -227,8 +227,8 @@ endif
 
 libmapi-installheader:
 	@echo "[*] install: libmapi headers"
-	$(INSTALL) -d $(DESTDIR)$(includedir)/libmapi 
-	$(INSTALL) -d $(DESTDIR)$(includedir)/libmapi/socket 
+	$(INSTALL) -d $(DESTDIR)$(includedir)/libmapi
+	$(INSTALL) -d $(DESTDIR)$(includedir)/libmapi/socket
 	$(INSTALL) -d $(DESTDIR)$(includedir)/gen_ndr
 	$(INSTALL) -m 0644 libmapi/libmapi.h $(DESTDIR)$(includedir)/libmapi/
 	$(INSTALL) -m 0644 libmapi/nspi.h $(DESTDIR)$(includedir)/libmapi/
@@ -324,7 +324,7 @@ libmapi.$(SHLIBEXT).$(PACKAGE_VERSION): 		\
 	gen_ndr/ndr_asyncemsmdb_c.po			\
 	gen_ndr/ndr_property.po				\
 	libmapi/socket/interface.po			\
-	libmapi/socket/netif.po				
+	libmapi/socket/netif.po
 	@echo "Linking $@"
 	@$(CC) $(DSOOPT) $(CFLAGS) $(LDFLAGS) -Wl,-soname,libmapi.$(SHLIBEXT).$(LIBMAPI_SO_VERSION) -o $@ $^ $(LIBS)
 
@@ -366,7 +366,7 @@ libmapipp.$(SHLIBEXT).$(PACKAGE_VERSION): 	\
 	libmapi++/src/session.po \
 	libmapi.$(SHLIBEXT).$(LIBMAPI_SO_VERSION)
 	@echo "Linking $@"
-	@$(CXX) $(DSOOPT) $(CXX11FLAGS) $(CXXFLAGS) $(LDFLAGS) -Wl,-soname,libmapipp.$(SHLIBEXT).$(LIBMAPIPP_SO_VERSION) -o $@ $^ $(LIBS) 
+	@$(CXX) $(DSOOPT) $(CXX11FLAGS) $(CXXFLAGS) $(LDFLAGS) -Wl,-soname,libmapipp.$(SHLIBEXT).$(LIBMAPIPP_SO_VERSION) -o $@ $^ $(LIBS)
 
 libmapixx-installpc:
 	@echo "[*] install: libmapi++ pc files"
@@ -447,7 +447,7 @@ bin/libmapixx-test:	libmapi++/tests/test.cpp	\
 		libmapipp.$(SHLIBEXT).$(PACKAGE_VERSION) \
 		libmapi.$(SHLIBEXT).$(PACKAGE_VERSION)
 	@echo "Linking sample application $@"
-	@$(CXX) $(CXX11FLAGS) $(CXXFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS) 
+	@$(CXX) $(CXX11FLAGS) $(CXXFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 clean:: libmapixx-test-clean
 
@@ -467,7 +467,7 @@ bin/libmapixx-attach: libmapi++/tests/attach_test.po	\
 clean:: libmapixx-attach-clean
 
 libmapixx-exception: bin/libmapixx-exception
- 
+
 bin/libmapixx-exception: libmapi++/tests/exception_test.cpp \
 		libmapipp.$(SHLIBEXT).$(PACKAGE_VERSION) \
 		libmapi.$(SHLIBEXT).$(PACKAGE_VERSION)
@@ -570,7 +570,7 @@ endif
 
 libmapiadmin-installheader:
 	@echo "[*] install: libmapiadmin headers"
-	$(INSTALL) -d $(DESTDIR)$(includedir)/libmapiadmin 
+	$(INSTALL) -d $(DESTDIR)$(includedir)/libmapiadmin
 	$(INSTALL) -m 0644 libmapiadmin/libmapiadmin.h $(DESTDIR)$(includedir)/libmapiadmin/
 	@$(SED) $(DESTDIR)$(includedir)/libmapiadmin/*.h
 
@@ -588,7 +588,7 @@ libmapiadmin.$(SHLIBEXT).$(PACKAGE_VERSION):	\
 	libmapiadmin/mapiadmin.po 		\
 	libmapi.$(SHLIBEXT).$(PACKAGE_VERSION)
 	@echo "Linking $@"
-	@$(CC) $(DSOOPT) $(LDFLAGS) -Wl,-soname,libmapiadmin.$(SHLIBEXT).$(LIBMAPIADMIN_SO_VERSION) -o $@ $^ $(LIBS) $(LIBMAPIADMIN_LIBS) 
+	@$(CC) $(DSOOPT) $(LDFLAGS) -Wl,-soname,libmapiadmin.$(SHLIBEXT).$(LIBMAPIADMIN_SO_VERSION) -o $@ $^ $(LIBS) $(LIBMAPIADMIN_LIBS)
 
 
 
@@ -602,11 +602,11 @@ libocpf:		libocpf.$(SHLIBEXT).$(PACKAGE_VERSION)
 
 libocpf-install:	libocpf-installpc	\
 			libocpf-installlib	\
-			libocpf-installheader	
+			libocpf-installheader
 
 libocpf-uninstall:	libocpf-uninstallpc	\
 			libocpf-uninstalllib	\
-			libocpf-uninstallheader	
+			libocpf-uninstallheader
 
 libocpf-clean::
 	rm -f libocpf/*.o libocpf/*.po
@@ -737,7 +737,7 @@ mapiproxy/dcesrv_mapiproxy.$(SHLIBEXT): 	mapiproxy/dcesrv_mapiproxy.po		\
 						mapiproxy/dcesrv_mapiproxy_rfr.po	\
 						mapiproxy/dcesrv_mapiproxy_unused.po	\
 						ndr_mapi.po				\
-						gen_ndr/ndr_exchange.po				
+						gen_ndr/ndr_exchange.po
 
 	@echo "Linking $@"
 	@$(CC) -o $@ $(DSOOPT) $^ -L. $(LDFLAGS) $(LIBS) $(SAMBASERVER_LIBS) $(SAMDB_LIBS) -Lmapiproxy mapiproxy/libmapiproxy.$(SHLIBEXT).$(PACKAGE_VERSION) libmapi.$(SHLIBEXT).$(PACKAGE_VERSION)
@@ -1015,7 +1015,7 @@ clean:: mapistore_clean
 mapiproxy-modules:	mapiproxy/modules/mpm_downgrade.$(SHLIBEXT)	\
 			mapiproxy/modules/mpm_pack.$(SHLIBEXT)		\
 			mapiproxy/modules/mpm_cache.$(SHLIBEXT)		\
-			mapiproxy/modules/mpm_dummy.$(SHLIBEXT)		
+			mapiproxy/modules/mpm_dummy.$(SHLIBEXT)
 
 mapiproxy-modules-install: mapiproxy-modules
 	$(INSTALL) -d $(DESTDIR)$(modulesdir)/dcerpc_mapiproxy/
@@ -1119,7 +1119,7 @@ clean:: mapiproxy-servers-clean
 mapiproxy/servers/exchange_nsp.$(SHLIBEXT):	mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.po	\
 						mapiproxy/servers/default/nspi/emsabp.po		\
 						mapiproxy/servers/default/nspi/emsabp_tdb.po		\
-						mapiproxy/servers/default/nspi/emsabp_property.po	
+						mapiproxy/servers/default/nspi/emsabp_property.po
 	@echo "Linking $@"
 	@$(CC) -o $@ $(DSOOPT) $(LDFLAGS) $^ -L. $(LIBS) $(TDB_LIBS) $(SAMBASERVER_LIBS) $(SAMDB_LIBS) -Lmapiproxy mapiproxy/libmapiproxy.$(SHLIBEXT).$(PACKAGE_VERSION)
 
@@ -1159,7 +1159,7 @@ mapiproxy/servers/exchange_ds_rfr.$(SHLIBEXT):	mapiproxy/servers/default/rfr/dce
 openchangeclient:	bin/openchangeclient
 
 openchangeclient-install:	openchangeclient
-	$(INSTALL) -d $(DESTDIR)$(bindir) 
+	$(INSTALL) -d $(DESTDIR)$(bindir)
 	$(INSTALL) -m 0755 bin/openchangeclient $(DESTDIR)$(bindir)
 
 openchangeclient-uninstall:
@@ -1191,7 +1191,7 @@ bin/openchangeclient: 	utils/openchangeclient.o			\
 mapiprofile:		bin/mapiprofile
 
 mapiprofile-install:	mapiprofile
-	$(INSTALL) -d $(DESTDIR)$(bindir) 
+	$(INSTALL) -d $(DESTDIR)$(bindir)
 	$(INSTALL) -m 0755 bin/mapiprofile $(DESTDIR)$(bindir)
 
 mapiprofile-uninstall:
@@ -1293,7 +1293,7 @@ bin/mapipropsdump: 	utils/mapipropsdump.o				\
 openchangepfadmin:	bin/openchangepfadmin
 
 openchangepfadmin-install:	openchangepfadmin
-	$(INSTALL) -d $(DESTDIR)$(bindir) 
+	$(INSTALL) -d $(DESTDIR)$(bindir)
 	$(INSTALL) -m 0755 bin/openchangepfadmin $(DESTDIR)$(bindir)
 
 openchangepfadmin-uninstall:
@@ -1312,7 +1312,7 @@ bin/openchangepfadmin:	utils/openchangepfadmin.o			\
 			libmapi.$(SHLIBEXT).$(PACKAGE_VERSION) 		\
 			libmapiadmin.$(SHLIBEXT).$(PACKAGE_VERSION)
 	@echo "Linking $@"
-	@$(CC) -o $@ $^ $(LDFLAGS) $(LIBS) $(LIBMAPIADMIN_LIBS) -lpopt			
+	@$(CC) -o $@ $^ $(LDFLAGS) $(LIBS) $(LIBMAPIADMIN_LIBS) -lpopt
 
 
 ###################
@@ -1514,7 +1514,7 @@ bin/mapitest:	utils/mapitest/mapitest.o			\
 		utils/mapitest/modules/module_lcid.o		\
 		utils/mapitest/modules/module_mapidump.o	\
 		utils/mapitest/modules/module_lzxpress.o	\
-		libmapi.$(SHLIBEXT).$(PACKAGE_VERSION)		
+		libmapi.$(SHLIBEXT).$(PACKAGE_VERSION)
 	@echo "Linking $@"
 	@$(CC) -o $@ $^ $(LDFLAGS) $(LIBS) -lpopt $(SUBUNIT_LIBS)
 
@@ -1697,7 +1697,7 @@ clean-python:
 clean:: clean-python
 
 pyopenchange: 	$(pythonscriptdir)/openchange/mapi.$(SHLIBEXT)			\
-		$(pythonscriptdir)/openchange/mapistore.$(SHLIBEXT)		
+		$(pythonscriptdir)/openchange/mapistore.$(SHLIBEXT)
 #		$(pythonscriptdir)/openchange/ocpf.$(SHLIBEXT)			\
 
 $(pythonscriptdir)/openchange/mapi.$(SHLIBEXT):	pyopenchange/pymapi.c				\
@@ -1789,7 +1789,7 @@ installman: doxygen
 uninstallman:
 	@./script/uninstallman.sh $(DESTDIR)$(mandir) $(manpages)
 
-doxygen:	
+doxygen:
 	echo "Doxify API documentation: HTML and man pages"
 	mkdir -p apidocs/html
 	mkdir -p apidocs/man
@@ -1856,7 +1856,7 @@ openchange_qt4:	qt-lib qt-demoapp
 
 qt-lib: libqtmapi
 
-qt-demoapp: qt/demo/demoapp.moc qt/demo/demoapp 
+qt-demoapp: qt/demo/demoapp.moc qt/demo/demoapp
 
 # No install yet - we need to finish this first
 
@@ -1904,7 +1904,7 @@ qt/demo/demoapp: qt/demo/demoapp.o 				\
 	ln -sf libqtmapi.$(SHLIBEXT).$(PACKAGE_VERSION) libqtmapi.$(SHLIBEXT)
 	ln -sf libqtmapi.$(SHLIBEXT).$(PACKAGE_VERSION) libqtmapi.$(SHLIBEXT).$(LIBQTMAPI_SO_VERSION)
 
-# This should be the last line in the makefile since other distclean rules may 
+# This should be the last line in the makefile since other distclean rules may
 # need config.mk
 distclean::
 	rm -f config.mk

--- a/config.mk.in
+++ b/config.mk.in
@@ -42,7 +42,7 @@ pythondir=@pythondir@
 sambaprefix=@sambaprefix@
 
 DSOOPT=-shared -fPIC
-CFLAGS=@CFLAGS@ @ENDIAN@ @COMPILER_OPTIONS_C@ @ASSERT_DEFINITION@ @SUBUNIT_CFLAGS@ \
+CFLAGS=@CFLAGS@ @ENDIAN@ @COMPILER_OPTIONS_C@ @ASSERT_DEFINITION@ @SUBUNIT_CFLAGS@ @NDR_COLOR@  \
        -DDEFAULT_LDIF=\"$(datadir)/setup/profiles\"						\
        -DMAPISTORE_LDIF=\"$(datadir)/setup/mapistore\"						\
        -DOPENCHANGEDB_DATA_DIR=\"$(datadir)/setup/openchangedb\"				\

--- a/configure.ac
+++ b/configure.ac
@@ -854,6 +854,20 @@ fi
 AC_SUBST(OPENCHANGE_QT4)
 
 dnl ***********************
+dnl Options
+dnl ***********************
+
+AC_ARG_ENABLE(ansi-color, AC_HELP_STRING([--enable-ansi-color],
+			  [Use ANSI colors in NDR logs]),
+			  ansi_color=yes,
+			  ansi_color=no)
+NDR_COLOR=
+if test x$ansi_color = xyes; then
+   NDR_COLOR=-DNDR_COLOR
+fi
+AC_SUBST(NDR_COLOR)
+
+dnl ***********************
 dnl Makefiles 
 dnl ***********************
 AC_CONFIG_FILES([config.mk libmapi.pc libmapiadmin.pc libocpf.pc mapiproxy/libmapiproxy.pc
@@ -933,6 +947,9 @@ OpenChange Configuration (Please review)
 	     - Qt4:			$enable_openchange_qt4
 
 	   * Installation prefix:	$prefix
+
+	   * Options:
+	     - Use ANSI colors:		$ansi_color
 
 ===============================================================
 

--- a/exchange.idl
+++ b/exchange.idl
@@ -3519,7 +3519,7 @@ System Attendant Private Interface
 
 	/*************************/
 	/* EcDoRpc Function 0x76 */
-	typedef [flag(NDR_NOALIGN)] struct {
+	typedef [noprint,flag(NDR_NOALIGN)] struct {
 		uint32			StreamDataSize;
 		uint8			StreamData[StreamDataSize];
 	} SyncUploadStateStreamContinue_req;

--- a/exchange.idl
+++ b/exchange.idl
@@ -4714,3 +4714,14 @@ System Attendant Private Interface
 {
 	void unknown_dummy();
 }
+
+[
+ uuid("8ac6ad47-9cbb-4518-8b8d-38e755bfdf01"),
+ pointer_default(unique),
+ helpstring("Debug")
+] interface exchange_debug
+{
+  [public,noprint] void FastTransferSourceGetBuffer(
+	       [in,out][flag(NDR_REMAINING)] DATA_BLOB data
+	       );
+}

--- a/exchange.idl
+++ b/exchange.idl
@@ -60,7 +60,7 @@ cpp_quote("#include <gen_ndr/ndr_misc.h>")
 		[in,out,unique,string,charset(DOS)]     uint8   **ppszUnused,
 		[in,out,unique,string,charset(DOS)]     uint8   **ppszServer
 		);
-	
+
 	/*****************/
 	/* Function 0x01 */
 	MAPISTATUS RfrGetFQDNFromLegacyDN(
@@ -257,7 +257,7 @@ System Attendant Private Interface
 		[range(0,100000)] uint32                        cValues;
 		[size_is(cValues+1), length_is(cValues)] uint32 aulPropTag[];
 	} PropertyTagArray_r;
-    
+
 	typedef struct {
 		FlatUID_r	*lpguid;
 		uint32		ulReserved;
@@ -311,7 +311,7 @@ System Attendant Private Interface
 
 	typedef struct {
 		[range(0,100000)] uint32	cValues;
-		[size_is(cValues)] uint32	*lpl; 
+		[size_is(cValues)] uint32	*lpl;
 	} LongArray_r;
 
 	typedef struct {
@@ -321,7 +321,7 @@ System Attendant Private Interface
 
 	typedef struct {
 		[range(0,100000)]uint32		cValues;
-		[size_is(cValues)] FlatUID_r	**lpguid; 
+		[size_is(cValues)] FlatUID_r	**lpguid;
 	} FlatUIDArray_r;
 
 	typedef struct {
@@ -353,9 +353,9 @@ System Attendant Private Interface
 	typedef [public]struct {
 		MAPITAGS ulPropTag;
 		uint32 dwAlignPad;
-		[switch_is(ulPropTag & 0xFFFF)] PROP_VAL_UNION value; 
+		[switch_is(ulPropTag & 0xFFFF)] PROP_VAL_UNION value;
 	} PropertyValue_r;
-	
+
 	typedef struct {
 		uint32					Reserved;
 		[range(0,100000)] uint32		cValues;
@@ -366,7 +366,7 @@ System Attendant Private Interface
 		[range(0,100000)] uint32	cRows;
 		[size_is(cRows)] PropertyRow_r	aRow[];
 	} PropertyRowSet_r;
-	
+
 	typedef struct {
 		[range(0,100000)] uint32		cRes;
 		[size_is(cRes)] Restriction_r		*lpRes;
@@ -467,7 +467,7 @@ System Attendant Private Interface
 
 	typedef [nopush,nopull,noprint] struct {
 		[range(0,100000)] uint32	cValues;
-		[size_is(cValues)] hyper	*lpui8; 
+		[size_is(cValues)] hyper	*lpui8;
 	} UI8Array_r;
 
 	typedef [switch_type(uint32),nopush,nopull,noprint] union {
@@ -498,9 +498,9 @@ System Attendant Private Interface
 	typedef [public,noprint,nopush,nopull] struct {
 		MAPITAGS ulPropTag;
 		uint32 dwAlignPad;
-		[switch_is(ulPropTag & 0xFFFF)] SPropValue_CTR value; 
+		[switch_is(ulPropTag & 0xFFFF)] SPropValue_CTR value;
 	} SPropValue;
-	
+
 	typedef [public,noprint,nopush,nopull] struct {
 		uint32			       	ulAdrEntryPad;
 		[range(0,100000)] uint32       	cValues;
@@ -810,7 +810,7 @@ System Attendant Private Interface
 	  EcDoRpc opnums
 	*/
 
-	typedef [public, enum8bit, flag(NDR_PAHEX)] enum 
+	typedef [public, enum8bit, flag(NDR_PAHEX)] enum
 		{
 			MAPI_STORE	= 0x1,
 			MAPI_ADDRBOOK	= 0x2,
@@ -826,7 +826,7 @@ System Attendant Private Interface
 			MAPI_FORMINFO	= 0xC
 		} MAPI_OBJTYPE;
 
-	typedef [public, v1_enum, flag(NDR_PAHEX)] enum 
+	typedef [public, v1_enum, flag(NDR_PAHEX)] enum
 		{
 			RightsNone		= 0x00000000,
 			RightsReadItems		= 0x00000001,
@@ -999,7 +999,7 @@ System Attendant Private Interface
 
 	typedef [public] struct {
 		uint32 cValues;
-		uint32 lpl[cValues]; 
+		uint32 lpl[cValues];
 	} mapi_MV_LONG_STRUCT;
 
 	typedef struct {
@@ -1008,7 +1008,7 @@ System Attendant Private Interface
 
 	typedef [public] struct {
 		uint32 cValues;
-		mapi_LPSTR strings[cValues]; 
+		mapi_LPSTR strings[cValues];
 	} mapi_SLPSTRArray;
 
 	typedef [public] struct {
@@ -1019,7 +1019,7 @@ System Attendant Private Interface
 		uint32 cValues;
 		mapi_LPWSTR strings[cValues];
 	} mapi_SLPSTRArrayW;
-	
+
 	typedef [public] struct {
 		uint32		cValues;
 		SBinary_short	bin[cValues];
@@ -1042,7 +1042,7 @@ System Attendant Private Interface
 	typedef [nopush,nopull,noprint,flag(NDR_NOALIGN)] struct {
 		uint8	wrap[0x8000];
 	} mapi_SPropValue_array_wrap;
-	/**********************************************************/	
+	/**********************************************************/
 
 	typedef [enum8bit] enum {
 		ActionType_OP_MOVE		= 0x1,
@@ -1067,7 +1067,7 @@ System Attendant Private Interface
 	typedef [flag(NDR_NOALIGN)] struct {
 		hyper			ReplyTemplateFID;
 		hyper			ReplyTemplateMID;
-		GUID			ReplyTemplateGUID;			
+		GUID			ReplyTemplateGUID;
 	} ReplyOOF_Action;
 
 	typedef [flag(NDR_NOALIGN)] struct {
@@ -1133,7 +1133,7 @@ System Attendant Private Interface
 		[case(PT_ACTIONS)]	RuleAction		RuleAction;
   		[case(PT_BINARY)]	SBinary_short		bin;
 		[case(PT_SVREID)]      	SBinary_short		bin;
-		[case(PT_MV_LONG)]	mapi_MV_LONG_STRUCT	MVl;	
+		[case(PT_MV_LONG)]	mapi_MV_LONG_STRUCT	MVl;
 		[case(PT_MV_STRING8)]	mapi_SLPSTRArray	MVszA;
 		[case(PT_MV_UNICODE)]	mapi_SLPSTRArrayW	MVszW;
 		[case(PT_MV_CLSID)]	mapi_SGuidArray		MVguid;
@@ -1142,7 +1142,7 @@ System Attendant Private Interface
 
 	typedef [public,flag(NDR_NOALIGN)] struct {
 		MAPITAGS ulPropTag;
-		[switch_is(ulPropTag & 0xFFFF)] mapi_SPropValue_CTR value; 
+		[switch_is(ulPropTag & 0xFFFF)] mapi_SPropValue_CTR value;
 	} mapi_SPropValue;
 
 	typedef [public,flag(NDR_NOALIGN)] struct {
@@ -1198,7 +1198,7 @@ System Attendant Private Interface
 		boolean8			       	IsGhosted;
 		[switch_is(IsGhosted)] IsGhosted	Ghost;
 	} OpenFolder_repl;
-	
+
 	/**************************/
 	/* EcDoRpc Function 0x3   */
 	typedef [enum8bit] enum {
@@ -1446,7 +1446,7 @@ System Attendant Private Interface
 
 	typedef [flag(NDR_NOALIGN)] struct {
 		uint16		PropertyProblemCount;
-		PropertyProblem	PropertyProblem[PropertyProblemCount];		
+		PropertyProblem	PropertyProblem[PropertyProblemCount];
 	} SetProps_repl;
 
 	/*************************/
@@ -1492,9 +1492,9 @@ System Attendant Private Interface
 	/*************************/
 	/* EcDoRpc Function 0xe  */
 
-	/* 
+	/*
 	 * MODRECIP_NULL and INVALID are not part of the msdn flags
-	 * but are added for printing support 
+	 * but are added for printing support
 	 */
 	typedef [enum8bit,flag(NDR_PAHEX)] enum {
 		MODRECIP_NULL		= 0x0,
@@ -1506,7 +1506,7 @@ System Attendant Private Interface
 
 	typedef [flag(NDR_NOALIGN)]struct {
 		uint32		idx;
-		ulRecipClass	RecipClass;		
+		ulRecipClass	RecipClass;
 		[subcontext(2),flag(NDR_REMAINING|NDR_NOALIGN)] RecipientRow RecipientRow;
 	} ModifyRecipientRow;
 
@@ -1611,7 +1611,7 @@ System Attendant Private Interface
 		SetColumns_TBL_SYNC	= 0x0,
 		SetColumns_TBL_ASYNC	= 0x1
 	} SetColumnsFlags;
-	
+
 	typedef [enum8bit] enum {
 		TBLSTAT_COMPLETE	= 0x0,
 		TBLSTAT_SORTING		= 0x9,
@@ -1638,7 +1638,7 @@ System Attendant Private Interface
                 TBL_ASYNC = 0x1,
                 TBL_BATCH = 0x2
         } TBL_FLAGS;
-	
+
         typedef [enum8bit, flag(NDR_PAHEX)] enum {
                 TABLE_SORT_ASCEND = 0x0,
                 TABLE_SORT_DESCEND = 0x1,
@@ -1904,7 +1904,7 @@ System Attendant Private Interface
 
 	typedef [flag(NDR_NOALIGN)] struct {
 	} SeekRowApprox_repl;
-	
+
 	/**************************/
 	/* EcDoRpc Function 0x1b  */
 	typedef [flag(NDR_NOALIGN)] struct {
@@ -2250,7 +2250,7 @@ System Attendant Private Interface
 	typedef [flag(NDR_NOALIGN)] struct {
 		hyper				FID;
 	} HierarchyRowDeletedNotification;
-	
+
 	typedef [flag(NDR_NOALIGN)] struct {
 		hyper				FID;
 		hyper				InsertAfterFID;
@@ -2330,7 +2330,7 @@ System Attendant Private Interface
 		hyper			MID;
 		hyper			OldFID;
 		hyper			OldMID;
-	} MessageMoveCopyNotification;	
+	} MessageMoveCopyNotification;
 
 	/* ContentsTableChange: case 0x8100 and 0xc100 */
 	typedef [flag(NDR_NOALIGN)] struct {
@@ -3081,7 +3081,7 @@ System Attendant Private Interface
 		[case(MNID_ID)] uint32		lid;
 		[case(MNID_STRING)] mapi_name	lpwstr;
 	} Kind;
-	
+
 	typedef [flag(NDR_NOALIGN)] struct {
 		ulKind				ulKind;
 		GUID				lpguid;
@@ -3222,7 +3222,7 @@ System Attendant Private Interface
 		uint16		PropertyIds[IdCount];
 		MAPINAMEID	PropertyNames[IdCount];
 	} QueryNamedProperties_repl;
-  
+
 	/*************************/
 	/* EcDoRpc Function 0x60 */
 	typedef [flag(NDR_NOALIGN)] struct {
@@ -3660,7 +3660,7 @@ System Attendant Private Interface
 	typedef [flag(NDR_NOALIGN)] struct {
 		uint8		handle_idx;
 		asclstr		name;
-	} OpenPublicFolderByName_req; 
+	} OpenPublicFolderByName_req;
 
 	typedef [flag(NDR_NOALIGN)] struct {
 		boolean8				HasRules;
@@ -3762,7 +3762,7 @@ System Attendant Private Interface
 		IGNORE_HOME_MDB			= 0x200,
 		NO_MAIL				= 0x400,
 		USE_PER_MDB_REPLID_MAPPING	= 0x01000000,
-		SUPPORT_PROGRESS		= 0x20000000 
+		SUPPORT_PROGRESS		= 0x20000000
 	} OpenFlags;
 
 	typedef [enum8bit] enum {
@@ -4197,7 +4197,7 @@ System Attendant Private Interface
 		EcDoRpc_MAPI_REPL	*mapi_repl;
 		uint32			*handles;
 	} mapi_response;
-	
+
 
 	[public,nopull,nopush] MAPISTATUS EcDoRpc(
 		[in,out]						policy_handle	*handle,
@@ -4219,8 +4219,8 @@ System Attendant Private Interface
 	/*
 	  we could directly use a NOTIFKEY structure rather than
 	  a uint8 array, but this makes the IDL more robust
-	
-	  sockaddr array is made of: 
+
+	  sockaddr array is made of:
 	   - family (unsigned short in) sa_family_t
 	   - address data sa_data[14];
 	 */
@@ -4314,7 +4314,7 @@ System Attendant Private Interface
 		AUX_TYPE_OSVERSIONINFO		= 0x16,
 		AUX_TYPE_EXORGINFO		= 0x17
 	} AUX_HEADER_TYPE_1;
-	
+
 	typedef [enum8bit,flag(NDR_PAHEX)] enum {
 		AUX_TYPE_PERF_SESSIONINFO_2	= 0x04,
 		AUX_TYPE_PERF_MDB_SUCCESS_2	= 0x07,
@@ -4339,7 +4339,7 @@ System Attendant Private Interface
 		uint16		SessionID;
 		uint16		RequestID;
 	} AUX_PERF_REQUESTID;
-	
+
 	/*************************/
 	/* AUX_HEADER case (0x2) */
 	typedef [public,enum16bit, flag(NDR_PAHEX)] enum {
@@ -4426,7 +4426,7 @@ System Attendant Private Interface
 		uint8		RequestOperation;
 		uint8		Reserved[3];
 	} AUX_PERF_DEFGC_SUCCESS;
-	
+
 	/**************************/
 	/* AUX_HEADER case (0x7)  */
 	/* AUX_HEADER case (0xE)  */

--- a/exchange.idl
+++ b/exchange.idl
@@ -299,7 +299,7 @@ System Attendant Private Interface
 		[size_is(cb)] uint8		*lpb;
 	} Binary_r;
 
-	typedef [public] struct {
+	typedef [public,noprint] struct {
 		uint32 dwLowDateTime;
 		uint32 dwHighDateTime;
 	} FILETIME;

--- a/exchange.idl
+++ b/exchange.idl
@@ -997,6 +997,11 @@ System Attendant Private Interface
 		[flag(NDR_BUFFERS)]uint8	lpb[cb];
 	} SBinary_short;
 
+	typedef [public,noprint,flag(NDR_NOALIGN)] struct {
+		uint32         cb;
+		[flag(NDR_BUFFERS)]uint8   lpb[cb];
+	} SBinary;
+
 	typedef [public] struct {
 		uint32 cValues;
 		uint32 lpl[cValues];
@@ -2966,7 +2971,7 @@ System Attendant Private Interface
 		TransferStatus_Done	= 0x0003
 	} TransferStatus;
 
-	typedef [flag(NDR_NOALIGN)] struct {
+	typedef [noprint,flag(NDR_NOALIGN)] struct {
 		TransferStatus	TransferStatus;
 		uint16		InProgressCount;
 		uint16		TotalStepCount;

--- a/exchange.idl
+++ b/exchange.idl
@@ -4715,13 +4715,3 @@ System Attendant Private Interface
 	void unknown_dummy();
 }
 
-[
- uuid("8ac6ad47-9cbb-4518-8b8d-38e755bfdf01"),
- pointer_default(unique),
- helpstring("Debug")
-] interface exchange_debug
-{
-  [public,noprint] void FastTransferSourceGetBuffer(
-	       [in,out][flag(NDR_REMAINING)] DATA_BLOB data
-	       );
-}

--- a/exchange_debug.idl
+++ b/exchange_debug.idl
@@ -1,0 +1,16 @@
+#include "idl_types.h"
+
+cpp_quote("#include <gen_ndr/ndr_misc.h>")
+
+import "exchange.idl";
+
+[
+ uuid("8ac6ad47-9cbb-4518-8b8d-38e755bfdf01"),
+ pointer_default(unique),
+ helpstring("Debug")
+] interface exchange_debug
+{
+  [public,noprint] void FastTransferSourceGetBuffer(
+	       [in,out][flag(NDR_REMAINING)] DATA_BLOB data
+	       );
+}

--- a/libmapi/libmapi_private.h
+++ b/libmapi/libmapi_private.h
@@ -8,12 +8,12 @@
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -73,6 +73,7 @@ enum ndr_err_code ndr_push_PersistDataArray(struct ndr_push *ndr, int ndr_flags,
 enum ndr_err_code ndr_pull_PersistDataArray(struct ndr_pull *ndr, int ndr_flags, struct PersistDataArray *r);
 enum ndr_err_code ndr_push_PersistElementArray(struct ndr_push *ndr, int ndr_flags, const struct PersistElementArray *r);
 enum ndr_err_code ndr_pull_PersistElementArray(struct ndr_pull *ndr, int ndr_flags, struct PersistElementArray *r);
+void ndr_dump_data(struct ndr_print *, const uint8_t *, int);
 
 /* The following private definitions come from libmapi/nspi.c */
 int nspi_disconnect_dtor(void *);

--- a/ndr_fasttransfer.c
+++ b/ndr_fasttransfer.c
@@ -190,17 +190,28 @@ static void ndr_print_IDSET(struct ndr_print *ndr, const struct idset *idset,
 static int ndr_parse_ics_state(TALLOC_CTX *mem_ctx, struct ndr_print *ndr,
                                struct ndr_pull *ndr_pull, uint32_t element)
 {
-	struct idset *idset;
-	struct SBinary PtypBinary;
-	DATA_BLOB buffer;
+	struct idset	*idset;
+	struct SBinary	PtypBinary;
+	DATA_BLOB	buffer;
+	const char	*name = NULL;
+
+	switch (element) {
+	case MetaTagIdsetGiven:   name = COLOR_BOLD NDR_CYAN(MetaTagIdsetGiven) COLOR_BOLD_OFF; break;
+	case MetaTagCnsetSeen:    name = COLOR_BOLD NDR_CYAN(MetaTagCnsetSeen) COLOR_BOLD_OFF; break;
+	case MetaTagCnsetSeenFAI: name = COLOR_BOLD NDR_CYAN(MetaTagCnsetSeenFAI) COLOR_BOLD_OFF; break;
+	case MetaTagCnsetRead:    name = COLOR_BOLD NDR_CYAN(MetaTagCnsetRead) COLOR_BOLD_OFF; break;
+	}
 
 	switch (element) {
 	case MetaTagIdsetGiven:
+	case MetaTagCnsetSeen:
+	case MetaTagCnsetSeenFAI:
+	case MetaTagCnsetRead:
 		NDR_CHECK(ndr_pull_SBinary(ndr_pull, NDR_SCALARS, &PtypBinary));
 		buffer.length = PtypBinary.cb;
 		buffer.data = PtypBinary.lpb;
 		idset = IDSET_parse(mem_ctx, buffer, false);
-		ndr_print_IDSET(ndr, idset, COLOR_BOLD NDR_CYAN(MetaTagIdsetGiven) COLOR_BOLD_OFF);
+		ndr_print_IDSET(ndr, idset, name);
 		return 0;
 	default:
 		return -1;

--- a/ndr_fasttransfer.c
+++ b/ndr_fasttransfer.c
@@ -24,6 +24,7 @@
 #include <ndr.h>
 #include "gen_ndr/ndr_exchange.h"
 #include "gen_ndr/ndr_property.h"
+#include "gen_ndr/ndr_exchange_debug.h"
 
 #if (!defined(NDR_COLOR))
 #define NDR_COLOR

--- a/ndr_fasttransfer.c
+++ b/ndr_fasttransfer.c
@@ -123,9 +123,9 @@ static int ndr_print_marker(struct ndr_print *ndr, uint32_t marker)
 	case EndToRecip:
 	case EndAttach:
 	case IncrSyncStateEnd:
-	if (_saved_depth != ndr->depth) {
-		ndr->depth--;
-	}
+		if (_saved_depth != ndr->depth) {
+			ndr->depth--;
+		}
 		break;
 	default:
 		ndr->depth++;

--- a/ndr_fasttransfer.c
+++ b/ndr_fasttransfer.c
@@ -288,15 +288,15 @@ static int ndr_parse_propValue(TALLOC_CTX *mem_ctx, struct ndr_print *ndr,
 		ndr_print_SBinary(ndr, propValue, &PtypBinary);
 		break;
 	default:
-		{
-			uint32_t _flags_save_default = ndr_pull->flags;
+	{
+		uint32_t _flags_save_default = ndr_pull->flags;
 
-			ndr->print(ndr, COLOR_RED "Not supported: %s" COLOR_END, propValue);
-			ndr_set_flags(&ndr_pull->flags, LIBNDR_FLAG_REMAINING);
-			NDR_CHECK(ndr_pull_DATA_BLOB(ndr_pull, NDR_SCALARS, &datablob));
-			ndr_pull->flags = _flags_save_default;
-			ndr_print_DATA_BLOB(ndr, propValue, datablob);
-		}
+		ndr->print(ndr, COLOR_RED "Not supported: %s" COLOR_END, propValue);
+		ndr_set_flags(&ndr_pull->flags, LIBNDR_FLAG_REMAINING);
+		NDR_CHECK(ndr_pull_DATA_BLOB(ndr_pull, NDR_SCALARS, &datablob));
+		ndr_pull->flags = _flags_save_default;
+		ndr_dump_data(ndr, datablob.data, datablob.length);
+	}
 	}
 	talloc_free(propValue);
 	return 0;

--- a/ndr_fasttransfer.c
+++ b/ndr_fasttransfer.c
@@ -25,6 +25,27 @@
 #include "gen_ndr/ndr_exchange.h"
 #include "gen_ndr/ndr_property.h"
 
+#define COLOR_BLACK    "\x1b[30m"
+#define COLOR_RED      "\x1b[31m"
+#define COLOR_GREEN    "\x1b[32m"
+#define COLOR_YELLOW   "\x1b[33m"
+#define COLOR_BLUE     "\x1b[34m"
+#define COLOR_MAGENTA  "\x1b[35m"
+#define COLOR_CYAN     "\x1b[36m"
+#define COLOR_WHITE    "\x1b[37m"
+#define COLOR_BOLD     "\x1b[1m"
+#define COLOR_INVERSE  "\x1b[7m"
+#define COLOR_BOLD_OFF "\x1b[22m"
+#define COLOR_END      "\x1b[0m"
+
+#define NDR_RED(s)     COLOR_RED     #s COLOR_END
+#define NDR_GREEN(s)   COLOR_GREEN   #s COLOR_END
+#define NDR_YELLOW(s)  COLOR_YELLOW  #s COLOR_END
+#define NDR_BLUE(s)    COLOR_BLUE    #s COLOR_END
+#define NDR_MAGENTA(s) COLOR_MAGENTA #s COLOR_END
+#define NDR_CYAN(s)    COLOR_CYAN    #s COLOR_END
+#define NDR_WHITE(s)   COLOR_WHITE   #s COLOR_END
+
 /**
  */
 static int ndr_print_marker(struct ndr_print *ndr, uint32_t marker)
@@ -60,31 +81,31 @@ static int ndr_print_marker(struct ndr_print *ndr, uint32_t marker)
 
 	switch (marker) {
 		/* Folders */
-	case StartTopFld: val = "\x1b[33mStartTopFld\x1b[0m"; break;
-	case StartSubFld: val = "\x1b[33mStartSubFld\x1b[0m"; break;
-	case EndFolder: val = "\x1b[33mEndFolder\x1b[0m"; break;
+	case StartTopFld: val = NDR_YELLOW("StartTopFld"); break;
+	case StartSubFld: val = NDR_YELLOW("StartSubFld"); break;
+	case EndFolder: val = NDR_YELLOW("EndFolder"); break;
 		/* Messages and their parts */
-	case StartMessage: val = "\x1b[33mStartMessage\x1b[0m"; break;
-	case StartFAIMsg: val = "\x1b[33mStartFAIMsg\x1b[0m"; break;
-	case EndMessage: val = "\x1b[33mEndMessage\x1b[0m"; break;
-	case StartEmbed: val = "\x1b[33mStartEmbed\x1b[0m"; break;
-	case EndEmbed: val = "\x1b[33mEndEmbed\x1b[0m"; break;
-	case StartRecip: val = "\x1b[33mStartRecip\x1b[0m"; break;
-	case EndToRecip: val = "\x1b[33mEndToRecip\x1b[0m"; break;
-	case NewAttach: val = "\x1b[33mNewAttach\x1b[0m"; break;
-	case EndAttach: val = "\x1b[33mEndAttach\x1b[0m"; break;
+	case StartMessage: val = NDR_YELLOW("StartMessage"); break;
+	case StartFAIMsg: val = NDR_YELLOW("StartFAIMsg"); break;
+	case EndMessage: val = NDR_YELLOW("EndMessage"); break;
+	case StartEmbed: val = NDR_YELLOW("StartEmbed"); break;
+	case EndEmbed: val = NDR_YELLOW("EndEmbed"); break;
+	case StartRecip: val = NDR_YELLOW("StartRecip"); break;
+	case EndToRecip: val = NDR_YELLOW("EndToRecip"); break;
+	case NewAttach: val = NDR_YELLOW("NewAttach"); break;
+	case EndAttach: val = NDR_YELLOW("EndAttach"); break;
 		/* Synchronization download */
-	case IncrSyncChg: val = "\x1b[33mIncrSyncChg\x1b[0m"; noend = true; break;
-	case IncrSyncChgPartial: val = "\x1b[33mIncrSyncChgPartial\x1b[0m"; noend = true; break;
-	case IncrSyncDel: val = "\x1b[33mIncrSyncDel\x1b[0m"; break;
-	case IncrSyncEnd: val = "\x1b[33mIncrSyncEnd\x1b[0m"; break;
-	case IncrSyncRead: val = "\x1b[33mIncrSyncRead\x1b[0m"; break;
-	case IncrSyncStateBegin: val = "\x1b[33mIncrSyncStateBegin\x1b[0m"; noend = true; break;
-	case IncrSyncStateEnd: val = "\x1b[33mIncrSyncStateEnd\x1b[0m"; break;
-	case IncrSyncProgressMode: val = "\x1b[33mIncrSyncProgressMode\x1b[0m"; break;
-	case IncrSyncProgressPerMsg: val = "\x1b[33mIncrSyncProgressPerMsg\x1b[0m"; break;
-	case IncrSyncMessage: val = "\x1b[33mIncrSyncMessage\x1b[0m"; break;
-	case IncrSyncGroupInfo: val = "\x1b[33mIncrSyncGroupInfo\x1b[0m"; break;
+	case IncrSyncChg: val = NDR_YELLOW("IncrSyncChg"); noend = true; break;
+	case IncrSyncChgPartial: val = NDR_YELLOW("IncrSyncChgPartial"); noend = true; break;
+	case IncrSyncDel: val = NDR_YELLOW("IncrSyncDel"); break;
+	case IncrSyncEnd: val = NDR_YELLOW("IncrSyncEnd"); break;
+	case IncrSyncRead: val = NDR_YELLOW("IncrSyncRead"); break;
+	case IncrSyncStateBegin: val = NDR_YELLOW("IncrSyncStateBegin"); noend = true; break;
+	case IncrSyncStateEnd: val = NDR_YELLOW("IncrSyncStateEnd"); break;
+	case IncrSyncProgressMode: val = NDR_YELLOW("IncrSyncProgressMode"); break;
+	case IncrSyncProgressPerMsg: val = NDR_YELLOW("IncrSyncProgressPerMsg"); break;
+	case IncrSyncMessage: val = NDR_YELLOW("IncrSyncMessage"); break;
+	case IncrSyncGroupInfo: val = NDR_YELLOW("IncrSyncGroupInfo"); break;
 		/* Special */
 	case FXErrorInfo: val = "FXErrorInfo"; break;
 	}
@@ -92,7 +113,7 @@ static int ndr_print_marker(struct ndr_print *ndr, uint32_t marker)
 		return -1;
 	}
 
-	ndr_print_enum(ndr, "\x1b[33mMarker\x1b[0m", "ENUM", val, marker);
+	ndr_print_enum(ndr, NDR_YELLOW(Marker), "ENUM", val, marker);
 
 	/* Adjust ndr depth */
 	switch (marker) {
@@ -124,11 +145,11 @@ static void ndr_print_IDSET(struct ndr_print *ndr, const struct idset *idset,
 	ndr->depth++;
 	while (idset) {
 		if (idset->idbased) {
-			ndr->print(ndr, "\x1b[32m%.4x: %d elements\x1b[0m", idset->repl.id, idset->range_count);
+			ndr->print(ndr, COLOR_GREEN "%.4x: %d elements" COLOR_END, idset->repl.id, idset->range_count);
 		}
 		else {
 			guid_str = GUID_string(NULL, &idset->repl.guid);
-			ndr->print(ndr, "\x1b[32m%s: %d elements\x1b[0m", guid_str, idset->range_count);
+			ndr->print(ndr, COLOR_GREEN "%s: %d elements" COLOR_END, guid_str, idset->range_count);
 			talloc_free(guid_str);
 		}
 
@@ -136,9 +157,9 @@ static void ndr_print_IDSET(struct ndr_print *ndr, const struct idset *idset,
 		range = idset->ranges;
 		for (i = 0; i < idset->range_count; i++) {
 			if (exchange_globcnt(range->low) > exchange_globcnt(range->high)) {
-				ndr->print(ndr, "\x1b[31mIncorrect GLOBCNT range as high value is larger than low value\x1b[0m");
+				ndr->print(ndr, COLOR_BOLD COLOR_RED "Incorrect GLOBCNT range as high value is larger than low value" COLOR_END COLOR_END);
 			}
-			ndr->print(ndr, "\x1b[32m[0x%.12" PRIx64 ":0x%.12" PRIx64 "]\x1b[0m", range->low, range->high);
+			ndr->print(ndr, COLOR_GREEN "0x%.12" PRIx64 ":0x%.12" PRIx64 COLOR_END, range->low, range->high);
 			range = range->next;
 		}
 		ndr->depth--;
@@ -162,7 +183,7 @@ static int ndr_parse_ics_state(TALLOC_CTX *mem_ctx, struct ndr_print *ndr,
 		buffer.length = PtypBinary.cb;
 		buffer.data = PtypBinary.lpb;
 		idset = IDSET_parse(mem_ctx, buffer, false);
-		ndr_print_IDSET(ndr, idset, "\x1b[32mMetaTagIdsetGiven\x1b[0m");
+		ndr_print_IDSET(ndr, idset, NDR_GREEN(MetaTagIdsetGiven));
 		return 0;
 	default:
 		return -1;
@@ -190,10 +211,9 @@ static int ndr_parse_propValue(TALLOC_CTX *mem_ctx, struct ndr_print *ndr,
 
 	_propValue = get_proptag_name(element);
 	if (_propValue == NULL) {
-		propValue = talloc_asprintf(mem_ctx, "0x%X", element);
+		propValue = talloc_asprintf(mem_ctx, COLOR_BOLD NDR_MAGENTA(0x%X) COLOR_BOLD_OFF, element);
 	} else {
-		//propValue = talloc_strdup(mem_ctx, _propValue);
-		propValue = talloc_asprintf(mem_ctx, "\x1b[1m\x1b[35m%s\x1b[0m\x1b[0m", _propValue);
+		propValue = talloc_asprintf(mem_ctx, COLOR_BOLD NDR_MAGENTA(%s) COLOR_BOLD_OFF, _propValue);
 	}
 
 	/* named property with propid > 0x8000 or known property */
@@ -271,7 +291,7 @@ static int ndr_parse_propValue(TALLOC_CTX *mem_ctx, struct ndr_print *ndr,
 		{
 			uint32_t _flags_save_default = ndr_pull->flags;
 
-			ndr->print(ndr, "Not supported: %s", propValue);
+			ndr->print(ndr, COLOR_RED "Not supported: %s" COLOR_END, propValue);
 			ndr_set_flags(&ndr_pull->flags, LIBNDR_FLAG_REMAINING);
 			NDR_CHECK(ndr_pull_DATA_BLOB(ndr_pull, NDR_SCALARS, &datablob));
 			ndr_pull->flags = _flags_save_default;

--- a/ndr_fasttransfer.c
+++ b/ndr_fasttransfer.c
@@ -49,6 +49,9 @@ static int ndr_print_marker(struct ndr_print *ndr, uint32_t marker)
 	case IncrSyncStateBegin:
 		if (noend == true) ndr->depth--;
 		break;
+	case IncrSyncEnd:
+		ndr->depth++;
+		break;
 	}
 
 	switch (marker) {
@@ -97,6 +100,8 @@ static int ndr_print_marker(struct ndr_print *ndr, uint32_t marker)
 	case IncrSyncStateEnd:
 		ndr->depth--;
 		break;
+	case IncrSyncEnd:
+		ndr->depth--;
 	default:
 		ndr->depth++;
 	}

--- a/ndr_fasttransfer.c
+++ b/ndr_fasttransfer.c
@@ -468,6 +468,34 @@ _PUBLIC_ void ndr_print_FastTransferSourceGetBuffer_repl(struct ndr_print *ndr, 
 }
 
 
+_PUBLIC_ void ndr_print_SyncUploadStateStreamContinue_req(struct ndr_print *ndr, const char *name, const struct SyncUploadStateStreamContinue_req *r)
+{
+	ndr_print_struct(ndr, name, "SyncUploadStateStreamContinue_req");
+	if (r == NULL) { ndr_print_null(ndr); return; }
+	{
+		uint32_t _flags_save_STRUCT = ndr->flags;
+		ndr_set_flags(&ndr->flags, LIBNDR_FLAG_NOALIGN);
+		ndr->depth++;
+		{
+			TALLOC_CTX	*mem_ctx;
+			struct idset	*idset;
+			DATA_BLOB	buffer;
+
+			mem_ctx = talloc_named(NULL, 0, "SyncUploadStateStreamContinue");
+			if (!mem_ctx) return;
+
+			buffer.length = r->StreamDataSize;
+			buffer.data = r->StreamData;
+			idset = IDSET_parse(mem_ctx, buffer, false);
+			ndr_print_IDSET(ndr, idset, name);
+			talloc_free(mem_ctx);
+		}
+
+		ndr->depth--;
+		ndr->flags = _flags_save_STRUCT;
+	}
+}
+
 /* Debug interface */
 _PUBLIC_ void ndr_print_FastTransferSourceGetBuffer(struct ndr_print *ndr, const char *name, int flags, const struct FastTransferSourceGetBuffer *r)
 {

--- a/ndr_fasttransfer.c
+++ b/ndr_fasttransfer.c
@@ -1,0 +1,388 @@
+/*
+  OpenChange implementation.
+
+  libndr mapi support
+
+  Copyright (C) Julien Kerihuel 2015
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "libmapi/libmapi.h"
+#include "libmapi/libmapi_private.h"
+#include <ndr.h>
+#include "gen_ndr/ndr_exchange.h"
+#include "gen_ndr/ndr_property.h"
+
+/**
+ */
+static int ndr_print_marker(struct ndr_print *ndr, uint32_t marker)
+{
+	const char *val = NULL;
+	static bool noend = false;
+
+	ndr_set_flags(&ndr->flags, LIBNDR_PRINT_ARRAY_HEX);
+
+	/* Adjust ndr depth */
+	switch (marker) {
+	case EndFolder:
+	case EndMessage:
+	case EndEmbed:
+	case EndToRecip:
+	case EndAttach:
+	case IncrSyncStateEnd:
+		ndr->depth--;
+		break;
+	case IncrSyncChg:
+	case IncrSyncChgPartial:
+	case IncrSyncStateBegin:
+		if (noend == true) ndr->depth--;
+		break;
+	}
+
+	switch (marker) {
+		/* Folders */
+	case StartTopFld: val = "\x1b[33mStartTopFld\x1b[0m"; break;
+	case StartSubFld: val = "\x1b[33mStartSubFld\x1b[0m"; break;
+	case EndFolder: val = "\x1b[33mEndFolder\x1b[0m"; break;
+		/* Messages and their parts */
+	case StartMessage: val = "\x1b[33mStartMessage\x1b[0m"; break;
+	case StartFAIMsg: val = "\x1b[33mStartFAIMsg\x1b[0m"; break;
+	case EndMessage: val = "\x1b[33mEndMessage\x1b[0m"; break;
+	case StartEmbed: val = "\x1b[33mStartEmbed\x1b[0m"; break;
+	case EndEmbed: val = "\x1b[33mEndEmbed\x1b[0m"; break;
+	case StartRecip: val = "\x1b[33mStartRecip\x1b[0m"; break;
+	case EndToRecip: val = "\x1b[33mEndToRecip\x1b[0m"; break;
+	case NewAttach: val = "\x1b[33mNewAttach\x1b[0m"; break;
+	case EndAttach: val = "\x1b[33mEndAttach\x1b[0m"; break;
+		/* Synchronization download */
+	case IncrSyncChg: val = "\x1b[33mIncrSyncChg\x1b[0m"; noend = true; break;
+	case IncrSyncChgPartial: val = "\x1b[33mIncrSyncChgPartial\x1b[0m"; noend = true; break;
+	case IncrSyncDel: val = "\x1b[33mIncrSyncDel\x1b[0m"; break;
+	case IncrSyncEnd: val = "\x1b[33mIncrSyncEnd\x1b[0m"; break;
+	case IncrSyncRead: val = "\x1b[33mIncrSyncRead\x1b[0m"; break;
+	case IncrSyncStateBegin: val = "\x1b[33mIncrSyncStateBegin\x1b[0m"; break;
+	case IncrSyncStateEnd: val = "\x1b[33mIncrSyncStateEnd\x1b[0m"; break;
+	case IncrSyncProgressMode: val = "\x1b[33mIncrSyncProgressMode\x1b[0m"; break;
+	case IncrSyncProgressPerMsg: val = "\x1b[33mIncrSyncProgressPerMsg\x1b[0m"; break;
+	case IncrSyncMessage: val = "\x1b[33mIncrSyncMessage\x1b[0m"; break;
+	case IncrSyncGroupInfo: val = "\x1b[33mIncrSyncGroupInfo\x1b[0m"; break;
+		/* Special */
+	case FXErrorInfo: val = "FXErrorInfo"; break;
+	}
+	if (val == NULL) {
+		return -1;
+	}
+
+	ndr_print_enum(ndr, "\x1b[33mMarker\x1b[0m", "ENUM", val, marker);
+
+	/* Adjust ndr depth */
+	switch (marker) {
+	case EndFolder:
+	case EndMessage:
+	case EndEmbed:
+	case EndToRecip:
+	case EndAttach:
+	case IncrSyncStateEnd:
+		ndr->depth--;
+		break;
+	default:
+		ndr->depth++;
+	}
+
+	return 0;
+}
+
+static void ndr_print_IDSET(struct ndr_print *ndr, const struct idset *idset,
+                            const char *label)
+{
+	struct globset_range *range;
+	uint32_t i;
+	char *guid_str;
+
+	ndr->print(ndr, "%s:", label);
+	ndr->depth++;
+	while (idset) {
+		if (idset->idbased) {
+			ndr->print(ndr, "\x1b[32m%.4x: %d elements\x1b[0m", idset->repl.id, idset->range_count);
+		}
+		else {
+			guid_str = GUID_string(NULL, &idset->repl.guid);
+			ndr->print(ndr, "\x1b[32m%s: %d elements\x1b[0m", guid_str, idset->range_count);
+			talloc_free(guid_str);
+		}
+
+		ndr->depth++;
+		range = idset->ranges;
+		for (i = 0; i < idset->range_count; i++) {
+			if (exchange_globcnt(range->low) > exchange_globcnt(range->high)) {
+				ndr->print(ndr, "\x1b[31mIncorrect GLOBCNT range as high value is larger than low value\x1b[0m");
+			}
+			ndr->print(ndr, "\x1b[32m[0x%.12" PRIx64 ":0x%.12" PRIx64 "]\x1b[0m", range->low, range->high);
+			range = range->next;
+		}
+		ndr->depth--;
+
+		idset = idset->next;
+	}
+	ndr->depth--;
+
+}
+
+static int ndr_parse_ics_state(TALLOC_CTX *mem_ctx, struct ndr_print *ndr,
+                               struct ndr_pull *ndr_pull, uint32_t element)
+{
+	struct idset *idset;
+	struct SBinary PtypBinary;
+	DATA_BLOB buffer;
+
+	switch (element) {
+	case MetaTagIdsetGiven:
+		NDR_CHECK(ndr_pull_SBinary(ndr_pull, NDR_SCALARS, &PtypBinary));
+		buffer.length = PtypBinary.cb;
+		buffer.data = PtypBinary.lpb;
+		idset = IDSET_parse(mem_ctx, buffer, false);
+		ndr_print_IDSET(ndr, idset, "\x1b[32mMetaTagIdsetGiven\x1b[0m");
+		return 0;
+	default:
+		return -1;
+	}
+	return -1;
+}
+
+static int ndr_parse_propValue(TALLOC_CTX *mem_ctx, struct ndr_print *ndr,
+                               struct ndr_pull *ndr_pull, uint32_t element)
+{
+	uint16_t        PtypInteger16;
+	uint32_t        PtypInteger32;
+	double          PtypFloating64;
+	uint16_t         PtypBoolean;
+	int64_t         PtypInteger64;
+	struct FILETIME PtypTime;
+	struct GUID     PtypGuid;
+	const char      *PtypString;
+	const char      *PtypString8;
+	struct Binary_r PtypServerId;
+	struct SBinary PtypBinary;
+	const char      *_propValue;
+	char            *propValue;
+
+	_propValue = get_proptag_name(element);
+	if (_propValue == NULL) {
+		propValue = talloc_asprintf(mem_ctx, "0x%X", element);
+	} else {
+		//propValue = talloc_strdup(mem_ctx, _propValue);
+		propValue = talloc_asprintf(mem_ctx, "\x1b[1m\x1b[35m%s\x1b[0m\x1b[0m", _propValue);
+	}
+
+	/* named property with propid > 0x8000 or known property */
+	if ((element >> 16) & 0x8000) {
+		//ret = ndr_parse_namedproperty(ndr_print, ndr_pull);
+		ndr_pull->offset += 1;
+		talloc_free(propValue);
+		return 0;
+	}
+
+	switch (element & 0xFFFF) {
+		/* fixedSizeValue */
+	case PT_SHORT:
+		NDR_CHECK(ndr_pull_uint16(ndr_pull, NDR_SCALARS, &PtypInteger16));
+		ndr_print_uint16(ndr, propValue, PtypInteger16);
+		break;
+	case PT_LONG:
+		NDR_CHECK(ndr_pull_uint32(ndr_pull, NDR_SCALARS, &PtypInteger32));
+		ndr_print_uint32(ndr, propValue, PtypInteger32);
+		break;
+		/* no support for PtypFloating32 0x0004 PT_FLOAT */
+	case PT_DOUBLE:
+		NDR_CHECK(ndr_pull_double(ndr_pull, NDR_SCALARS, &PtypFloating64));
+		ndr_print_double(ndr, propValue, PtypFloating64);
+		break;
+		/* no support for PtypCurrency, 0x0006 PT_CURRENCY */
+		/* no support for PtypFloatingTime, 0x0007 PT_APPTIME */
+	case PT_BOOLEAN:
+		NDR_CHECK(ndr_pull_uint16(ndr_pull, NDR_SCALARS, &PtypBoolean));
+		ndr_print_string(ndr, propValue, (const char *)((PtypBoolean == true) ? "True" : "False"));
+		//ndr_print_uint16(ndr, propValue, PtypBoolean);
+		break;
+	case PT_I8:
+		NDR_CHECK(ndr_pull_dlong(ndr_pull, NDR_SCALARS, &PtypInteger64));
+		ndr_print_dlong(ndr, propValue, PtypInteger64);
+		break;
+	case PT_SYSTIME:
+		NDR_CHECK(ndr_pull_FILETIME(ndr_pull, NDR_SCALARS, &PtypTime));
+		ndr_print_FILETIME(ndr, propValue, &PtypTime);
+		break;
+	case PT_CLSID:
+		NDR_CHECK(ndr_pull_GUID(ndr_pull, NDR_SCALARS, &PtypGuid));
+		ndr_print_GUID(ndr, propValue, &PtypGuid);
+		break;
+		/* varSizeValue */
+	case PT_UNICODE:
+	{
+		uint32_t  _flags_save_string = ndr_pull->flags;
+		NDR_CHECK(ndr_pull_uint32(ndr_pull, NDR_SCALARS, &PtypInteger32));
+		ndr_set_flags(&ndr_pull->flags, LIBNDR_FLAG_STR_NULLTERM);
+		NDR_CHECK(ndr_pull_string(ndr_pull, NDR_SCALARS, &PtypString));
+		ndr_pull->flags = _flags_save_string;
+		ndr_print_string(ndr, propValue, PtypString);
+	}
+	break;
+	case PT_STRING8:
+	{
+		/* FIXME: probably need to pull uint32_t first */
+		uint32_t _flags_save_string = ndr_pull->flags;
+		ndr_set_flags(&ndr_pull->flags, LIBNDR_FLAG_STR_RAW8|LIBNDR_FLAG_STR_NULLTERM|LIBNDR_FLAG_STR_SIZE4);
+		NDR_CHECK(ndr_pull_string(ndr_pull, NDR_SCALARS, &PtypString8));
+		ndr_pull->flags = _flags_save_string;
+		ndr_print_string(ndr, propValue, PtypString8);
+	}
+	break;
+	case PT_SVREID:
+		NDR_CHECK(ndr_pull_Binary_r(ndr_pull, NDR_SCALARS, &PtypServerId));
+		ndr_print_Binary_r(ndr, propValue, &PtypServerId);
+		break;
+	case PT_BINARY:
+		NDR_CHECK(ndr_pull_SBinary(ndr_pull, NDR_SCALARS, &PtypBinary));
+		ndr_print_SBinary(ndr, propValue, &PtypBinary);
+		break;
+	default:
+		ndr->print(ndr, "Not supported: %s", propValue);
+	}
+	talloc_free(propValue);
+	return 0;
+}
+
+/**
+   \details Parse and Display Fast Transfer element. An element is either
+   a marker or a propvalue.
+
+   \param mem_ctx pointer to the memory context
+   \param ndr pointer to the ndr_print structure
+   \param ndr_pull pointer to the ndr_pull structure representing the fxbuffer
+
+   \return value >= 0 on success, otherwise -1
+*/
+static int ndr_parse_FastTransferElement(TALLOC_CTX *mem_ctx, struct ndr_print *ndr, struct ndr_pull *ndr_pull)
+{
+	uint32_t  element;
+	int       ret;
+
+	NDR_CHECK(ndr_pull_uint32(ndr_pull, NDR_SCALARS, &element));
+
+	ret = ndr_print_marker(ndr, element);
+	if (ret == 0) return 0;
+
+	ret = ndr_parse_ics_state(mem_ctx, ndr, ndr_pull, element);
+	if (ret == 0) return 0;
+
+	ret = ndr_parse_propValue(mem_ctx, ndr, ndr_pull, element);
+	return ret;
+}
+
+/**
+   \details Parse and display Fast Transfer Stream
+
+   \param ndr pointer to the ndr_print structure
+   \param buf the FastTransfer Stream buffer to parse
+
+   \return 0 on success, otherwise -1
+*/
+static int ndr_parse_FastTransferStream(struct ndr_print *ndr, DATA_BLOB buf)
+{
+	TALLOC_CTX      *mem_ctx;
+	struct ndr_pull *ndr_pull;
+	int             ret = 0;
+	int             offset;
+
+	mem_ctx = talloc_named(NULL, 0, "FastTransferStream");
+	if (!mem_ctx) return -1;
+	if (buf.length == 0) return 0;
+
+	/* Map DATA_BLOB to ndr pull context */
+	ndr_pull = talloc_zero(mem_ctx, struct ndr_pull);
+	NDR_ERR_HAVE_NO_MEMORY(ndr_pull);
+	ndr_pull->flags |= LIBNDR_FLAG_NOALIGN;
+	ndr_pull->current_mem_ctx = mem_ctx;
+	ndr_pull->data = buf.data;
+	ndr_pull->data_size = buf.length;
+	ndr_pull->offset = 0;
+
+	ndr_set_flags(&ndr_pull->flags, LIBNDR_FLAG_NOALIGN);
+	ndr_set_flags(&ndr->flags, LIBNDR_FLAG_NOALIGN);
+
+	while (ndr_pull->offset < ndr_pull->data_size -1) {
+		offset = ndr_parse_FastTransferElement(mem_ctx, ndr, ndr_pull);
+		if (offset < 0) {
+			ret = -1;
+			goto end;
+		}
+	}
+
+end:
+	talloc_free(mem_ctx);
+	return ret;
+}
+
+_PUBLIC_ void ndr_print_FastTransferSourceGetBuffer_repl(struct ndr_print *ndr, const char *name, const struct FastTransferSourceGetBuffer_repl *r)
+{
+	int res;
+
+	ndr_print_struct(ndr, name, "FastTransferSourceGetBuffer_repl");
+	if (r == NULL) { ndr_print_null(ndr); return; }
+	{
+		uint32_t _flags_save_STRUCT = ndr->flags;
+		ndr_set_flags(&ndr->flags, LIBNDR_FLAG_NOALIGN);
+		ndr->depth++;
+		ndr_print_TransferStatus(ndr, "TransferStatus", r->TransferStatus);
+		ndr_print_uint16(ndr, "InProgressCount", r->InProgressCount);
+		ndr_print_uint16(ndr, "TotalStepCount", r->TotalStepCount);
+		ndr_print_uint8(ndr, "Reserved", r->Reserved);
+		ndr_print_uint16(ndr, "TransferBufferSize", r->TransferBufferSize);
+		ndr_print_DATA_BLOB(ndr, "TransferBuffer", r->TransferBuffer);
+		res = ndr_parse_FastTransferStream(ndr, r->TransferBuffer);
+		if (res != 0) {
+			ndr_print_DATA_BLOB(ndr, "TransferBuffer", r->TransferBuffer);
+		}
+		ndr->depth--;
+		ndr->flags = _flags_save_STRUCT;
+	}
+}
+
+
+/* Debug interface */
+_PUBLIC_ void ndr_print_FastTransferSourceGetBuffer(struct ndr_print *ndr, const char *name, int flags, const struct FastTransferSourceGetBuffer *r)
+{
+	ndr_print_struct(ndr, name, "FastTransferSourceGetBuffer");
+	if (r == NULL) { ndr_print_null(ndr); return; }
+	ndr->depth++;
+	if (flags & NDR_SET_VALUES) {
+		ndr->flags |= LIBNDR_PRINT_SET_VALUES;
+	}
+	if (flags & NDR_IN) {
+		ndr_print_struct(ndr, "in", "FastTransferSourceGetBuffer");
+		ndr->depth++;
+		ndr_print_DATA_BLOB(ndr, "data", r->in.data);
+		ndr_parse_FastTransferStream(ndr, r->in.data);
+		ndr->depth--;
+	}
+	if (flags & NDR_OUT) {
+		ndr_print_struct(ndr, "out", "FastTransferSourceGetBuffer");
+		ndr->depth++;
+		ndr_print_DATA_BLOB(ndr, "data", r->out.data);
+		ndr_parse_FastTransferStream(ndr, r->out.data);
+		ndr->depth--;
+	}
+	ndr->depth--;
+}

--- a/ndr_fasttransfer.c
+++ b/ndr_fasttransfer.c
@@ -200,6 +200,7 @@ static int ndr_parse_ics_state(TALLOC_CTX *mem_ctx, struct ndr_print *ndr,
 	case MetaTagCnsetSeen:    name = COLOR_BOLD NDR_CYAN(MetaTagCnsetSeen) COLOR_BOLD_OFF; break;
 	case MetaTagCnsetSeenFAI: name = COLOR_BOLD NDR_CYAN(MetaTagCnsetSeenFAI) COLOR_BOLD_OFF; break;
 	case MetaTagCnsetRead:    name = COLOR_BOLD NDR_CYAN(MetaTagCnsetRead) COLOR_BOLD_OFF; break;
+	case MetaTagIdsetDeleted: name = COLOR_BOLD NDR_CYAN(MetaTagIdsetDeleted) COLOR_BOLD_OFF; break;
 	}
 
 	switch (element) {
@@ -207,6 +208,7 @@ static int ndr_parse_ics_state(TALLOC_CTX *mem_ctx, struct ndr_print *ndr,
 	case MetaTagCnsetSeen:
 	case MetaTagCnsetSeenFAI:
 	case MetaTagCnsetRead:
+	case MetaTagIdsetDeleted:
 		NDR_CHECK(ndr_pull_SBinary(ndr_pull, NDR_SCALARS, &PtypBinary));
 		buffer.length = PtypBinary.cb;
 		buffer.data = PtypBinary.lpb;

--- a/ndr_fasttransfer.c
+++ b/ndr_fasttransfer.c
@@ -31,6 +31,11 @@ static int ndr_print_marker(struct ndr_print *ndr, uint32_t marker)
 {
 	const char *val = NULL;
 	static bool noend = false;
+	static uint32_t _saved_depth = 0;
+
+	if (_saved_depth == 0) {
+		_saved_depth = ndr->depth;
+	}
 
 	ndr_set_flags(&ndr->flags, LIBNDR_PRINT_ARRAY_HEX);
 
@@ -42,15 +47,14 @@ static int ndr_print_marker(struct ndr_print *ndr, uint32_t marker)
 	case EndToRecip:
 	case EndAttach:
 	case IncrSyncStateEnd:
-		ndr->depth--;
+		if (_saved_depth != ndr->depth) {
+			ndr->depth--;
+		}
 		break;
 	case IncrSyncChg:
 	case IncrSyncChgPartial:
 	case IncrSyncStateBegin:
 		if (noend == true) ndr->depth--;
-		break;
-	case IncrSyncEnd:
-		ndr->depth++;
 		break;
 	}
 
@@ -75,7 +79,7 @@ static int ndr_print_marker(struct ndr_print *ndr, uint32_t marker)
 	case IncrSyncDel: val = "\x1b[33mIncrSyncDel\x1b[0m"; break;
 	case IncrSyncEnd: val = "\x1b[33mIncrSyncEnd\x1b[0m"; break;
 	case IncrSyncRead: val = "\x1b[33mIncrSyncRead\x1b[0m"; break;
-	case IncrSyncStateBegin: val = "\x1b[33mIncrSyncStateBegin\x1b[0m"; break;
+	case IncrSyncStateBegin: val = "\x1b[33mIncrSyncStateBegin\x1b[0m"; noend = true; break;
 	case IncrSyncStateEnd: val = "\x1b[33mIncrSyncStateEnd\x1b[0m"; break;
 	case IncrSyncProgressMode: val = "\x1b[33mIncrSyncProgressMode\x1b[0m"; break;
 	case IncrSyncProgressPerMsg: val = "\x1b[33mIncrSyncProgressPerMsg\x1b[0m"; break;
@@ -98,10 +102,10 @@ static int ndr_print_marker(struct ndr_print *ndr, uint32_t marker)
 	case EndToRecip:
 	case EndAttach:
 	case IncrSyncStateEnd:
+	if (_saved_depth != ndr->depth) {
 		ndr->depth--;
+	}
 		break;
-	case IncrSyncEnd:
-		ndr->depth--;
 	default:
 		ndr->depth++;
 	}

--- a/ndr_fasttransfer.c
+++ b/ndr_fasttransfer.c
@@ -190,6 +190,7 @@ static void ndr_print_IDSET(struct ndr_print *ndr, const struct idset *idset,
 static int ndr_parse_ics_state(TALLOC_CTX *mem_ctx, struct ndr_print *ndr,
                                struct ndr_pull *ndr_pull, uint32_t element)
 {
+	bool		idbased;
 	struct idset	*idset;
 	struct SBinary	PtypBinary;
 	DATA_BLOB	buffer;
@@ -212,7 +213,8 @@ static int ndr_parse_ics_state(TALLOC_CTX *mem_ctx, struct ndr_print *ndr,
 		NDR_CHECK(ndr_pull_SBinary(ndr_pull, NDR_SCALARS, &PtypBinary));
 		buffer.length = PtypBinary.cb;
 		buffer.data = PtypBinary.lpb;
-		idset = IDSET_parse(mem_ctx, buffer, false);
+		idbased = (element == MetaTagIdsetDeleted) ? true : false;
+		idset = IDSET_parse(mem_ctx, buffer, idbased);
 		ndr_print_IDSET(ndr, idset, name);
 		return 0;
 	default:

--- a/ndr_fasttransfer.c
+++ b/ndr_fasttransfer.c
@@ -25,6 +25,21 @@
 #include "gen_ndr/ndr_exchange.h"
 #include "gen_ndr/ndr_property.h"
 
+#if (!defined(NDR_COLOR))
+#define NDR_COLOR
+#define COLOR_BLACK
+#define COLOR_RED
+#define COLOR_GREEN
+#define COLOR_YELLOW
+#define COLOR_BLUE
+#define COLOR_MAGENTA
+#define COLOR_CYAN
+#define COLOR_WHITE
+#define COLOR_BOLD
+#define COLOR_INVERSE
+#define COLOR_BOLD_OFF
+#define COLOR_END
+#else
 #define COLOR_BLACK    "\x1b[30m"
 #define COLOR_RED      "\x1b[31m"
 #define COLOR_GREEN    "\x1b[32m"
@@ -37,6 +52,7 @@
 #define COLOR_INVERSE  "\x1b[7m"
 #define COLOR_BOLD_OFF "\x1b[22m"
 #define COLOR_END      "\x1b[0m"
+#endif
 
 #define NDR_RED(s)     COLOR_RED     #s COLOR_END
 #define NDR_GREEN(s)   COLOR_GREEN   #s COLOR_END

--- a/ndr_fasttransfer.c
+++ b/ndr_fasttransfer.c
@@ -145,11 +145,11 @@ static void ndr_print_IDSET(struct ndr_print *ndr, const struct idset *idset,
 	ndr->depth++;
 	while (idset) {
 		if (idset->idbased) {
-			ndr->print(ndr, COLOR_GREEN "%.4x: %d elements" COLOR_END, idset->repl.id, idset->range_count);
+			ndr->print(ndr, COLOR_CYAN "%.4x (%d elements):" COLOR_END, idset->repl.id, idset->range_count);
 		}
 		else {
 			guid_str = GUID_string(NULL, &idset->repl.guid);
-			ndr->print(ndr, COLOR_GREEN "%s: %d elements" COLOR_END, guid_str, idset->range_count);
+			ndr->print(ndr, COLOR_CYAN "{%s} (%d elements):" COLOR_END, guid_str, idset->range_count);
 			talloc_free(guid_str);
 		}
 
@@ -159,7 +159,7 @@ static void ndr_print_IDSET(struct ndr_print *ndr, const struct idset *idset,
 			if (exchange_globcnt(range->low) > exchange_globcnt(range->high)) {
 				ndr->print(ndr, COLOR_BOLD COLOR_RED "Incorrect GLOBCNT range as high value is larger than low value" COLOR_END COLOR_END);
 			}
-			ndr->print(ndr, COLOR_GREEN "0x%.12" PRIx64 ":0x%.12" PRIx64 COLOR_END, range->low, range->high);
+			ndr->print(ndr, COLOR_CYAN "0x%.12" PRIx64 ":0x%.12" PRIx64 COLOR_END, range->low, range->high);
 			range = range->next;
 		}
 		ndr->depth--;
@@ -183,7 +183,7 @@ static int ndr_parse_ics_state(TALLOC_CTX *mem_ctx, struct ndr_print *ndr,
 		buffer.length = PtypBinary.cb;
 		buffer.data = PtypBinary.lpb;
 		idset = IDSET_parse(mem_ctx, buffer, false);
-		ndr_print_IDSET(ndr, idset, NDR_GREEN(MetaTagIdsetGiven));
+		ndr_print_IDSET(ndr, idset, COLOR_BOLD NDR_CYAN(MetaTagIdsetGiven) COLOR_BOLD_OFF);
 		return 0;
 	default:
 		return -1;

--- a/ndr_fasttransfer.c
+++ b/ndr_fasttransfer.c
@@ -186,6 +186,7 @@ static int ndr_parse_propValue(TALLOC_CTX *mem_ctx, struct ndr_print *ndr,
 	struct SBinary PtypBinary;
 	const char      *_propValue;
 	char            *propValue;
+	DATA_BLOB				datablob;
 
 	_propValue = get_proptag_name(element);
 	if (_propValue == NULL) {
@@ -267,7 +268,15 @@ static int ndr_parse_propValue(TALLOC_CTX *mem_ctx, struct ndr_print *ndr,
 		ndr_print_SBinary(ndr, propValue, &PtypBinary);
 		break;
 	default:
-		ndr->print(ndr, "Not supported: %s", propValue);
+		{
+			uint32_t _flags_save_default = ndr_pull->flags;
+
+			ndr->print(ndr, "Not supported: %s", propValue);
+			ndr_set_flags(&ndr_pull->flags, LIBNDR_FLAG_REMAINING);
+			NDR_CHECK(ndr_pull_DATA_BLOB(ndr_pull, NDR_SCALARS, &datablob));
+			ndr_pull->flags = _flags_save_default;
+			ndr_print_DATA_BLOB(ndr, propValue, datablob);
+		}
 	}
 	talloc_free(propValue);
 	return 0;

--- a/ndr_mapi.c
+++ b/ndr_mapi.c
@@ -2807,3 +2807,22 @@ _PUBLIC_ enum ndr_err_code ndr_pull_PersistElementArray(struct ndr_pull *ndr, in
 	}
 	return NDR_ERR_SUCCESS;
 }
+
+_PUBLIC_ void ndr_print_FILETIME(struct ndr_print *ndr, const char *name, const struct FILETIME *r)
+{
+	TALLOC_CTX		*mem_ctx;
+	NTTIME			time;
+	const char		*date;
+
+	mem_ctx = talloc_named(NULL, 0, "FILETIME");
+	if (!mem_ctx) { ndr_print_string(ndr, name, "ERROR"); return; }
+	if (r == NULL) { ndr_print_string(ndr, name, "NULL"); return; }
+
+	time = r->dwHighDateTime;
+	time = time << 32;
+	time |= r->dwLowDateTime;
+	date = nt_time_string(mem_ctx, time);
+	ndr_print_string(ndr, name, date);
+
+	talloc_free(mem_ctx);
+}

--- a/ndr_mapi.c
+++ b/ndr_mapi.c
@@ -75,7 +75,7 @@ static enum ndr_err_code ndr_push_lxpress_chunk(struct ndr_push *ndrpush,
 
 	plain_chunk.data = ndrpull->data + plain_chunk_offset;
 	plain_chunk.length = plain_chunk_size;
-	
+
 	if (plain_chunk_size < max_plain_size) {
 		*last = true;
 	};
@@ -245,7 +245,7 @@ _PUBLIC_ enum ndr_err_code ndr_pull_mapi2k7_request(struct ndr_pull *ndr, int nd
 						NDR_CHECK(ndr_pull_mapi_request(_ndr_buffer, NDR_SCALARS|NDR_BUFFERS, r->mapi_request));
 					} else {
 						NDR_CHECK(ndr_pull_mapi_request(_ndr_buffer, NDR_SCALARS|NDR_BUFFERS, r->mapi_request));
-						
+
 					}
 				}
 				NDR_CHECK(ndr_pull_subcontext_end(ndr, _ndr_buffer, 0, -1));
@@ -267,23 +267,23 @@ _PUBLIC_ enum ndr_err_code ndr_pull_mapi2k7_response(struct ndr_pull *ndr, int n
 			ndr_set_flags(&ndr->flags, LIBNDR_FLAG_NOALIGN|LIBNDR_FLAG_REMAINING);
 			{
 				struct ndr_pull *_ndr_buffer;
-				
+
 				if (ndr->flags & LIBNDR_FLAG_REF_ALLOC) {
 					NDR_PULL_ALLOC(ndr, r->mapi_response);
 				}
-				
+
 				NDR_CHECK((ndr_pull_subcontext_start(ndr, &_ndr_buffer, 0, r->header.Size)));
 				{
 					if (r->header.Flags & RHEF_Compressed) {
 						struct ndr_pull *_ndr_data_compressed = NULL;
-						
+
 						NDR_CHECK(ndr_pull_lzxpress_decompress(_ndr_buffer, &_ndr_data_compressed, r->header.SizeActual));
 						NDR_CHECK(ndr_pull_mapi_response(_ndr_data_compressed, NDR_SCALARS|NDR_BUFFERS, r->mapi_response));
 					} else if (r->header.Flags & RHEF_XorMagic) {
 						obfuscate_data(_ndr_buffer->data, _ndr_buffer->data_size, 0xA5);
 						NDR_CHECK(ndr_pull_mapi_response(_ndr_buffer, NDR_SCALARS|NDR_BUFFERS, r->mapi_response));
 					} else {
-						NDR_CHECK(ndr_pull_mapi_response(_ndr_buffer, NDR_SCALARS|NDR_BUFFERS, r->mapi_response));			
+						NDR_CHECK(ndr_pull_mapi_response(_ndr_buffer, NDR_SCALARS|NDR_BUFFERS, r->mapi_response));
 					}
 				}
 				NDR_CHECK(ndr_pull_subcontext_end(ndr, _ndr_buffer, 0, r->header.Size));
@@ -436,14 +436,14 @@ _PUBLIC_ enum ndr_err_code ndr_pull_mapi2k7_AuxInfo(struct ndr_pull *ndr, int nd
 
 						ndr_set_flags(&ndr->flags, LIBNDR_FLAG_NOALIGN);
 						NDR_CHECK(ndr_pull_lzxpress_decompress(_ndr_buffer, &_ndr_data_compressed, r->RPC_HEADER_EXT.SizeActual));
-						
+
 						for (cntr_AUX_HEADER_0 = 0; _ndr_data_compressed->offset < _ndr_data_compressed->data_size; cntr_AUX_HEADER_0++) {
 							NDR_CHECK(ndr_pull_AUX_HEADER(_ndr_data_compressed, NDR_SCALARS, &r->AUX_HEADER[cntr_AUX_HEADER_0]));
 							r->AUX_HEADER = talloc_realloc(_mem_save_AUX_HEADER_0, r->AUX_HEADER, struct AUX_HEADER, cntr_AUX_HEADER_0 + 2);
 						}
 						r->AUX_HEADER = talloc_realloc(_mem_save_AUX_HEADER_0, r->AUX_HEADER, struct AUX_HEADER, cntr_AUX_HEADER_0 + 2);
 						r->AUX_HEADER[cntr_AUX_HEADER_0].Size = 0;
-						
+
 					/* obfuscation case */
 					} else if (r->RPC_HEADER_EXT.Flags & RHEF_XorMagic) {
 						obfuscate_data(_ndr_buffer->data, _ndr_buffer->data_size, 0xA5);
@@ -534,7 +534,7 @@ void ndr_print_mapi_request(struct ndr_print *ndr, const char *name, const struc
 			if (ret != -1 && idx_0) {
 				ndr_print_EcDoRpc_MAPI_REQ(ndr, "mapi_request", &r->mapi_req[cntr_mapi_req_0]);
 				free(idx_0);
-			} 
+			}
 		}
 		ndr->depth--;
 	}
@@ -571,7 +571,7 @@ void ndr_print_mapi_response(struct ndr_print *ndr, const char *name, const stru
 	}
 
 	ndr->print(ndr, "%-25s: (handles) number=%u", name, rlength / 4);
-	
+
 	if (rlength) {
 		uint32_t i;
 
@@ -586,9 +586,9 @@ void ndr_print_mapi_response(struct ndr_print *ndr, const char *name, const stru
 
 
 /*
-  push mapi_request / mapi_response onto the wire.  
+  push mapi_request / mapi_response onto the wire.
 
-  MAPI length field includes length bytes. 
+  MAPI length field includes length bytes.
   But these bytes do not belong to the mapi content in the user
   context. We have to add them when pushing mapi content length
   (uint16_t) and next subtract when pushing the content blob
@@ -601,7 +601,7 @@ enum ndr_err_code ndr_push_mapi_request(struct ndr_push *ndr, int ndr_flags, con
 
 	ndr_set_flags(&ndr->flags, LIBNDR_FLAG_NOALIGN);
 	NDR_CHECK(ndr_push_uint16(ndr, NDR_SCALARS, r->length));
-	
+
 	for (count = 0; ndr->offset < r->length - 2; count++) {
 		NDR_CHECK(ndr_push_EcDoRpc_MAPI_REQ(ndr, NDR_SCALARS, &r->mapi_req[count]));
 	}
@@ -668,12 +668,12 @@ enum ndr_err_code ndr_pull_mapi_request(struct ndr_pull *ndr, int ndr_flags, str
 		}
 		r->mapi_req = talloc_realloc(_mem_save_mapi_req_0, r->mapi_req, struct EcDoRpc_MAPI_REQ, cntr_mapi_req_0 + 2);
 		r->mapi_req[cntr_mapi_req_0].opnum = 0;
-		
+
 		if (_ndr_mapi_req->offset != r->length - 2) {
 			return NDR_ERR_BUFSIZE;
 		}
 		NDR_CHECK(ndr_pull_subcontext_end(ndr, _ndr_mapi_req, 4, -1));
-	
+
 		_mem_save_handles_0 = NDR_PULL_GET_MEM_CTX(ndr);
 		count = (r->mapi_len - r->length) / sizeof(uint32_t);
 		r->handles = talloc_array(_mem_save_handles_0, uint32_t, count + 1);
@@ -703,7 +703,7 @@ enum ndr_err_code ndr_pull_mapi_response(struct ndr_pull *ndr, int ndr_flags, st
 	r->mapi_len = length;
 
 	NDR_CHECK(ndr_pull_uint16(ndr, NDR_SCALARS, &r->length));
-	
+
 	/* If length equals length field then skipping subcontext */
 	if (r->length > sizeof (uint16_t)) {
 		_mem_save_mapi_repl_0 = NDR_PULL_GET_MEM_CTX(ndr);
@@ -747,7 +747,7 @@ _PUBLIC_ enum ndr_err_code ndr_push_EcDoRpc_MAPI_REPL(struct ndr_push *ndr, int 
 			NDR_CHECK(ndr_push_uint8(ndr, NDR_SCALARS, r->opnum));
 			if ((r->opnum == op_MAPI_Notify) || (r->opnum == op_MAPI_Pending)) {
 				NDR_CHECK(ndr_push_set_switch_value(ndr, &r->u, r->opnum));
-				NDR_CHECK(ndr_push_EcDoRpc_MAPI_REPL_UNION(ndr, NDR_SCALARS, &r->u));				
+				NDR_CHECK(ndr_push_EcDoRpc_MAPI_REPL_UNION(ndr, NDR_SCALARS, &r->u));
 			} else {
 				NDR_CHECK(ndr_push_uint8(ndr, NDR_SCALARS, r->handle_idx));
 				NDR_CHECK(ndr_push_MAPISTATUS(ndr, NDR_SCALARS, r->error_code));
@@ -1119,7 +1119,7 @@ _PUBLIC_ enum ndr_err_code ndr_push_EcDoConnectEx(struct ndr_push *ndr, int flag
 			return ndr_push_error(ndr, NDR_ERR_INVALID_POINTER, "NULL [ref] pointer");
 		}
 		NDR_CHECK(ndr_push_uint32(ndr, NDR_SCALARS, *r->in.pcbAuxOut));
-	}		
+	}
 
 	if (flags & NDR_OUT) {
 		if (r->out.handle == NULL) {
@@ -1311,7 +1311,7 @@ _PUBLIC_ enum ndr_err_code ndr_pull_EcDoConnectEx(struct ndr_pull *ndr, int flag
 		*r->out.pulTimeStamp = *r->in.pulTimeStamp;
 		NDR_PULL_ALLOC(ndr, r->out.pcbAuxOut);
 		*r->out.pcbAuxOut = *r->in.pcbAuxOut;
-	}		
+	}
 
 	if (flags & NDR_OUT) {
 		if (ndr->flags & LIBNDR_FLAG_REF_ALLOC) {
@@ -2445,7 +2445,7 @@ enum ndr_err_code ndr_pull_BufferTooSmall_repl(struct ndr_pull *ndr, int ndr_fla
 
 _PUBLIC_ enum ndr_err_code ndr_push_ExtendedException(struct ndr_push *ndr, int ndr_flags, uint16_t WriterVersion2, const struct ExceptionInfo *ExceptionInfo, const struct ExtendedException *r)
 {
-	bool subjectIsSet, locationIsSet; 
+	bool subjectIsSet, locationIsSet;
 	{
 		uint32_t _flags_save_STRUCT = ndr->flags;
 
@@ -2494,7 +2494,7 @@ _PUBLIC_ enum ndr_err_code ndr_push_ExtendedException(struct ndr_push *ndr, int 
 
 _PUBLIC_ enum ndr_err_code ndr_pull_ExtendedException(struct ndr_pull *ndr, int ndr_flags, uint16_t WriterVersion2, const struct ExceptionInfo *ExceptionInfo, struct ExtendedException *r)
 {
-	bool subjectIsSet, locationIsSet; 
+	bool subjectIsSet, locationIsSet;
 	{
 		uint32_t _flags_save_STRUCT = ndr->flags;
 
@@ -2655,7 +2655,7 @@ _PUBLIC_ enum ndr_err_code ndr_pull_AppointmentRecurrencePattern(struct ndr_pull
 				return NDR_ERR_BUFSIZE;
 			}
 		}
-                
+
 		if (ndr_flags & NDR_BUFFERS) {
 			NDR_CHECK(ndr_pull_RecurrencePattern(ndr, NDR_BUFFERS, &r->RecurrencePattern));
 			_mem_save_ExceptionInfo_0 = NDR_PULL_GET_MEM_CTX(ndr);

--- a/ndr_mapi.c
+++ b/ndr_mapi.c
@@ -2093,7 +2093,7 @@ _PUBLIC_ void ndr_dump_data(struct ndr_print *ndr, const uint8_t *buf, int len)
 {
 	TALLOC_CTX *mem_ctx;
 	char *line = NULL;
-	int i=0, j=0;
+	int i=0, j=0, idx=0;
 
 	if (len<=0) return;
 
@@ -2101,7 +2101,7 @@ _PUBLIC_ void ndr_dump_data(struct ndr_print *ndr, const uint8_t *buf, int len)
 	if (!mem_ctx) return;
 
 	for (i=0;i<len;) {
-
+		idx = i;
 		if (i%16 == 0) {
 			if (i<len)  {
 				line = talloc_asprintf(mem_ctx, "[%04X] ", i);
@@ -2114,14 +2114,14 @@ _PUBLIC_ void ndr_dump_data(struct ndr_print *ndr, const uint8_t *buf, int len)
 			line = talloc_asprintf_append(line, "  ");
 		}
 		if (i%16 == 0) {
-
-			for (j =0; j < 8; j++) {
-				line = talloc_asprintf_append(line, "%c", isprint(buf[j]) ? buf[j] : '.');
+			idx = i - 16;
+			for (j=0; j < 8; j++, idx++) {
+				line = talloc_asprintf_append(line, "%c", isprint(buf[idx]) ? buf[idx] : '.');
 			}
 
 			line = talloc_asprintf_append(line, " ");
-			for (j=8; j < 16; j++) {
-				line = talloc_asprintf_append(line, "%c", isprint(buf[j]) ? buf[j] : '.');
+			for (j=8; j < 16; j++, idx++) {
+				line = talloc_asprintf_append(line, "%c", isprint(buf[idx]) ? buf[idx] : '.');
 			}
 			ndr->print(ndr, "%s", line);
 			talloc_free(line);
@@ -2130,23 +2130,25 @@ _PUBLIC_ void ndr_dump_data(struct ndr_print *ndr, const uint8_t *buf, int len)
 
 	if (i%16) {
 		int n;
+
 		n = 16 - (i%16);
-		line = talloc_asprintf_append(line, " ");
+		idx = i - (i%16);
 		if (n>8) {
-			line = talloc_asprintf_append(line, " ");
+			line = talloc_asprintf_append(line, "  ");
 		}
 		while (n--) {
 			line = talloc_asprintf_append(line, "   ");
 		}
+		line = talloc_asprintf_append(line, "  ");
 		n = MIN(8,i%16);
-		for (j =(i -(i%16)); j < n; j++) {
-			line = talloc_asprintf_append(line, "%c", isprint(buf[j]) ? buf[j] : '.');
+		for (j = 0; j < n; j++, idx++) {
+			line = talloc_asprintf_append(line, "%c", isprint(buf[idx]) ? buf[idx] : '.');
 		}
 		line = talloc_asprintf_append(line, " ");
 		n = (i%16) - n;
 		if (n>0) {
-			for (j = i - n; j < n; j++) {
-				line = talloc_asprintf_append(line, "%c", isprint(buf[j]) ? buf[j] : '.');
+			for (j = i - n; j < i + n; j++, idx++) {
+				line = talloc_asprintf_append(line, "%c", isprint(buf[idx]) ? buf[idx] : '.');
 			}
 		}
 		ndr->print(ndr, "%s", line);

--- a/ndr_mapi.c
+++ b/ndr_mapi.c
@@ -2042,7 +2042,7 @@ _PUBLIC_ void ndr_print_SBinary_short(struct ndr_print *ndr, const char *name, c
 		uint32_t _flags_save_STRUCT = ndr->flags;
 		ndr_set_flags(&ndr->flags, LIBNDR_FLAG_NOALIGN);
 		ndr->depth++;
-		dump_data(0, r->lpb, r->cb);
+		ndr_dump_data(ndr, r->lpb, r->cb);
 		ndr->depth--;
 		ndr->flags = _flags_save_STRUCT;
 	}

--- a/ndr_mapi.c
+++ b/ndr_mapi.c
@@ -1,24 +1,25 @@
-/* 
+/*
    OpenChange implementation.
 
    libndr mapi support
 
    Copyright (C) Julien Kerihuel 2005-2014
-   
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <ctype.h>
 #include "libmapi/libmapi.h"
 #include "libmapi/libmapi_private.h"
 #include <ndr.h>
@@ -2086,6 +2087,84 @@ _PUBLIC_ void ndr_print_XID(struct ndr_print *ndr, const char *name, const struc
 	talloc_free(guid_str);
 	talloc_free(line);
 	ndr->flags = _flags_save_STRUCT;
+}
+
+_PUBLIC_ void ndr_dump_data(struct ndr_print *ndr, const uint8_t *buf, int len)
+{
+	TALLOC_CTX *mem_ctx;
+	char *line = NULL;
+	int i=0, j=0;
+
+	if (len<=0) return;
+
+	mem_ctx = talloc_named(NULL, 0, "ndr_dump_data");
+	if (!mem_ctx) return;
+
+	for (i=0;i<len;) {
+
+		if (i%16 == 0) {
+			if (i<len)  {
+				line = talloc_asprintf(mem_ctx, "[%04X] ", i);
+			}
+		}
+
+		line = talloc_asprintf_append(line, "%02X ", (int)buf[i]);
+		i++;
+		if (i%8 == 0) {
+			line = talloc_asprintf_append(line, "  ");
+		}
+		if (i%16 == 0) {
+
+			for (j =0; j < 8; j++) {
+				line = talloc_asprintf_append(line, "%c", isprint(buf[j]) ? buf[j] : '.');
+			}
+
+			line = talloc_asprintf_append(line, " ");
+			for (j=8; j < 16; j++) {
+				line = talloc_asprintf_append(line, "%c", isprint(buf[j]) ? buf[j] : '.');
+			}
+			ndr->print(ndr, "%s", line);
+			talloc_free(line);
+		}
+	}
+
+	if (i%16) {
+		int n;
+		n = 16 - (i%16);
+		line = talloc_asprintf_append(line, " ");
+		if (n>8) {
+			line = talloc_asprintf_append(line, " ");
+		}
+		while (n--) {
+			line = talloc_asprintf_append(line, "   ");
+		}
+		n = MIN(8,i%16);
+		for (j =(i -(i%16)); j < n; j++) {
+			line = talloc_asprintf_append(line, "%c", isprint(buf[j]) ? buf[j] : '.');
+		}
+		line = talloc_asprintf_append(line, " ");
+		n = (i%16) - n;
+		if (n>0) {
+			for (j = i - n; j < n; j++) {
+				line = talloc_asprintf_append(line, "%c", isprint(buf[j]) ? buf[j] : '.');
+			}
+		}
+		ndr->print(ndr, "%s", line);
+		talloc_free(line);
+	}
+}
+
+_PUBLIC_ void ndr_print_SBinary(struct ndr_print *ndr, const char *name, const struct SBinary *r)
+{
+	ndr->print(ndr, "%-25s: SBinary cb=%u", name, (unsigned)r->cb);
+	{
+		uint32_t _flags_save_STRUCT = ndr->flags;
+		ndr_set_flags(&ndr->flags, LIBNDR_FLAG_NOALIGN);
+		ndr->depth++;
+		ndr_dump_data(ndr, r->lpb, r->cb);
+		ndr->depth--;
+		ndr->flags = _flags_save_STRUCT;
+	}
 }
 
 _PUBLIC_ void ndr_print_fuzzyLevel(struct ndr_print *ndr, const char *name, uint32_t r)

--- a/script/fxdump.py
+++ b/script/fxdump.py
@@ -1,0 +1,138 @@
+#!/usr/bin/python
+#
+# OpenChange debugging script
+#
+# Copyright (C) Julien Kerihuel <j.kerihuel@openchange.org> 2015
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+#
+# Usage example:
+# ./script/fxdump.py - | ndrdump -l libmapi.so exchange_debug FastTransferSourceGetBuffer in
+# [0000] 03 00 12 40 02 01 E1 65   00 00 00 00 02 01 E0 65   ...@...e .......e
+# [0010] 16 00 00 00 53 64 9A AE   39 18 32 4A BB 4E 18 39   ....Sd.. 9.2J.N.9
+# [0020] 52 F0 5C BD 00 00 00 00   03 F6 40 00 08 30 80 33   R.\..... ..@..0.3
+# [0030] 89 D7 C5 AD D0 01 02 01   E2 65 14 00 00 00 A3 3D   ........ .e.....=
+# [0040] 77 9F 1A 38 A4 40 A9 1B   E2 30 04 EE 43 BD 00 00   w..8.@.. .0..C...
+# [0050] 04 1A 02 01 E3 65 2C 00   00 00 16 53 64 9A AE 39   .....e,. ...Sd..9
+# [0060] 18 32 4A BB 4E 18 39 52   F0 5C BD 00 00 00 00 00   .2J.N.9R .\......
+# [0070] 24 14 A3 3D 77 9F 1A 38   A4 40 A9 1B E2 30 04 EE   $..=w..8 .@...0..
+# [0080] 43 BD 00 00 04 1A 1F 00   01 30 0E 00 00 00 4F 00   C....... .0....O.
+# [0090] 75 00 74 00 62 00 6F 00   78 00 00 00 14 00 49 67   u.t.b.o. x.....Ig
+# [00A0] 01 00 00 00 00 00 03 F4   03 00 39 66 FB 03 00 00   ........ ..9f....
+# [00B0] 02 01 DA 36 06 00 00 00   01 04 00 00 10 00 40 00   ...6.... ......@.
+# [00C0] 07 30 00 37 90 FE BE AD   D0 01 0B 00 F4 10 00 00   .0.7.... ........
+# [00D0] 0B 00 F6 10 00 00 1F 00   13 36 12 00 00 00 49 00   ........ .6....I.
+# [00E0] 50 00 46 00 2E 00 4E 00   6F 00 74 00 65 00 00 00   P.F...N. o.t.e...
+# [00F0] 03 00 17 36 00 00 00 00   0B 00 0A 36 00 00 03 00   ...6.... ...6....
+# [0100] 12 40 02 01 E1 65 00 00   00 00 02 01 E0 65 16 00   .@...e.. .....e..
+# [0110] 00 00 53 64 9A AE 39 18   32 4A BB 4E 18 39 52 F0   ..Sd..9. 2J.N.9R.
+# [0120] 5C BD 00 00 00 00 03 F7   40 00 08 30 00 CA 21 D8   \....... @..0..!.
+# [0130] C5 AD D0 01 02 01 E2 65   14 00 00 00 A3 3D 77 9F   .......e .....=w.
+# [0140] 1A 38 A4 40 A9 1B E2 30   04 EE 43 BD 00 00 04 1B   .8.@...0 ..C.....
+# [0150] 02 01 E3 65 2C 00 00 00   16 53 64 9A AE 39 18 32   ...e,... .Sd..9.2
+# [0160] 4A BB 4E 18 39 52 F0 5C   BD 00 00 00 00 00 26 14   J.N.9R.\ ......&.
+# [0170] A3 3D 77 9F 1A 38 A4 40   A9 1B E2 30 04 EE 43 BD   .=w..8.@ ...0..C.
+# [0180] 00 00 04 1B 1F 00 01 30   0A 00 00 00 53 00 65 00   .......0 ....S.e.
+# [0190] 6E 00 74 00 00 00 14 00   49 67 01 00 00 00 00 00   n.t..... Ig......
+# [01A0] 03 F4 03 00 39 66 FB 03   00 00 02 01 DA 36 06 00   ....9f.. .....6..
+# [01B0] 00 00 01 04 00 00 10 00   40 00 07 30 00 37 90 FE   ........ @..0.7..
+# [01C0] BE AD D0 01 0B 00 F4 10   00 00 0B 00 F6 10 00 00   ........ ........
+# [01D0] 1F 00 13 36 12 00 00 00   49 00 50 00 46 00 2E 00   ...6.... I.P.F...
+# [01E0] 4E 00 6F 00 74 00 65 00   00 00 03 00 17 36 00 00   N.o.t.e. .....6..
+# [01F0] 00 00 0B 00 0A 36 00 00   03 00 3A 40 02 01 96 67   .....6.. ..:@...g
+# [0200] 1C 00 00 00 53 64 9A AE   39 18 32 4A BB 4E 18 39   ....Sd.. 9.2J.N.9
+# [0210] 52 F0 5C BD 04 00 00 00   00 52 00 24 01 31 50 00   R.\..... .R.$.1P.
+# [0220] 03 00 17 40 39 00 00 00   53 64 9A AE 39 18 32 4A   ...@9... Sd..9.2J
+# [0230] BB 4E 18 39 52 F0 5C BD   05 00 00 00 00 03 52 F5   .N.9R.\. ......R.
+# [0240] FF 50 05 00 00 00 00 04   52 01 12 50 05 00 00 00   .P...... R..P....
+# [0250] 00 04 52 22 93 50 05 00   00 00 01 04 52 02 05 50   ..R".P.. ....R..P
+# [0260] 00 03 00 3B 40 03 00 14   40                       ...;@... @
+# ^D ^D
+# Marker          : IncrSyncChg (0x40120003)
+#     PidTagParentSourceKey: SBinary cb=0
+#     PidTagSourceKey: SBinary cb=22
+#         [0000] 53 64 9A AE 39 18 32 4A   BB 4E 18 39 52 F0 5C BD   Sd..9.2J .N.9R.\.
+#         [0010] 00 00 00 00 03 F6
+#     PidTagLastModificationTime: 'mar jun 23 17:04:03 2015 CEST'
+#     PidTagChangeKey: SBinary cb=20
+#         [0000] A3 3D 77 9F 1A 38 A4 40   A9 1B E2 30 04 EE 43 BD   .=w..8.@ ...0..C.
+#         [0010] 00 00 04 1A
+#     PidTagPredecessorChangeList: SBinary cb=44
+#         [0000] 16 53 64 9A AE 39 18 32   4A BB 4E 18 39 52 F0 5C   .Sd..9.2 J.N.9R.\
+#         [0010] BD 00 00 00 00 00 24 14   A3 3D 77 9F 1A 38 A4 40   .Sd..9.2 J.N.9R.\
+#         [0020] A9 1B E2 30 04 EE 43 BD   00 00 04 1A
+#     PidTagDisplayName: 'Outbox'
+#     PidTagParentFolderId: 0xf403000000000001 (-863846703525003263)
+#     PidTagRights: 0x000003fb (1019)
+#     PidTagExtendedFolderFlags: SBinary cb=6
+#         [0000] 01 04 00 00 10 00  ......
+#     PidTagCreationTime: 'mar jun 23 16:15:02 2015 CEST'
+#     PidTagAttributeHidden: 'False'
+#     PidTagAttributeReadOnly: 'False'
+#     PidTagContainerClass: 'IPF.Note'
+#     0x36170003               : 0x00000000 (0)
+#     PidTagSubfolders: 'False'
+# Marker          : IncrSyncChg (0x40120003)
+#     PidTagParentSourceKey: SBinary cb=0
+#     PidTagSourceKey: SBinary cb=22
+#         [0000] 53 64 9A AE 39 18 32 4A   BB 4E 18 39 52 F0 5C BD   Sd..9.2J .N.9R.\.
+#         [0010] 00 00 00 00 03 F7
+#     PidTagLastModificationTime: 'mar jun 23 17:04:04 2015 CEST'
+#     PidTagChangeKey: SBinary cb=20
+#         [0000] A3 3D 77 9F 1A 38 A4 40   A9 1B E2 30 04 EE 43 BD   .=w..8.@ ...0..C.
+#         [0010] 00 00 04 1B
+#     PidTagPredecessorChangeList: SBinary cb=44
+#         [0000] 16 53 64 9A AE 39 18 32   4A BB 4E 18 39 52 F0 5C   .Sd..9.2 J.N.9R.\
+#         [0010] BD 00 00 00 00 00 26 14   A3 3D 77 9F 1A 38 A4 40   .Sd..9.2 J.N.9R.\
+#         [0020] A9 1B E2 30 04 EE 43 BD   00 00 04 1B
+#     PidTagDisplayName: 'Sent'
+#     PidTagParentFolderId: 0xf403000000000001 (-863846703525003263)
+#     PidTagRights: 0x000003fb (1019)
+#     PidTagExtendedFolderFlags: SBinary cb=6
+#         [0000] 01 04 00 00 10 00  ......
+#     PidTagCreationTime: 'mar jun 23 16:15:02 2015 CEST'
+#     PidTagAttributeHidden: 'False'
+#     PidTagAttributeReadOnly: 'False'
+#     PidTagContainerClass: 'IPF.Note'
+#     0x36170003               : 0x00000000 (0)
+#     PidTagSubfolders: 'False'
+# Marker          : IncrSyncStateBegin (0x403A0003)
+#     0x67960102               : SBinary cb=28
+#         [0000] 53 64 9A AE 39 18 32 4A   BB 4E 18 39 52 F0 5C BD   Sd..9.2J .N.9R.\.
+#         [0010] 04 00 00 00 00 52 00 24   01 31 50 00
+#     MetaTagIdsetGiven:
+##             [0xf50300000000:0xff0300000000]
+#             [0x010400000000:0x120400000000]
+#             [0x220400000000:0x930400000000]
+#             [0x020401000000:0x050401000000]
+# Marker          : IncrSyncStateEnd (0x403B0003)
+#                            Marker          : IncrSyncEnd (0x40140003)
+#
+#
+
+import fileinput
+import sys
+import re
+from binascii import unhexlify
+
+binary = ''
+for line in fileinput.input():
+    if len(line) == 1 and line[0] == '\n':
+        break
+    m = re.findall(r'[0-9A-Z]{2}\s+', line)
+    hexdata =''.join(m[:16]).replace(' ', '').strip('\n')
+    binary += unhexlify(hexdata)
+print binary


### PR DESCRIPTION
- structured output for FX markers
- structured output for FX MetaTag
- colorized (ANSI color) output for FastTransferSourceGetBuffer
- print FILETIME into human readable dates
- print boolean values as 'True' and 'False' string
- ndr oriented function for dump_data which now dumps binary blob at ndr->depth
- decidated function to supply custom decoding for important properties (PidTagChangeKey, PidTagSourceKey, PidTagPredecessorChangeList)
- add exchange_debug interface and FastTransferSourceGetBuffer meta function to easily feed ndrdump with DATA_BLOB as an input
- add a convenient script (./script/fxdump.py) to turn hexadecimal output into binary blob to feed ndrdump using the exchange_debug interface