### PR TITLE
Several fixes on openchangeclient to send mails to OpenChange

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 * Send event invitation mails to several attendees, mixing internal and external recipients
 * Fix folder hierarchy synchronization issues on mailbox subfolders
 * Old mails are now synchronized after account cleanup
+* File name and correct size in small sized attachments, and submit time are now sent
+  by OpenChange client against OpenChange server
 
 ### Performances
 * Optimize the download of contents when you were in the middle of the first synchronization process in a business size mailbox.

--- a/utils/openchangeclient.c
+++ b/utils/openchangeclient.c
@@ -746,7 +746,7 @@ static bool openchangeclient_stream(TALLOC_CTX *mem_ctx, mapi_object_t obj_paren
 }
 
 
-#define SETPROPS_COUNT	4
+#define SETPROPS_COUNT	5
 
 /**
  * Send a mail
@@ -766,6 +766,7 @@ static enum MAPISTATUS openchangeclient_sendmail(TALLOC_CTX *mem_ctx,
 	mapi_object_t			obj_outbox;
 	mapi_object_t			obj_message;
 	mapi_object_t			obj_stream;
+	struct timeval                  now;
 	uint32_t			index = 0;
 	uint32_t			msgflag;
 	struct SPropValue		props[SETPROPS_COUNT];
@@ -893,6 +894,13 @@ static enum MAPISTATUS openchangeclient_sendmail(TALLOC_CTX *mem_ctx,
 			mapi_object_init(&obj_stream);
 			openchangeclient_stream(mem_ctx, obj_message, obj_stream, PR_HTML, 2, oclient->pr_html);
 		}
+	}
+
+	/* Send the submit time */
+	if (gettimeofday(&now, NULL) == 0) {
+		set_SPropValue_proptag_date_timeval(&props[prop_count - 1],
+						    PR_CLIENT_SUBMIT_TIME, &now);
+		prop_count++;
 	}
 
 	retval = SetProps(&obj_message, 0, props, prop_count);

--- a/utils/openchangeclient.c
+++ b/utils/openchangeclient.c
@@ -715,6 +715,9 @@ static bool openchangeclient_stream(TALLOC_CTX *mem_ctx, mapi_object_t obj_paren
 	/* WriteStream operation */
 	printf("We are about to write %u bytes in the stream\n", bin.cb);
 	size = MAX_READ_SIZE;
+	if (size > bin.cb) {
+		size = bin.cb;
+	}
 	offset = 0;
 	while (offset <= bin.cb) {
 		stream.length = size;

--- a/utils/openchangeclient.c
+++ b/utils/openchangeclient.c
@@ -925,9 +925,9 @@ static enum MAPISTATUS openchangeclient_sendmail(TALLOC_CTX *mem_ctx,
 			props_attach[0].value.l = ATTACH_BY_VALUE;
 			props_attach[1].ulPropTag = PR_RENDERING_POSITION;
 			props_attach[1].value.l = 0;
-			props_attach[2].ulPropTag = PR_ATTACH_FILENAME;
+			props_attach[2].ulPropTag = PR_ATTACH_FILENAME_UNICODE;
 			printf("Sending %s:\n", oclient->attach[i].filename);
-			props_attach[2].value.lpszA = get_filename(oclient->attach[i].filename);
+			props_attach[2].value.lpszW = get_filename(oclient->attach[i].filename);
 			props_attach[3].ulPropTag = PR_ATTACH_CONTENT_ID;
 			props_attach[3].value.lpszA = get_filename(oclient->attach[i].filename);
 			count_props_attach = 4;


### PR DESCRIPTION
* Send `PidTagClientSubmitTime` while sending mail
* Send filename as unicode
* Send only available bytes while sending an attachment whose length is < 1024B