### PR TITLE
oxcfxics: pass predecessor change list to backend on MessageMove ROP

### DIFF
--- a/exchange.idl
+++ b/exchange.idl
@@ -2172,11 +2172,15 @@ System Attendant Private Interface
 		[switch_is(1)] GLOBCNT	GLOBCNT;
 	} ShortTermID; /* MID, FID, CN */
 
-	typedef [public,flag(NDR_NOALIGN)] struct {
-		GUID			GUID;
-		uint8			Size;
-		uint8			Data[Size];
+	typedef [public,noprint,flag(NDR_NOALIGN)] struct {
+		GUID			NameSpaceGuid;
+		[flag(NDR_REMAINING)] DATA_BLOB LocalId;
 	} XID;
+
+	typedef [public,flag(NDR_NOALIGN)] struct {
+		uint8     XidSize;
+		[subcontext(0),subcontext_size(XidSize)] XID XID;
+	} SizedXid;
 
 	typedef [enum16bit] enum {
 		TABLE_CHANGED		=	0x1,

--- a/libmapi/libmapi.h
+++ b/libmapi/libmapi.h
@@ -290,6 +290,7 @@ struct AddressBookEntryId *get_AddressBookEntryId(TALLOC_CTX *, struct Binary_r 
 struct OneOffEntryId	*get_OneOffEntryId(TALLOC_CTX *, struct Binary_r *);
 struct PersistData      *get_PersistData(TALLOC_CTX *, struct Binary_r *);
 struct PersistDataArray *get_PersistDataArray(TALLOC_CTX *, struct Binary_r *);
+struct SizedXid         *get_SizedXidArray(TALLOC_CTX *, struct Binary_r *, uint32_t *);
 const char		*get_TypedString(struct TypedString *);
 bool			set_mapi_SPropValue(TALLOC_CTX *, struct mapi_SPropValue *, const void *);
 bool			set_mapi_SPropValue_proptag(TALLOC_CTX *, struct mapi_SPropValue *, uint32_t, const void *);

--- a/mapiproxy/libmapistore/mapistore.h
+++ b/mapiproxy/libmapistore/mapistore.h
@@ -193,7 +193,7 @@ struct mapistore_backend {
 		enum mapistore_error	(*open_message)(void *, TALLOC_CTX *, uint64_t, bool, void **);
 		enum mapistore_error	(*create_message)(void *, TALLOC_CTX *, uint64_t, uint8_t, void **);
 		enum mapistore_error	(*delete_message)(void *, uint64_t, uint8_t);
-		enum mapistore_error	(*move_copy_messages)(void *, void *, TALLOC_CTX *, uint32_t, uint64_t *, uint64_t *, struct Binary_r **, uint8_t);
+		enum mapistore_error	(*move_copy_messages)(void *, void *, TALLOC_CTX *, uint32_t, uint64_t *, uint64_t *, struct Binary_r **, struct Binary_r **, uint8_t);
  		enum mapistore_error	(*move_folder)(void *, void *, TALLOC_CTX *, const char *);
  		enum mapistore_error	(*copy_folder)(void *, void *, TALLOC_CTX *, bool, const char *);
 		enum mapistore_error	(*get_deleted_fmids)(void *, TALLOC_CTX *, enum mapistore_table_type, uint64_t, struct UI8Array_r **, uint64_t *);
@@ -332,7 +332,7 @@ enum mapistore_error mapistore_folder_delete(struct mapistore_context *, uint32_
 enum mapistore_error mapistore_folder_open_message(struct mapistore_context *, uint32_t, void *, TALLOC_CTX *, uint64_t, bool, void **);
 enum mapistore_error mapistore_folder_create_message(struct mapistore_context *, uint32_t, void *, TALLOC_CTX *, uint64_t, uint8_t, void **);
 enum mapistore_error mapistore_folder_delete_message(struct mapistore_context *, uint32_t, void *, uint64_t, uint8_t);
-enum mapistore_error mapistore_folder_move_copy_messages(struct mapistore_context *, uint32_t, void *, void *, TALLOC_CTX *, uint32_t, uint64_t *, uint64_t *, struct Binary_r **, uint8_t);
+enum mapistore_error mapistore_folder_move_copy_messages(struct mapistore_context *, uint32_t, void *, void *, TALLOC_CTX *, uint32_t, uint64_t *, uint64_t *, struct Binary_r **, struct Binary_r **, uint8_t);
 enum mapistore_error mapistore_folder_move_folder(struct mapistore_context *, uint32_t, void *, void *, TALLOC_CTX *, const char *);
 enum mapistore_error mapistore_folder_copy_folder(struct mapistore_context *, uint32_t, void *, void *, TALLOC_CTX *, bool, const char *);
 enum mapistore_error mapistore_folder_get_deleted_fmids(struct mapistore_context *, uint32_t, void *, TALLOC_CTX *, enum mapistore_table_type, uint64_t, struct UI8Array_r **, uint64_t *);

--- a/mapiproxy/libmapistore/mapistore_backend.c
+++ b/mapiproxy/libmapistore/mapistore_backend.c
@@ -573,9 +573,9 @@ enum mapistore_error mapistore_backend_folder_delete_message(struct backend_cont
         return bctx->backend->folder.delete_message(folder, mid, flags);
 }
 
-enum mapistore_error mapistore_backend_folder_move_copy_messages(struct backend_context *bctx, void *target_folder, void *source_folder, TALLOC_CTX *mem_ctx, uint32_t mid_count, uint64_t *source_mids, uint64_t *target_mids, struct Binary_r **target_change_keys, uint8_t want_copy)
+enum mapistore_error mapistore_backend_folder_move_copy_messages(struct backend_context *bctx, void *target_folder, void *source_folder, TALLOC_CTX *mem_ctx, uint32_t mid_count, uint64_t *source_mids, uint64_t *target_mids, struct Binary_r **target_change_keys, struct Binary_r **target_predecessor_change_lists, uint8_t want_copy)
 {
-	return bctx->backend->folder.move_copy_messages(target_folder, source_folder, mem_ctx, mid_count, source_mids, target_mids, target_change_keys, want_copy);
+	return bctx->backend->folder.move_copy_messages(target_folder, source_folder, mem_ctx, mid_count, source_mids, target_mids, target_change_keys, target_predecessor_change_lists, want_copy);
 }
 
 enum mapistore_error mapistore_backend_folder_move_folder(struct backend_context *bctx, void *move_folder, void *target_folder, TALLOC_CTX *mem_ctx, const char *new_folder_name)

--- a/mapiproxy/libmapistore/mapistore_backend_defaults.c
+++ b/mapiproxy/libmapistore/mapistore_backend_defaults.c
@@ -140,6 +140,7 @@ static enum mapistore_error mapistore_op_defaults_move_copy_messages(void *targe
 								     uint64_t *source_mids,
 								     uint64_t *target_mids,
 								     struct Binary_r **target_change_keys,
+								     struct Binary_r **target_predecessor_change_lists,
 								     uint8_t want_copy)
 {
 	OC_DEBUG(3, "MAPISTORE defaults - MAPISTORE_ERR_NOT_IMPLEMENTED");

--- a/mapiproxy/libmapistore/mapistore_interface.c
+++ b/mapiproxy/libmapistore/mapistore_interface.c
@@ -760,7 +760,11 @@ _PUBLIC_ enum mapistore_error mapistore_folder_delete_message(struct mapistore_c
 
  */
 _PUBLIC_ enum mapistore_error mapistore_folder_move_copy_messages(struct mapistore_context *mstore_ctx, uint32_t context_id,
-								  void *target_folder, void *source_folder, TALLOC_CTX *mem_ctx, uint32_t mid_count, uint64_t *source_mids, uint64_t *target_mids, struct Binary_r **target_change_keys, uint8_t want_copy)
+								  void *target_folder, void *source_folder, TALLOC_CTX *mem_ctx,
+								  uint32_t mid_count, uint64_t *source_mids, uint64_t *target_mids,
+								  struct Binary_r **target_change_keys,
+								  struct Binary_r **target_predecessor_change_lists,
+								  uint8_t want_copy)
 {
 	struct backend_context	*backend_ctx;
 
@@ -772,7 +776,9 @@ _PUBLIC_ enum mapistore_error mapistore_folder_move_copy_messages(struct mapisto
 	MAPISTORE_RETVAL_IF(!backend_ctx, MAPISTORE_ERR_INVALID_PARAMETER, NULL);
 
 	/* Step 2. Call backend operation */
-	return mapistore_backend_folder_move_copy_messages(backend_ctx, target_folder, source_folder, mem_ctx, mid_count, source_mids, target_mids, target_change_keys, want_copy);
+	return mapistore_backend_folder_move_copy_messages(backend_ctx, target_folder, source_folder, mem_ctx, mid_count,
+							   source_mids, target_mids, target_change_keys,
+							   target_predecessor_change_lists, want_copy);
 }
 
 /**

--- a/mapiproxy/libmapistore/mapistore_private.h
+++ b/mapiproxy/libmapistore/mapistore_private.h
@@ -148,7 +148,7 @@ enum mapistore_error mapistore_backend_folder_delete(struct backend_context *, v
 enum mapistore_error mapistore_backend_folder_open_message(struct backend_context *, void *, TALLOC_CTX *, uint64_t, bool, void **);
 enum mapistore_error mapistore_backend_folder_create_message(struct backend_context *, void *, TALLOC_CTX *, uint64_t, uint8_t, void **);
 enum mapistore_error mapistore_backend_folder_delete_message(struct backend_context *, void *, uint64_t, uint8_t);
-enum mapistore_error mapistore_backend_folder_move_copy_messages(struct backend_context *, void *, void *, TALLOC_CTX *, uint32_t, uint64_t *, uint64_t *, struct Binary_r **, uint8_t);
+enum mapistore_error mapistore_backend_folder_move_copy_messages(struct backend_context *, void *, void *, TALLOC_CTX *, uint32_t, uint64_t *, uint64_t *, struct Binary_r **, struct Binary_r **, uint8_t);
 enum mapistore_error mapistore_backend_folder_move_folder(struct backend_context *, void *, void *, TALLOC_CTX *, const char *);
 enum mapistore_error mapistore_backend_folder_copy_folder(struct backend_context *, void *, void *, TALLOC_CTX *, bool, const char *);
 enum mapistore_error mapistore_backend_folder_get_deleted_fmids(struct backend_context *, void *, TALLOC_CTX *, enum mapistore_table_type, uint64_t, struct UI8Array_r **, uint64_t *);

--- a/mapiproxy/servers/default/emsmdb/oxcfold.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfold.c
@@ -1009,7 +1009,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopMoveCopyMessages(TALLOC_CTX *mem_ctx,
 		}
 
 		/* We invoke the backend method */
-		mapistore_folder_move_copy_messages(emsmdbp_ctx->mstore_ctx, contextID, destination_object->backend_object, source_object->backend_object, mem_ctx, mapi_req->u.mapi_MoveCopyMessages.count, mapi_req->u.mapi_MoveCopyMessages.message_id, targetMIDs, NULL, mapi_req->u.mapi_MoveCopyMessages.WantCopy);
+		mapistore_folder_move_copy_messages(emsmdbp_ctx->mstore_ctx, contextID, destination_object->backend_object, source_object->backend_object, mem_ctx, mapi_req->u.mapi_MoveCopyMessages.count, mapi_req->u.mapi_MoveCopyMessages.message_id, targetMIDs, NULL, NULL, mapi_req->u.mapi_MoveCopyMessages.WantCopy);
 		talloc_free(targetMIDs);
 
 		/* /\* The backend might do this for us. In any case, we try to add it ourselves *\/ */

--- a/ndr_mapi.c
+++ b/ndr_mapi.c
@@ -2060,6 +2060,34 @@ _PUBLIC_ void ndr_print_Binary_r(struct ndr_print *ndr, const char *name, const 
 	}
 }
 
+_PUBLIC_ void ndr_print_XID(struct ndr_print *ndr, const char *name, const struct XID *r)
+{
+	uint32_t	_flags_save_STRUCT = ndr->flags;
+	char		*guid_str;
+	char		*line;
+	int		i;
+
+	if (r == NULL) {
+		ndr->print(ndr, "%s: NULL", name);
+		return;
+	}
+
+	ndr_set_flags(&ndr->flags, LIBNDR_FLAG_NOALIGN);
+	guid_str = GUID_string(NULL, &r->NameSpaceGuid);
+	line = talloc_asprintf(NULL, " ");
+	for (i = 0; i < r->LocalId.length; i++) {
+		line = talloc_asprintf_append(line, "%02X ", r->LocalId.data[i]);
+	}
+	if (name) {
+		ndr->print(ndr, "%s: {%s}:%s", name, guid_str, line);
+	} else {
+		ndr->print(ndr, "{%s}:%s", guid_str, line);
+	}
+	talloc_free(guid_str);
+	talloc_free(line);
+	ndr->flags = _flags_save_STRUCT;
+}
+
 _PUBLIC_ void ndr_print_fuzzyLevel(struct ndr_print *ndr, const char *name, uint32_t r)
 {
 	ndr_print_uint32(ndr, name, r);


### PR DESCRIPTION
* Cherry-pick the proper XID structure from @jkerihuel branch to decode FXBuffer.
* Implement helper function `get_SizedXidArray` to parse `PidTagPredecessorChangeList` property value in backend code

This is send back to backend code to manage the Predecessor Change List property value sent by the client to update accordingly and manage conflicts, if required.

This should be managed by OpenChange, but by now, it is leveraged to backends.