### PR TITLE
Reuse memcached connections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -963,6 +963,7 @@ mapiproxy/libmapistore.$(SHLIBEXT).$(PACKAGE_VERSION):  mapiproxy/libmapistore/m
 							mapiproxy/libmapistore/backends/indexing_tdb.po			\
 							mapiproxy/libmapistore/backends/indexing_mysql.po		\
 							mapiproxy/util/mysql.po						\
+							mapiproxy/util/oc_memcached.po					\
 							mapiproxy/util/ccan/htable/htable.po				\
 							mapiproxy/util/ccan/hash/hash.po				\
 							mapiproxy/libmapiproxy.$(SHLIBEXT).$(PACKAGE_VERSION)		\

--- a/mapiproxy/libmapistore/backends/indexing_mysql.c
+++ b/mapiproxy/libmapistore/backends/indexing_mysql.c
@@ -103,7 +103,7 @@ static memcached_st *_memcached_setup(struct indexing_context *ictx,
 	}
 
 	/* Request a memcached connection */
-	memc = oc_memcached_new_connection(conn_str);
+	memc = oc_memcached_new_connection(conn_str, true);
 	if (!memc) {
 		OC_DEBUG(1, "Error trying to get memcached connection");
 		return NULL;
@@ -773,7 +773,7 @@ static int mapistore_indexing_mysql_destructor(struct indexing_context *ictx)
 	if (ictx && ictx->data) {
 		MYSQL *conn = ictx->data;
 		if (ictx->cache) {
-			oc_memcached_release_connection((memcached_st *)ictx->cache);
+			oc_memcached_release_connection((memcached_st *)ictx->cache, true);
 		}
 		if (ictx->url) {
 			OC_DEBUG(5, "Destroying indexing context `%s`\n", ictx->url);

--- a/mapiproxy/libmapistore/backends/indexing_mysql.c
+++ b/mapiproxy/libmapistore/backends/indexing_mysql.c
@@ -11,12 +11,12 @@
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -33,9 +33,9 @@
 #include "../../util/ccan/hash/hash.h"
 #include "../../util/schema_migration.h"
 #include "mapiproxy/libmapiproxy/backends/openchangedb_mysql.h"
+#include "mapiproxy/util/oc_memcached.h"
 
 #include <talloc.h>
-#include <libmemcached/memcached.h>
 
 #define MYSQL(context)	((MYSQL *)context->data)
 
@@ -88,7 +88,6 @@ static memcached_st *_memcached_setup(struct indexing_context *ictx,
 	int			mret;
 	MYSQL_RES		*res;
 	uint32_t		num_rows = 0;
-	memcached_server_st	*servers = NULL;
 	memcached_st		*memc = NULL;
 	memcached_return	rc;
 	uint32_t		i;
@@ -103,21 +102,13 @@ static memcached_st *_memcached_setup(struct indexing_context *ictx,
 		return ictx->cache;
 	}
 
-	/* Initialize memcached connection */
-	if (conn_str) {
-		memc = memcached(conn_str, strlen(conn_str));
-		if (!memc) return NULL;
-	} else {
-		memc = (memcached_st *) memcached_create(NULL);
-		if (!memc) return NULL;
-
-		servers = memcached_server_list_append(servers, "127.0.0.1", 11211, &rc);
-		rc = memcached_server_push(memc, servers);
-		if (rc != MEMCACHED_SUCCESS) {
-			OC_DEBUG(0, "[ERR]: Unable to add server to memcached list\n");
-			return NULL;
-		}
+	/* Request a memcached connection */
+	memc = oc_memcached_new_connection(conn_str);
+	if (!memc) {
+		OC_DEBUG(1, "Error trying to get memcached connection");
+		return NULL;
 	}
+
 	/* Retrieve indexing records for user */
 	mem_ctx = talloc_new(NULL);
 	if (!mem_ctx) return NULL;
@@ -782,7 +773,7 @@ static int mapistore_indexing_mysql_destructor(struct indexing_context *ictx)
 	if (ictx && ictx->data) {
 		MYSQL *conn = ictx->data;
 		if (ictx->cache) {
-			memcached_free((memcached_st *)ictx->cache);
+			oc_memcached_release_connection((memcached_st *)ictx->cache);
 		}
 		if (ictx->url) {
 			OC_DEBUG(5, "Destroying indexing context `%s`\n", ictx->url);

--- a/mapiproxy/libmapistore/backends/indexing_mysql.c
+++ b/mapiproxy/libmapistore/backends/indexing_mysql.c
@@ -104,10 +104,7 @@ static memcached_st *_memcached_setup(struct indexing_context *ictx,
 
 	/* Request a memcached connection */
 	memc = oc_memcached_new_connection(conn_str, true);
-	if (!memc) {
-		OC_DEBUG(1, "Error trying to get memcached connection");
-		return NULL;
-	}
+	if (!memc) return NULL;
 
 	/* Retrieve indexing records for user */
 	mem_ctx = talloc_new(NULL);

--- a/mapiproxy/libmapistore/mapistore.h
+++ b/mapiproxy/libmapistore/mapistore.h
@@ -264,6 +264,7 @@ struct processing_context;
 
 struct mapistore_notification_context {
 	memcached_st				*memc_ctx;
+	bool					threading;
 };
 
 struct mapistore_context {

--- a/mapiproxy/libmapistore/mapistore_notification.c
+++ b/mapiproxy/libmapistore/mapistore_notification.c
@@ -108,10 +108,7 @@ enum mapistore_error mapistore_notification_init(TALLOC_CTX *mem_ctx,
 	threading = lpcfg_parm_bool(lp_ctx, NULL, "mapistore", "threading", false);
 	notification_ctx->threading = threading;
 	notification_ctx->memc_ctx = oc_memcached_new_connection(url, !threading);
-	if (!notification_ctx->memc_ctx) {
-		OC_DEBUG(1, "Error trying to get memcached connection");
-		MAPISTORE_RETVAL_ERR(MAPISTORE_ERR_CONTEXT_FAILED, NULL);
-	}
+	MAPISTORE_RETVAL_IF(!notification_ctx->memc_ctx, MAPISTORE_ERR_CONTEXT_FAILED, NULL);
 	talloc_set_destructor((void *)notification_ctx, (int (*)(void *))mapistore_notification_destructor);
 
 	*_notification_ctx = notification_ctx;

--- a/mapiproxy/services/plugins/dovecot/openchange-plugin.c
+++ b/mapiproxy/services/plugins/dovecot/openchange-plugin.c
@@ -255,6 +255,10 @@ static bool openchange_newmail(struct openchange_user *user,
 		if (bret == false) {
 			i_fatal("unable to set resolver address '%s'", user->resolver);
 		}
+		bret = lpcfg_set_cmdline(lp_ctx, "mapistore:threading", "true");
+		if (bret == false) {
+			i_fatal("unable to set threading as enabled");
+		}
 	}
 	retval = mapistore_notification_init(mem_ctx, lp_ctx, &ctx);
 	if (retval != MAPISTORE_SUCCESS) {

--- a/mapiproxy/util/oc_memcached.c
+++ b/mapiproxy/util/oc_memcached.c
@@ -1,0 +1,139 @@
+/*
+   Memcached util functions
+
+   OpenChange Project
+
+   Copyright (C) Jesús García Sáez 2015
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "oc_memcached.h"
+#include <inttypes.h>
+#include <stdbool.h>
+#include <talloc.h>
+#include "ccan/htable/htable.h"
+#include "ccan/hash/hash.h"
+#include <libmapi/oc_log.h>
+
+#define DEFAULT_CONFIG "default"
+
+/* Items stored on ht table */
+struct memc_item {
+	memcached_st	*memc;
+	const char	*config_string;
+};
+
+/* Rehash function for ht table */
+static size_t _ht_rehash(const void *e, void *unused)
+{
+	return hash_string(((struct memc_item *)e)->config_string);
+}
+
+/* Comparison function to get items from ht table */
+static bool _ht_cmp(const void *e, void *string)
+{
+	return strcmp(((struct memc_item *)e)->config_string, (const char *)string) == 0;
+}
+
+/* This is a dictionary [config_string] -> [memcached_st *] (actually struct memc_item) */
+static struct htable ht = HTABLE_INITIALIZER(ht, _ht_rehash, NULL);
+
+
+/**
+   \details Returns a memcached_st pointer to use it in all libmemcached
+   functions. Internally this connections will be reused between different
+   calls (it will be one connection per config_string).
+
+   \param config_string Config string to initialize a memcached context,
+   in case of being NULL it will default to MSTORE_MEMC_DFLT_HOST. For more
+   info about format check online doc of libmemcached:
+
+       http://docs.libmemcached.org/libmemcached_configuration.html
+ */
+memcached_st *oc_memcached_new_connection(const char *config_string)
+{
+	memcached_st		*memc;
+	memcached_server_st     *servers = NULL;
+	memcached_return	rc;
+	struct memc_item	*entry = NULL;
+	bool			custom_config = false;
+	uint32_t		hashed_string;
+	const char		*value_string;
+
+	if (config_string) {
+		custom_config = true;
+		value_string = config_string;
+	} else {
+		value_string = DEFAULT_CONFIG;
+	}
+	hashed_string = hash_string(value_string);
+	entry = htable_get(&ht, hashed_string, _ht_cmp, value_string);
+	if (entry) {
+		OC_DEBUG(5, "[memcached] Found connection, reusing it %"PRIu32, hashed_string);
+		return entry->memc;
+	}
+
+	/* Initialize memcached connection */
+	if (custom_config) {
+		memc = memcached(value_string, strlen(value_string));
+		if (!memc) {
+			OC_DEBUG(3, "[memcached] Failed to initialize memcached with config string `%s`",
+				 value_string);
+			return NULL;
+		}
+	} else {
+		memc = (memcached_st *) memcached_create(NULL);
+		if (!memc) {
+			OC_DEBUG(3, "[memcached] Failed memcached_create");
+			return NULL;
+		}
+
+		servers = memcached_server_list_append(servers, MSTORE_MEMC_DFLT_HOST, MSTORE_MEMC_DFLT_PORT, &rc);
+		rc = memcached_server_push(memc, servers);
+		if (rc != MEMCACHED_SUCCESS) {
+			OC_DEBUG(3, "[memcached] Failed to add server to memcached list");
+			return NULL;
+		}
+	}
+
+	/* This entries will never be deallocated */
+	entry = talloc_zero(talloc_autofree_context(), struct memc_item);
+	entry->config_string = talloc_strdup(entry, value_string);
+	if (entry->config_string == NULL) {
+		OC_DEBUG(3, "[memcached] Failed talloc_strdup: out of memory?");
+		return NULL;
+	}
+	entry->memc = memc;
+
+	/* Store the new connection in our table */
+	if (!htable_add(&ht, hashed_string, entry)) {
+		OC_DEBUG(3, "[memcached] Error adding new memcached connection");
+	} else {
+		OC_DEBUG(5, "[memcached] Stored new connection %"PRIu32, hashed_string);
+	}
+
+	return memc;
+}
+
+/**
+   \details Close and free one memcached connection.
+
+   \note Actually right now the connections are not neither closed nor freed
+   because we reuse them between users and operations.
+ */
+void oc_memcached_release_connection(memcached_st *memc_ctx)
+{
+	// Do nothing, connections shared
+}

--- a/mapiproxy/util/oc_memcached.h
+++ b/mapiproxy/util/oc_memcached.h
@@ -28,8 +28,8 @@
 #define MSTORE_MEMC_DFLT_PORT 11211
 
 
-memcached_st *oc_memcached_new_connection(const char *config_string);
-void oc_memcached_release_connection(memcached_st *memc_ctx);
+memcached_st *oc_memcached_new_connection(const char *config_string, bool shared);
+void oc_memcached_release_connection(memcached_st *memc_ctx, bool shared);
 
 
 #endif /* __OC_MEMCACHED_H_ */

--- a/mapiproxy/util/oc_memcached.h
+++ b/mapiproxy/util/oc_memcached.h
@@ -1,9 +1,9 @@
 /*
-   OpenChange Storage Abstraction Layer library
+   Memcached util functions
 
    OpenChange Project
 
-   Copyright (C) Julien Kerihuel 2015
+   Copyright (C) Jesús García Sáez 2015
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -19,18 +19,17 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef	MAPISTORE_NOTIFICATION_H
-#define	MAPISTORE_NOTIFICATION_H
+#ifndef __OC_MEMCACHED_H__
+#define __OC_MEMCACHED_H__
 
-#include "mapiproxy/libmapistore/mapistore.h"
-#include "mapiproxy/libmapistore/mapistore_private.h"
-#include "mapiproxy/libmapistore/mapistore_errors.h"
-#include "mapiproxy/libmapistore/gen_ndr/ndr_mapistore_notification.h"
+#include <libmemcached/memcached.h>
 
-/* Define format strings used for key storage in memcached */
-#define	MSTORE_MEMC_FMT_SESSION	"session:%s"
-#define	MSTORE_MEMC_FMT_RESOLVER "resolver:%s"
-#define	MSTORE_MEMC_FMT_SUBSCRIPTION "subscription:%s"
-#define	MSTORE_MEMC_FMT_DELIVER "deliver:%s"
+#define MSTORE_MEMC_DFLT_HOST "127.0.0.1"
+#define MSTORE_MEMC_DFLT_PORT 11211
 
-#endif /* MAPISTORE_NOTIFICATION_H */
+
+memcached_st *oc_memcached_new_connection(const char *config_string);
+void oc_memcached_release_connection(memcached_st *memc_ctx);
+
+
+#endif /* __OC_MEMCACHED_H_ */


### PR DESCRIPTION
Reuse memcached connections based on configuration string, this normally means that we will have two open connections against memcached: one for indexing and another for notifications and those connections will be reused by all sessions and operations.