### PR TITLE
Fix MySQL update check

### DIFF
--- a/testsuite/libmapiproxy/openchangedb.c
+++ b/testsuite/libmapiproxy/openchangedb.c
@@ -179,6 +179,42 @@ START_TEST (test_set_mapistoreURI) {
 
 	retval = openchangedb_set_mapistoreURI(g_oc_ctx, USER1, fid, initial_uri);
 	CHECK_SUCCESS;
+
+	/* Test wrong fid to check MAPI_E_NOT_FOUND */
+	retval = openchangedb_set_mapistoreURI(g_oc_ctx, USER1, 0x2312121212322, initial_uri);
+	ck_assert_int_eq(retval, MAPI_E_NOT_FOUND);
+
+} END_TEST
+
+START_TEST (test_set_mapistoreURI_same_value) {
+	char *initial_uri = "sogo://paco:paco@mail/folderA1/";
+	char *uri;
+	uint64_t fid = 13980299143264862209ul;
+	retval = openchangedb_get_mapistoreURI(g_mem_ctx, g_oc_ctx, USER1, fid, &uri, true);
+	CHECK_SUCCESS;
+	ck_assert_str_eq(uri, initial_uri);
+
+	retval = openchangedb_set_mapistoreURI(g_oc_ctx, USER1, fid, "foobar");
+	CHECK_SUCCESS;
+
+	retval = openchangedb_set_mapistoreURI(g_oc_ctx, USER1, fid, "foobar");
+	CHECK_SUCCESS;
+
+	retval = openchangedb_get_mapistoreURI(g_mem_ctx, g_oc_ctx, USER1, fid, &uri, true);
+	CHECK_SUCCESS;
+	ck_assert_str_eq(uri, "foobar");
+
+	retval = openchangedb_set_mapistoreURI(g_oc_ctx, USER1, fid, initial_uri);
+	CHECK_SUCCESS;
+} END_TEST
+
+START_TEST (test_set_mapistoreURI_expected_fail) {
+	char *initial_uri = "sogo://paco:paco@mail/folderA1/";
+
+	/* Test wrong fid to check MAPI_E_NOT_FOUND */
+	retval = openchangedb_set_mapistoreURI(g_oc_ctx, USER1, 0x2312121212322, initial_uri);
+	ck_assert_int_eq(retval, MAPI_E_NOT_FOUND);
+
 } END_TEST
 
 START_TEST (test_get_parent_fid) {
@@ -883,6 +919,33 @@ START_TEST (test_set_system_idx) {
 	ck_assert_int_eq(system_idx, initial_system_idx);
 } END_TEST
 
+START_TEST (test_set_system_idx_same_value) {
+        int initial_system_idx, system_idx;
+	uint64_t fid = 13980299143264862209ul;
+
+	retval = openchangedb_get_system_idx(g_oc_ctx, USER1, fid, &initial_system_idx);
+	CHECK_SUCCESS;
+
+	retval = openchangedb_set_system_idx(g_oc_ctx, USER1, fid, 3);
+	CHECK_SUCCESS;
+
+	retval = openchangedb_set_system_idx(g_oc_ctx, USER1, fid, 3);
+	CHECK_SUCCESS;
+
+	retval = openchangedb_get_system_idx(g_oc_ctx, USER1, fid, &system_idx);
+	CHECK_SUCCESS;
+	ck_assert_int_eq(system_idx, 3);
+
+	retval = openchangedb_set_system_idx(g_oc_ctx, USER1, fid, initial_system_idx);
+	CHECK_SUCCESS;
+} END_TEST
+
+START_TEST (test_set_system_idx_expected_fail) {
+	/* Check a wrong fid which leads to MAPI_E_NOT_FOUND */
+	retval = openchangedb_set_system_idx(g_oc_ctx, USER1, 0x323232322, 42);
+	ck_assert_int_eq(retval, MAPI_E_NOT_FOUND);
+} END_TEST
+
 START_TEST (test_get_system_idx_from_public_folder) {
 	int system_idx = 0;
 	uint64_t fid = 504403158265495553ul;
@@ -1316,6 +1379,8 @@ static Suite *openchangedb_create_suite(const char *backend_name,
 	tcase_add_test(tc, test_get_PublicFolderReplica);
 	tcase_add_test(tc, test_get_mapistoreURI);
 	tcase_add_test(tc, test_set_mapistoreURI);
+	tcase_add_test(tc, test_set_mapistoreURI_same_value);
+	tcase_add_test(tc, test_set_mapistoreURI_expected_fail);
 	tcase_add_test(tc, test_get_parent_fid);
 	tcase_add_test(tc, test_get_parent_fid_which_is_the_mailbox);
 	tcase_add_test(tc, test_get_fid);
@@ -1349,6 +1414,8 @@ static Suite *openchangedb_create_suite(const char *backend_name,
 	tcase_add_test(tc, test_get_message_count_from_public_folder);
 	tcase_add_test(tc, test_get_system_idx);
 	tcase_add_test(tc, test_set_system_idx);
+	tcase_add_test(tc, test_set_system_idx_same_value);
+	tcase_add_test(tc, test_set_system_idx_expected_fail);
 	tcase_add_test(tc, test_get_system_idx_from_public_folder);
 
 	tcase_add_test(tc, test_create_and_edit_message);

--- a/testsuite/libmapistore/mapistore_indexing.c
+++ b/testsuite/libmapistore/mapistore_indexing.c
@@ -259,6 +259,28 @@ START_TEST(test_update_fmid_should_fail) {
 	ck_assert_int_eq(retval,  MAPISTORE_ERR_NOT_FOUND);
 } END_TEST
 
+START_TEST(test_update_fmid_same_value) {
+	enum mapistore_error	retval;
+	char			*mapistore_uri = NULL;
+	bool			soft_deleted = true;
+
+	/* prepare some data */
+	retval = g_ictx->add_fmid(g_ictx, g_test_username, INDEXING_TEST_FMID, INDEXING_TEST_URI);
+	ck_assert_int_eq(retval, MAPISTORE_SUCCESS);
+
+	/* actual test */
+	retval = g_ictx->update_fmid(g_ictx, g_test_username, INDEXING_TEST_FMID, INDEXING_TEST_URI_2);
+	ck_assert_int_eq(retval,  MAPISTORE_SUCCESS);
+
+	/* Recheck update a matched value successes */
+	retval = g_ictx->update_fmid(g_ictx, g_test_username, INDEXING_TEST_FMID, INDEXING_TEST_URI_2);
+	ck_assert_int_eq(retval,  MAPISTORE_SUCCESS);
+
+	/* check what is in db */
+	retval = g_ictx->get_uri(g_ictx, g_test_username, g_ictx, INDEXING_TEST_FMID, &mapistore_uri, &soft_deleted);
+	ck_assert(!soft_deleted);
+	ck_assert_str_eq(mapistore_uri, INDEXING_TEST_URI_2);
+} END_TEST
 
 /* del_fmid */
 
@@ -531,6 +553,7 @@ static TCase *create_test_case_indexing_interface(const char *name, SFun setup,
 	tcase_add_test(tc_interface, test_add_fmid_duplicate_value_should_fail);
 	tcase_add_test(tc_interface, test_update_fmid_sanity);
 	tcase_add_test(tc_interface, test_update_fmid);
+	tcase_add_test(tc_interface, test_update_fmid_same_value);
 	tcase_add_test(tc_interface, test_update_fmid_should_fail);
 	tcase_add_test(tc_interface, test_del_fmid_sanity);
 	tcase_add_test(tc_interface, test_del_fmid_unknown_fmid);


### PR DESCRIPTION
`mysql_affected_rows` is only reporting the affected rows and when the value has the desired value the number of affected rows is 0. We can change this behaviour by setting CLIENT_FOUND_ROWS
flag on mysql_real_connect but I'd prefer to have the MySQL connection as standard as possible and this case is not so often.

More details on the following link:

https://dev.mysql.com/doc/refman/5.5/en/mysql-affected-rows.html

This is affecting the following low level procedures:

* set_mapistore_URI
* set_system_idx
* update_fmid