### PR TITLE
Workaround: Revert of release sessions

### DIFF
--- a/mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.c
+++ b/mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.c
@@ -1153,7 +1153,6 @@ static NTSTATUS dcerpc_server_asyncemsmdb_unbind(struct dcesrv_connection_contex
 	}
 
 	DLIST_REMOVE(asyncemsmdb_session, session);
-	talloc_free(session);
 
 	/* flush pending call on connection */
 	context->conn->pending_call_list = NULL;

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
@@ -264,7 +264,6 @@ static enum MAPISTATUS dcesrv_EcDoDisconnect(struct dcesrv_call_state *dce_call,
 			ret = mpm_session_release(session->session);
 			if (ret == true) {
 				DLIST_REMOVE(emsmdb_session, session);
-				talloc_free(session);
 				OC_DEBUG(5, "Session found and released\n");
 			} else {
 				OC_DEBUG(5, "Session found and ref_count decreased\n");


### PR DESCRIPTION
Partial revert of https://github.com/openchange/openchange/pull/347 (what fixes the crash there was the removal of `mapistore_release` call).

There is some issue with session handling that creates crashes if we release the session.

ps: I will look into this soon.