### PR TITLE
asyncemsmdb: Do not crash on stop

### DIFF
--- a/mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.c
+++ b/mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.c
@@ -1226,7 +1226,7 @@ NTSTATUS samba_init_module(void)
 	NT_STATUS_NOT_OK_RETURN(status);
 
 	/* Initialize exchange_async_emsmdb session */
-	asyncemsmdb_session = talloc_zero(talloc_autofree_context(), struct exchange_asyncemsmdb_session);
+	asyncemsmdb_session = talloc_zero(NULL, struct exchange_asyncemsmdb_session);
 	if (!asyncemsmdb_session) return NT_STATUS_NO_MEMORY;
 	asyncemsmdb_session->data = NULL;
 


### PR DESCRIPTION
Stopping the server frees first the `asyncemsmdb_session` that calling
the `dcerpc_server_asyncemsmdb_unbind` to disconnect the current
dcerpc sessions. It *may* be because the `talloc_autofree_context` is called
before freeing the connections.

See this log:

```
mapiproxy/libmapistore/mapistore_interface.c:148(mapistore_release): freeing up mstore_ctx ref: 0x7f74cdc0b310
mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.c:105(asyncemsmdb_mapistore_destructor): MAPIStore context released
mapiproxy/libmapistore/backends/namedprops_mysql.c:269(mapistore_namedprops_mysql_destructor): Destroying namedprops mysql context
mapiproxy/libmapistore/mapistore_interface.c:148(mapistore_release): freeing up mstore_ctx ref: 0x7f74cdbeb260
mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.c:105(asyncemsmdb_mapistore_destructor): MAPIStore context released
mapiproxy/libmapistore/backends/namedprops_mysql.c:269(mapistore_namedprops_mysql_destructor): Destroying namedprops mysql context
mapiproxy/dcesrv_mapiproxy.c:280(mapiproxy_op_unbind): mapiproxy::mapiproxy_op_unbind
mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c:1637(dcesrv_exchange_nsp_unbind): dcesrv_exchange_nsp_unbind: server_id=0, context_id=0x626e7500
mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c:1735(dcesrv_exchange_emsmdb_unbind): dcesrv_exchange_emsmdb_unbind: server_id=0, context_id=
0x37653632
mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.c:1147(dcerpc_server_asyncemsmdb_unbind): dcerpc_server_asyncemsmdb_unbind
mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.c:1153(dcerpc_server_asyncemsmdb_unbind): [asyncemsmdb] unbind tcp://192.168.56.13:6038
===============================================================
INTERNAL ERROR: Signal 11 in pid 13062 (4.1.17-Zentyal)
Please read the Trouble-Shooting section of the Samba HOWTO
===============================================================
```

With this fix, the session are never freed as reported by leak report but, at least, it does not
crash.

The fix is from @blaxter (blaxter at gmail)