### PR TITLE
indexing: Do not setup deleted fmid in memcached

### DIFF
--- a/mapiproxy/libmapistore/backends/indexing_mysql.c
+++ b/mapiproxy/libmapistore/backends/indexing_mysql.c
@@ -123,7 +123,8 @@ static memcached_st *_memcached_setup(struct indexing_context *ictx,
 	if (!mem_ctx) return NULL;
 
 	sql = talloc_asprintf(mem_ctx, "SELECT fmid,url FROM "INDEXING_TABLE" "
-			      "WHERE username = '%s'", _sql(mem_ctx, username));
+			      "WHERE username = '%s' AND soft_deleted = '%d'",
+			      _sql(mem_ctx, username), 0);
 
 	mret = select_without_fetch(MYSQL(ictx), sql, &res);
 	if (mret != MYSQL_SUCCESS) {


### PR DESCRIPTION
According to `mysql_record_get_fmid`, if a uri is indexed in
memcached, then the fmid is not deleted. But the `_memcached_setup`
method is populating the key/value store with deleted entries.

This fix makes sure only no soft deleted entries are in memcached
key/value store.