### PR TITLE
Notifications when username is different from email

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 
 ### Fixes
 
+* Support notifications when the username is different from mail address (e.g. user bob with bobby@domain.com as his email)
 * Rpcproxy handles client disconnections better
 * Out of office message supports non-ascii characters
 * Support notifications when the username is a mail address (e.g. Zentyal Cloud)

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
@@ -1542,6 +1542,7 @@ static enum MAPISTATUS dcesrv_EcDoAsyncConnectEx(struct dcesrv_call_state *dce_c
 	struct dcesrv_handle		*handle;
 	struct dcesrv_endpoint		*item;
 	bool				found;
+	const char			*email;
 
 	OC_DEBUG(3, "exchange_emsmdb: EcDoAsyncConnectEx (0xe)\n");
 
@@ -1594,8 +1595,17 @@ static enum MAPISTATUS dcesrv_EcDoAsyncConnectEx(struct dcesrv_call_state *dce_c
 	}
 
 	/* Step 3. Register the global session */
+	retval = emsmdbp_get_external_email(emsmdbp_ctx, &email);
+	if (retval != MAPISTORE_SUCCESS) {
+		OC_DEBUG(1, "[EcDoAsyncConnectEx] Unable to find external email "
+			 "(for %s) to register session", emsmdbp_ctx->username);
+		r->out.async_handle->handle_type = 0;
+		r->out.async_handle->uuid = GUID_zero();
+		r->out.result = DCERPC_FAULT_CONTEXT_MISMATCH;
+		return MAPI_E_LOGON_FAILED;
+	}
 	retval = mapistore_notification_session_add(emsmdbp_ctx->mstore_ctx, r->in.handle->uuid,
-						    handle->wire_handle.uuid, dcesrv_call_account_name(dce_call));
+						    handle->wire_handle.uuid, email);
 	if (retval != MAPISTORE_SUCCESS) {
 		OC_DEBUG(0, "[EcDoAsyncConnectEx]: session registration failed with '%s'\n",
 			 mapistore_errstr(retval));

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
@@ -304,6 +304,7 @@ bool			emsmdbp_verify_userdn(struct dcesrv_call_state *, struct emsmdbp_context 
 enum MAPISTATUS		emsmdbp_resolve_recipient(TALLOC_CTX *, struct emsmdbp_context *, char *, struct mapi_SPropTagArray *, struct RecipientRow *);
 enum MAPISTATUS		emsmdbp_fetch_organizational_units(TALLOC_CTX *, struct emsmdbp_context *, char **, char **);
 enum MAPISTATUS		emsmdbp_get_org_dn(struct emsmdbp_context *, struct ldb_dn **);
+enum MAPISTATUS		emsmdbp_get_external_email(struct emsmdbp_context *, const char **);
 
 const struct GUID *const	MagicGUIDp;
 int				emsmdbp_guid_to_replid(struct emsmdbp_context *, const char *username, const struct GUID *, uint16_t *);

--- a/mapiproxy/services/plugins/dovecot/ChangeLog
+++ b/mapiproxy/services/plugins/dovecot/ChangeLog
@@ -1,0 +1,1 @@
+ * Removed openchange_cn option, always using email

--- a/mapiproxy/services/plugins/dovecot/README.md
+++ b/mapiproxy/services/plugins/dovecot/README.md
@@ -103,7 +103,8 @@ plugin {
   * __openchange_cn = STRING__ This option specifies the field used by
     the dovecot service to query the resolver service. Acceptable
     values are: __username__ or __email__. If no option is specified,
-    username is used by default.
+    email is used by default. username options means to get the first
+    part of the email (bob instead bob@domain.com)
 
   * __openchange_backend = STRING__ This option specifies the
     mapistore backend used by OpenChange server to deliver and fetch

--- a/mapiproxy/services/plugins/dovecot/README.md
+++ b/mapiproxy/services/plugins/dovecot/README.md
@@ -87,7 +87,6 @@ configuration file inside the plugin section:
 ```
 plugin {
        openchange_resolver = "--SERVER=127.0.0.1:11211"
-       openchange_cn = "username"
 }
 ```
 
@@ -99,12 +98,6 @@ plugin {
     http://docs.libmemcached.org/libmemcached_configuration.html. If
     no option is provided `--SERVER=127.0.0.1:11211` is used by
     default.
-
-  * __openchange_cn = STRING__ This option specifies the field used by
-    the dovecot service to query the resolver service. Acceptable
-    values are: __username__ or __email__. If no option is specified,
-    email is used by default. username options means to get the first
-    part of the email (bob instead bob@domain.com)
 
   * __openchange_backend = STRING__ This option specifies the
     mapistore backend used by OpenChange server to deliver and fetch

--- a/mapiproxy/services/plugins/dovecot/openchange-plugin.c
+++ b/mapiproxy/services/plugins/dovecot/openchange-plugin.c
@@ -138,11 +138,11 @@ static void openchange_mail_user_created(struct mail_user *user)
 	}
 
 	str = mail_user_plugin_getenv(user, "openchange_cn");
-	if ((str == NULL) || !strcmp(str, "username")) {
+	if (str && !strcmp(str, "username")) {
 		aux = i_strdup(user->username);
 		ocuser->username = i_strdup(strtok(aux, "@"));
 		free(aux);
-	} else if (str && !strcmp(str, "email")) {
+	} else if (str == NULL || !strcmp(str, "email")) {
 		ocuser->username = i_strdup(user->username);
 	} else {
 		i_fatal("Invalid openchange_cn parameter in dovecot.conf");

--- a/mapiproxy/services/plugins/dovecot/openchange-plugin.c
+++ b/mapiproxy/services/plugins/dovecot/openchange-plugin.c
@@ -137,16 +137,7 @@ static void openchange_mail_user_created(struct mail_user *user)
 		ocuser->resolver = i_strdup(str);
 	}
 
-	str = mail_user_plugin_getenv(user, "openchange_cn");
-	if (str && !strcmp(str, "username")) {
-		aux = i_strdup(user->username);
-		ocuser->username = i_strdup(strtok(aux, "@"));
-		free(aux);
-	} else if (str == NULL || !strcmp(str, "email")) {
-		ocuser->username = i_strdup(user->username);
-	} else {
-		i_fatal("Invalid openchange_cn parameter in dovecot.conf");
-	}
+	ocuser->username = i_strdup(user->username);
 
 	str = mail_user_plugin_getenv(user, "openchange_backend");
 	if (str == NULL) {


### PR DESCRIPTION
* Use email (obtained from `proxyAddresses:SMTP:xxxx` entry which must be always present for openchange users) to create notification session.
* Removed `openchange_cn` option from dovecot plugin, always using email.

This fixes scenarios where the username is different from the email, for example username `bob` with an email `bobby@domain.com`.