### PR TITLE
Tentative fix for CR-1136.

### DIFF
--- a/mapiproxy/libmapistore/backends/indexing_mysql.c
+++ b/mapiproxy/libmapistore/backends/indexing_mysql.c
@@ -713,10 +713,14 @@ static enum mapistore_error mysql_record_allocate_fmids(struct indexing_context 
 	MAPISTORE_RETVAL_IF(ret != MYSQL_SUCCESS, MAPISTORE_ERR_DATABASE_OPS, NULL);
 
 	mem_ctx = talloc_new(NULL);
+	MAPISTORE_RETVAL_IF(!mem_ctx, MAPISTORE_ERR_NO_MEMORY, NULL);
+
 	sql = talloc_asprintf(mem_ctx,
 		"SELECT next_fmid FROM %s "
 		"WHERE username = '%s'",
 		INDEXING_ALLOC_TABLE, _sql(mem_ctx, username));
+	MAPISTORE_RETVAL_IF(!sql, MAPISTORE_ERR_NO_MEMORY, mem_ctx);
+
 	ret = select_first_uint(MYSQL(ictx), sql, &next_fmid);
 	switch (ret) {
 	case MYSQL_SUCCESS:
@@ -730,6 +734,7 @@ static enum mapistore_error mysql_record_allocate_fmids(struct indexing_context 
 			INDEXING_ALLOC_TABLE,
 			next_fmid + count,
 			_sql(mem_ctx, username));
+		MAPISTORE_RETVAL_IF(!sql, MAPISTORE_ERR_NO_MEMORY, mem_ctx);
 		break;
 	case MYSQL_NOT_FOUND:
 		// First allocation, insert in the database
@@ -740,6 +745,7 @@ static enum mapistore_error mysql_record_allocate_fmids(struct indexing_context 
 			INDEXING_ALLOC_TABLE,
 			_sql(mem_ctx, username),
 			next_fmid + count);
+		MAPISTORE_RETVAL_IF(!sql, MAPISTORE_ERR_NO_MEMORY, mem_ctx);
 		break;
 
 	default:

--- a/mapiproxy/servers/default/emsmdb/oxcmsg.c
+++ b/mapiproxy/servers/default/emsmdb/oxcmsg.c
@@ -326,7 +326,8 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopCreateMessage(TALLOC_CTX *mem_ctx,
 	struct emsmdbp_object		*folder_object = NULL;
 	struct emsmdbp_object		*message_object = NULL;
 	uint32_t			handle;
-	uint64_t			folderID, messageID;
+	uint64_t			folderID;
+	uint64_t			messageID = 0;
 	uint32_t			contextID;
 	bool				mapistore = false;
 	void				*data;


### PR DESCRIPTION
The analysis of the message identifiers involved in every crash
tends to highlight that the mid is initially garbage pushed to
the database and the fequency of this crash is statistically very
low ]1/5000;1/500000[. This patch therefore initializes messageID
to 0 beforehand and add memory checks to prevent data corruption.

At this stage of the investigation, this is the only plausible
explanation available. If it does fix the issue, then I expect
this fix to help narrowing it down even further.