### PR TITLE
emsmdb: Initialize attachmentID in attachment objects

### DIFF
--- a/mapiproxy/servers/default/emsmdb/oxcmsg.c
+++ b/mapiproxy/servers/default/emsmdb/oxcmsg.c
@@ -1422,6 +1422,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopCreateAttach(TALLOC_CTX *mem_ctx,
 	uint32_t		handle;
 	uint32_t		contextID;
 	uint64_t		messageID;
+	uint32_t		attachmentID = 0;
 	struct mapi_handles		*rec = NULL;
 	struct mapi_handles		*attachment_rec = NULL;
 	struct emsmdbp_object		*message_object = NULL;
@@ -1485,7 +1486,9 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopCreateAttach(TALLOC_CTX *mem_ctx,
 								   messageID, message_object);
 		if (attachment_object) {
 			mretval = mapistore_message_create_attachment(emsmdbp_ctx->mstore_ctx, contextID, message_object->backend_object,
-								      attachment_object, &attachment_object->backend_object, &mapi_repl->u.mapi_CreateAttach.AttachmentID);
+								      attachment_object, &attachment_object->backend_object, &attachmentID);
+			attachment_object->object.attachment->attachmentID = attachmentID;
+			mapi_repl->u.mapi_CreateAttach.AttachmentID = attachmentID;
 			if (mretval) {
 				mapi_handles_delete(emsmdbp_ctx->handles_ctx, attachment_rec->handle);
 				OC_DEBUG(5, "could not open nor create mapistore message\n");


### PR DESCRIPTION
Previously the attachmentID was let initialized.
This error did not trigger any known failure because the PidTagAttachNumber
was latter assigned using the position in the attachment table.