### PR TITLE
Clean up trailing comma in binding options

### DIFF
--- a/libmapi/IMSProvider.c
+++ b/libmapi/IMSProvider.c
@@ -111,7 +111,12 @@ static char *build_binding_string(struct mapi_context *mapi_ctx,
 	if (profile->localaddr) {
 		binding = talloc_asprintf_append(binding, "localaddress=%s,", profile->localaddr);
 	}
-	
+	/* Removing trailing comma if any */
+	if (strlen(binding) > 0) {
+		if (*(binding + strlen(binding) - 1) == ',') {
+			*(binding + strlen(binding) - 1) = '\0';
+		}
+	}
 	binding = talloc_strdup_append(binding, "]");
 
 	return binding;


### PR DESCRIPTION
Without this, when we use --debug-data option, we get:
Failed to parse dcerpc binding 'ncacn_ip_tcp:exchange2010.octest1.frogmouth.net[print,]'
libmapi/IMSProvider.c:67(provider_rpc_connection): Failed to connect to remote server: ncacn_ip_tcp:exchange2010.octest1.frogmouth.net[print,] NT_STATUS_INVALID_PARAMETER_MIX
