### PR TITLE
oxcfxics: fix minimum length on parsing IDSETs

### DIFF
--- a/libmapi/idset.c
+++ b/libmapi/idset.c
@@ -245,6 +245,15 @@ _PUBLIC_ struct globset_range *GLOBSET_parse(TALLOC_CTX *mem_ctx, DATA_BLOB buff
 	bool end = false;
 	uint8_t command;
 
+	/* Sanity checks */
+	if (buffer.length == 0) {
+		if (byte_countP) {
+			*byte_countP = 0;
+		}
+		return NULL;
+	}
+
+
 	parser = talloc_zero(NULL, struct GLOBSET_parser);
 	parser->buffer = buffer;
 

--- a/libmapi/idset.c
+++ b/libmapi/idset.c
@@ -359,13 +359,13 @@ static void check_idset(const struct idset *idset)
 */
 _PUBLIC_ struct idset *IDSET_parse(TALLOC_CTX *mem_ctx, DATA_BLOB buffer, bool idbased)
 {
-	struct idset		*idset, *prev_idset = NULL;
+	struct idset		*idset = NULL, *prev_idset = NULL;
 	DATA_BLOB		guid_blob, globset;
 	uint32_t		total_bytes, byte_count, id_length;
 
-	if (buffer.length < 17) return NULL;
-
 	id_length = (idbased == true) ? 2 : 16;
+
+	if (buffer.length < id_length) return NULL;
 
 	total_bytes = 0;
 	while (total_bytes < buffer.length) {

--- a/testsuite/libmapi/mapi_idset.c
+++ b/testsuite/libmapi/mapi_idset.c
@@ -37,15 +37,19 @@ START_TEST (test_IDSET_parse) {
 	const uint8_t		case_0[] =
 		{0x1, 0x0, 0x6, 0x0, 0x0, 0x0, 0x1, 0x4, 0x2e, 0x05, 0x0, 0x0, 0x0, 0x1,
 		 0x4, 0x52, 0x35, 0x37, 0x50, 0x0};
+        /* A REPLID-based IDSET whose length is smaller than REPLGUID-based IDSET minimum length */
+	const uint8_t		case_1[] =
+		{0x1, 0x0, 0x5, 0x0, 0x0, 0x0, 0x1, 0x4, 0x52, 0x19, 0x1A, 0x50, 0x0};
 	/* REPLGUID-based IDSET case (MetaTagCnsetSeen) */
-	const uint8_t		 case_1[] =
+	const uint8_t		 case_2[] =
 		{0x9b, 0xb9, 0xff, 0xb5, 0xf, 0x44, 0x77, 0x4f, 0xb4, 0x88, 0xc5, 0xc6, 0x70,
 		 0x2e, 0xe3, 0xa8, 0x4, 0x0, 0x0, 0x0, 0x0, 0x52, 0x0, 0xa5, 0x1, 0x51, 0x50, 0x0};
-	const uint8_t		 *cases[] = {case_0, case_1};
+	const uint8_t		 *cases[] = {case_0, case_1, case_2};
 	const size_t		 cases_size[] = { sizeof(case_0)/sizeof(uint8_t),
-						  sizeof(case_1)/sizeof(uint8_t) };
-	const bool		 id_based[] = {true, false};
-	const uint32_t		 range_count[] = {2, 1};
+						  sizeof(case_1)/sizeof(uint8_t),
+						  sizeof(case_2)/sizeof(uint8_t) };
+	const bool		 id_based[] = {true, true, false};
+	const uint32_t		 range_count[] = {2, 1, 1};
 	const size_t		 CASES_NUM = sizeof(cases)/sizeof(uint8_t*);
 
 	for (i = 0; i < CASES_NUM; i++) {


### PR DESCRIPTION
Now the REPLID-based parsing works with instances whose length is lower than 16B.

I've picked the sanity check on GLOBSET parser to have a IDSET without GLOBSET as valid parsed. It is required to have safer code while lowering the minimum length ceil.