### PR TITLE
oxcfxics: Fix deletion of IDs within an idset

### DIFF
--- a/libmapi/idset.c
+++ b/libmapi/idset.c
@@ -961,7 +961,7 @@ static void IDSET_ranges_remove_globcnt(struct idset *idset, uint64_t eid) {
 			done = true;
 		}
 		else if (range->high == eid) {
-			range->high = exchange_globcnt(work_eid + 1);
+			range->high = exchange_globcnt(work_eid - 1);
 			done = true;
 		}
 		else if ((exchange_globcnt(range->low) < work_eid) && (exchange_globcnt(range->high) > work_eid)) {


### PR DESCRIPTION
When the last element in a range was being deleted, the higher element in the range was being increased instead of decreased, which produced a wrong final idset.