### PR TITLE
Replaced mysql_affected_rows with mysql_num_rows.

### DIFF
--- a/mapiproxy/libmapiproxy/backends/openchangedb_mysql.c
+++ b/mapiproxy/libmapiproxy/backends/openchangedb_mysql.c
@@ -343,7 +343,7 @@ static enum MAPISTATUS set_mapistoreURI(struct openchangedb_context *self,
 	OPENCHANGE_RETVAL_IF(!sql, MAPI_E_NOT_ENOUGH_MEMORY, mem_ctx);
 
 	retval = status(execute_query(conn, sql));
-	if (mysql_affected_rows(conn) == 0) {
+	if (mysql_num_rows(conn) == 0) {
 		retval = MAPI_E_NOT_FOUND;
 	}
 
@@ -2071,7 +2071,7 @@ static enum MAPISTATUS set_system_idx(struct openchangedb_context *self,
 	OPENCHANGE_RETVAL_IF(!sql, MAPI_E_NOT_ENOUGH_MEMORY, mem_ctx);
 
 	retval = status(execute_query(conn, sql));
-	if (mysql_affected_rows(conn) == 0) {
+	if (mysql_num_rows(conn) == 0) {
 		retval = MAPI_E_NOT_FOUND;
 	}
 


### PR DESCRIPTION
This is required in case for some reason the record is already there.
If an update is requested for this record the "update" will fail.
Since no changes are made. However the value is configured at the
desired value. As such the requested action has in a way actually
succeeded.