### PR TITLE
Free user sessions on unbind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -814,7 +814,7 @@ mapiproxy/libmapiproxy.$(SHLIBEXT).$(PACKAGE_VERSION):	mapiproxy/libmapiproxy/dc
 							mapiproxy/util/ccan/htable/htable.po			\
 							libmapi.$(SHLIBEXT).$(PACKAGE_VERSION)
 	@echo "Linking $@"
-	@$(CC) -o $@ $(DSOOPT) $(LDFLAGS) -Wl,-soname,libmapiproxy.$(SHLIBEXT).$(LIBMAPIPROXY_SO_VERSION) $^ -L. $(LIBS) $(TDB_LIBS) $(DL_LIBS) $(MYSQL_LIBS) $(PYTHON_LIBS)
+	@$(CC) -o $@ $(DSOOPT) $(LDFLAGS) -Wl,-soname,libmapiproxy.$(SHLIBEXT).$(LIBMAPIPROXY_SO_VERSION) $^ -L. $(LIBS) $(TDB_LIBS) $(DL_LIBS) $(MYSQL_LIBS) $(PYTHON_LIBS) $(SAMBASERVER_LIBS) $(SAMDB_LIBS)
 
 libmapiproxy.$(SHLIBEXT).$(LIBMAPIPROXY_SO_VERSION): mapiproxy/libmapiproxy.$(SHLIBEXT).$(PACKAGE_VERSION)
 	ln -fs $< $@

--- a/mapiproxy/libmapiproxy/dcesrv_mapiproxy_session.c
+++ b/mapiproxy/libmapiproxy/dcesrv_mapiproxy_session.c
@@ -44,7 +44,7 @@ static struct mpm_session	*mpm_sessions = NULL;
    \return Pointer to an allocated mpm_session structure on success,
    otherwise NULL
  */
-struct mpm_session *mpm_session_new(struct server_id serverid,
+static struct mpm_session *mpm_session_new(struct server_id serverid,
 				    uint32_t context_id,
 				    const char *username,
 				    struct GUID	*uuid)

--- a/mapiproxy/libmapiproxy/dcesrv_mapiproxy_session.c
+++ b/mapiproxy/libmapiproxy/dcesrv_mapiproxy_session.c
@@ -10,12 +10,12 @@
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -33,44 +33,6 @@
 
 static struct mpm_session	*mpm_sessions = NULL;
 
-/**
-   \details Create and return an allocated pointer to a mpm session
-
-   \param mem_ctx pointer to the memory context
-   \param serverid reference to the session context server identifier
-   structure
-   \param context_id reference to the context identifier
-
-   \return Pointer to an allocated mpm_session structure on success,
-   otherwise NULL
- */
-static struct mpm_session *mpm_session_new(struct server_id serverid,
-				    uint32_t context_id,
-				    const char *username,
-				    struct GUID	*uuid)
-{
-	struct mpm_session	*session = NULL;
-
-	session = talloc_zero(NULL, struct mpm_session);
-	if (!session) return NULL;
-
-	session->server_id = serverid;
-	session->context_id = context_id;
-	if (uuid) session->uuid = *uuid;
-	session->destructor = NULL;
-	session->private_data = NULL;
-
-	/* Released RPC connection, session may be kept to avoid premature release
-	of private_data, that will be cleared when all user sessions are released */
-	session->released = false;
-	session->username = talloc_strdup(session, username);
-	if (!session->username) return NULL;
-
-	DLIST_ADD_END(mpm_sessions, session, struct mpm_session *);
-
-	return session;
-}
-
 
 /**
    \details Create and return an allocated pointer to a mpm session
@@ -84,14 +46,51 @@ static struct mpm_session *mpm_session_new(struct server_id serverid,
 struct mpm_session *mpm_session_init(struct dcesrv_call_state *dce_call,
 				     struct GUID *uuid)
 {
+	struct mpm_session	*session = NULL;
+
 	if (!dce_call) return NULL;
 	if (!dce_call->conn) return NULL;
 	if (!dce_call->context) return NULL;
 
-	return mpm_session_new(dce_call->conn->server_id,
-			       dce_call->context->context_id,
-			       dcesrv_call_account_name(dce_call),
-			       uuid);
+	session = talloc_zero(NULL, struct mpm_session);
+	if (!session) return NULL;
+
+	session->server_id = dce_call->conn->server_id;
+	session->context_id = dce_call->context->context_id;
+	if (uuid) {
+		session->uuid = *uuid;
+	}
+	session->destructor = NULL;
+	session->private_data = NULL;
+
+	/* Released RPC connection, session may be kept to avoid premature release
+	of private_data, that will be cleared when all user sessions are released */
+	session->released = false;
+	session->username = talloc_strdup(session, dcesrv_call_account_name(dce_call));
+	if (!session->username) return NULL;
+	DLIST_ADD(mpm_sessions, session);
+
+	return session;
+}
+
+
+/**
+   \details Free session private data
+
+   \param session to free
+
+   \return true if data was released
+ */
+bool mpm_session_release(struct mpm_session *session) {
+	if (!session) return false;
+
+	if (session->destructor) {
+		session->destructor(session->private_data);
+		session->destructor = NULL;
+		return true;
+	}
+
+	return false;
 }
 
 
@@ -135,7 +134,7 @@ bool mpm_session_set_private_data(struct mpm_session *session,
 
 
 /**
-   \details Release RPC session
+   \details Unbind RPC session
 
    This code will release mapiproxy session data (and remove it from
    mpm_sessions array) when all user sessions are marked as deleted
@@ -145,45 +144,48 @@ bool mpm_session_set_private_data(struct mpm_session *session,
  */
 bool mpm_session_unbind(struct server_id *server_id, uint32_t context_id)
 {
-	struct mpm_session	*current = NULL;
-	bool			release = true;
+	struct mpm_session	*current, *next;
 	char			*username = NULL;
 
 	if (!server_id) return false;
 
-	// Mark all server_id/context_id sessions as released
+	/* Mark all server_id/context_id sessions as released */
 	for (current = mpm_sessions; current; current = current->next) {
-		if (memcmp(server_id, &current->server_id, sizeof(struct server_id)) == 0 &&
+		if (server_id_equal(server_id, &current->server_id) &&
 		    context_id == current->context_id) {
-			current->released = release;
+			current->released = true;
 			username = current->username;
 		}
 	}
 
 	if (username) {
-		// At least one session marked, are all of them gone?
-		for (current = mpm_sessions; current && release; current = current->next) {
+		/* At least one session marked, are all of them gone? */
+		for (current = mpm_sessions; current; current = current->next) {
 			if (strcmp(username, current->username) == 0 && !current->released) {
-				OC_DEBUG(5, "Keeping %s sessions as some of context are not unbinded yet", username);
-				release = false;
+				OC_DEBUG(6, "Keeping %s sessions as some of context are not unbinded yet", username);
+				return false;
 			}
 		}
 
-		if (release) {
-			OC_DEBUG(5, "Cleaning sessions for user %s", username);
-			for (current = mpm_sessions; current; current = current->next) {
-				if (strcmp(username, current->username) == 0) {
-					// Destroy private data
-					if (current->destructor) {
-						current->destructor(current->private_data);
-					}
+		/* If we reach here, all user contexts are makred for release, clean up */
+		OC_DEBUG(5, "Cleaning sessions for user %s", username);
+		username = talloc_strdup(NULL, username);
+		current = mpm_sessions;
+		while (current) {
+			if (strcmp(username, current->username) == 0) {
+				/* Destroy private data */
+				mpm_session_release(current);
 
-					// Remove and free session entry
-					DLIST_REMOVE(mpm_sessions, current);
-					talloc_free(current);
-				}
+				/* Remove and free session entry */
+				next = current->next;
+				DLIST_REMOVE(mpm_sessions, current);
+				talloc_free(current);
+				current = next;
+			} else {
+				current = current->next;
 			}
 		}
+		talloc_free(username);
 	}
 
 	return true;

--- a/mapiproxy/libmapiproxy/dcesrv_mapiproxy_session.c
+++ b/mapiproxy/libmapiproxy/dcesrv_mapiproxy_session.c
@@ -199,6 +199,8 @@ struct mpm_session *mpm_session_find_by_uuid(struct GUID *uuid)
 {
 	struct mpm_session	*session;
 
+	if (!uuid) return NULL;
+
 	for (session = mpm_sessions; session; session = session->next) {
 		if (GUID_equal(uuid, &session->uuid)) {
 			return session;

--- a/mapiproxy/libmapiproxy/dcesrv_mapiproxy_session.c
+++ b/mapiproxy/libmapiproxy/dcesrv_mapiproxy_session.c
@@ -60,8 +60,8 @@ static struct mpm_session *mpm_session_new(struct server_id serverid,
 	session->destructor = NULL;
 	session->private_data = NULL;
 
-	// Released RPC connection, session may be kept to avoid premature release
-	// of private_data, that will be cleared when all user sessions are released
+	/* Released RPC connection, session may be kept to avoid premature release
+	of private_data, that will be cleared when all user sessions are released */
 	session->released = false;
 	session->username = talloc_strdup(session, username);
 	if (!session->username) return NULL;

--- a/mapiproxy/libmapiproxy/dcesrv_mapiproxy_session.c
+++ b/mapiproxy/libmapiproxy/dcesrv_mapiproxy_session.c
@@ -22,6 +22,7 @@
 
 #include "mapiproxy/dcesrv_mapiproxy.h"
 #include "libmapiproxy.h"
+#include "utils/dlinklist.h"
 
 /**
    \file dcesrv_mapiproxy_session.c
@@ -29,6 +30,7 @@
    \brief session API for mapiproxy modules
  */
 
+static struct mpm_session	*mpm_sessions = NULL;
 
 /**
    \details Create and return an allocated pointer to a mpm session
@@ -41,21 +43,29 @@
    \return Pointer to an allocated mpm_session structure on success,
    otherwise NULL
  */
-struct mpm_session *mpm_session_new(TALLOC_CTX *mem_ctx, 
-				     struct server_id serverid,
-				     uint32_t context_id)
+struct mpm_session *mpm_session_new(struct server_id serverid,
+				    uint32_t context_id,
+				    const char *username,
+				    struct GUID	*uuid)
 {
 	struct mpm_session	*session = NULL;
 
-	if (!mem_ctx) return NULL;
-
-	session = talloc_zero(mem_ctx, struct mpm_session);
+	session = talloc_zero(NULL, struct mpm_session);
 	if (!session) return NULL;
 
 	session->server_id = serverid;
 	session->context_id = context_id;
+	if (uuid) session->uuid = *uuid;
 	session->destructor = NULL;
 	session->private_data = NULL;
+
+	// Released RPC connection, session may be kept to avoid premature release
+	// of private_data, that will be cleared when all user sessions are released
+	session->released = false;
+	session->username = talloc_strdup(session, username);
+	if (!session->username) return NULL;
+
+	DLIST_ADD_END(mpm_sessions, session, struct mpm_session *);
 
 	return session;
 }
@@ -64,22 +74,23 @@ struct mpm_session *mpm_session_new(TALLOC_CTX *mem_ctx,
 /**
    \details Create and return an allocated pointer to a mpm session
 
-   \param mem_ctx pointer to the memory context
    \param dce_call pointer to the session context
+   \param uuid session
 
    \return Pointer to an allocated mpm_session structure on success,
    otherwise NULL
  */
-struct mpm_session *mpm_session_init(TALLOC_CTX *mem_ctx,
-				     struct dcesrv_call_state *dce_call)
+struct mpm_session *mpm_session_init(struct dcesrv_call_state *dce_call,
+				     struct GUID *uuid)
 {
-	if (!mem_ctx) return NULL;
 	if (!dce_call) return NULL;
 	if (!dce_call->conn) return NULL;
 	if (!dce_call->context) return NULL;
 
-	return mpm_session_new(mem_ctx, dce_call->conn->server_id, 
-			       dce_call->context->context_id);
+	return mpm_session_new(dce_call->conn->server_id,
+			       dce_call->context->context_id,
+			       dcesrv_call_account_name(dce_call),
+			       uuid);
 }
 
 
@@ -123,7 +134,8 @@ bool mpm_session_set_private_data(struct mpm_session *session,
 
 
 /**
-   \details Release a mapiproxy session context
+   \details Release a mapiproxy session, private data (if any) will be released
+   when all user sessions are gone
 
    \param session pointer to the mpm session context
 
@@ -150,13 +162,32 @@ bool mpm_session_release(struct mpm_session *session)
 
 
 /**
+   \details Find and return a session by UUID (will return NULL if not found)
+
+   \param Session UUID
+ */
+struct mpm_session *mpm_session_find_by_uuid(struct GUID *uuid)
+{
+	struct mpm_session	*session;
+
+	for (session = mpm_sessions; session; session = session->next) {
+		if (GUID_equal(uuid, &session->uuid)) {
+			return session;
+		}
+	}
+
+	return NULL;
+}
+
+
+/**
    \details Compare the mpm session with the session context one
 
    \param session pointer to the mapiproxy module session
    \param sid reference to a server_id structure to compare
    \param context_id the connection context id to compare
  */
-bool mpm_session_cmp_sub(struct mpm_session *session, 
+bool mpm_session_cmp_sub(struct mpm_session *session,
 			 struct server_id sid,
 			 uint32_t context_id)
 {

--- a/mapiproxy/libmapiproxy/dcesrv_mapiproxy_session.c
+++ b/mapiproxy/libmapiproxy/dcesrv_mapiproxy_session.c
@@ -4,6 +4,7 @@
    OpenChange Project
 
    Copyright (C) Julien Kerihuel 2008
+   Copyright (C) Carlos Pérez-Aradros Herce 2015
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -53,28 +54,10 @@ struct mpm_session *mpm_session_new(TALLOC_CTX *mem_ctx,
 
 	session->server_id = serverid;
 	session->context_id = context_id;
-	session->ref_count = 0;
 	session->destructor = NULL;
 	session->private_data = NULL;
 
 	return session;
-}
-
-
-/**
-   \details Increment the ref_count associated to a session
-
-   \param session pointer to the session where to increment ref_count
-
-   \return true on success, otherwise false
- */
-bool mpm_session_increment_ref_count(struct mpm_session *session)
-{
-	if (!session) return false;
-
-	session->ref_count += 1;
-
-	return true;
 }
 
 
@@ -152,10 +135,8 @@ bool mpm_session_release(struct mpm_session *session)
 
 	if (!session) return false;
 
-	if (session->ref_count) {
-		session->ref_count -= 1;
-		return false;
-	}
+	// TODO proper checking before release
+	return false;
 
 	if (session->destructor) {
 		ret = session->destructor(session->private_data);

--- a/mapiproxy/libmapiproxy/libmapiproxy.h
+++ b/mapiproxy/libmapiproxy/libmapiproxy.h
@@ -196,7 +196,7 @@ bool mpm_session_set_private_data(struct mpm_session *, void *);
 bool mpm_session_unbind(struct server_id *, uint32_t);
 bool mpm_session_cmp_sub(struct mpm_session *, struct server_id, uint32_t);
 bool mpm_session_cmp(struct mpm_session *, struct dcesrv_call_state *);
-struct mpm_session *mpm_session_find_by_uuid(struct GUID *uuid);
+struct mpm_session *mpm_session_find_by_uuid(struct GUID *);
 
 struct openchangedb_context;
 

--- a/mapiproxy/libmapiproxy/libmapiproxy.h
+++ b/mapiproxy/libmapiproxy/libmapiproxy.h
@@ -10,12 +10,12 @@
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -192,6 +192,7 @@ void *mapiproxy_server_openchangedb_init(struct loadparm_context *);
 /* definitions from dcesrv_mapiproxy_session. c */
 struct mpm_session *mpm_session_init(struct dcesrv_call_state *, struct GUID *);
 bool mpm_session_set_destructor(struct mpm_session *, bool (*destructor)(void *));
+bool mpm_session_release(struct mpm_session *);
 bool mpm_session_set_private_data(struct mpm_session *, void *);
 bool mpm_session_unbind(struct server_id *, uint32_t);
 bool mpm_session_cmp_sub(struct mpm_session *, struct server_id, uint32_t);

--- a/mapiproxy/libmapiproxy/libmapiproxy.h
+++ b/mapiproxy/libmapiproxy/libmapiproxy.h
@@ -74,6 +74,10 @@ struct mpm_session {
 	uint32_t			context_id;
 	bool				(*destructor)(void *);
 	void				*private_data;
+	const char			*username;
+	struct GUID			uuid;
+	bool				released;
+	struct mpm_session		*next, *prev;
 };
 
 
@@ -186,13 +190,14 @@ TDB_CONTEXT *mapiproxy_server_emsabp_tdb_init(struct loadparm_context *);
 void *mapiproxy_server_openchangedb_init(struct loadparm_context *);
 
 /* definitions from dcesrv_mapiproxy_session. c */
-struct mpm_session *mpm_session_new(TALLOC_CTX *, struct server_id, uint32_t);
-struct mpm_session *mpm_session_init(TALLOC_CTX *, struct dcesrv_call_state *);
+struct mpm_session *mpm_session_new(struct server_id, uint32_t, const char *, struct GUID *);
+struct mpm_session *mpm_session_init(struct dcesrv_call_state *, struct GUID *);
 bool mpm_session_set_destructor(struct mpm_session *, bool (*destructor)(void *));
 bool mpm_session_set_private_data(struct mpm_session *, void *);
 bool mpm_session_release(struct mpm_session *);
 bool mpm_session_cmp_sub(struct mpm_session *, struct server_id, uint32_t);
 bool mpm_session_cmp(struct mpm_session *, struct dcesrv_call_state *);
+struct mpm_session *mpm_session_find_by_uuid(struct GUID *uuid);
 
 struct openchangedb_context;
 

--- a/mapiproxy/libmapiproxy/libmapiproxy.h
+++ b/mapiproxy/libmapiproxy/libmapiproxy.h
@@ -74,7 +74,7 @@ struct mpm_session {
 	uint32_t			context_id;
 	bool				(*destructor)(void *);
 	void				*private_data;
-	const char			*username;
+	char				*username;
 	struct GUID			uuid;
 	bool				released;
 	struct mpm_session		*next, *prev;
@@ -194,7 +194,7 @@ struct mpm_session *mpm_session_new(struct server_id, uint32_t, const char *, st
 struct mpm_session *mpm_session_init(struct dcesrv_call_state *, struct GUID *);
 bool mpm_session_set_destructor(struct mpm_session *, bool (*destructor)(void *));
 bool mpm_session_set_private_data(struct mpm_session *, void *);
-bool mpm_session_release(struct mpm_session *);
+bool mpm_session_unbind(struct server_id *, uint32_t);
 bool mpm_session_cmp_sub(struct mpm_session *, struct server_id, uint32_t);
 bool mpm_session_cmp(struct mpm_session *, struct dcesrv_call_state *);
 struct mpm_session *mpm_session_find_by_uuid(struct GUID *uuid);

--- a/mapiproxy/libmapiproxy/libmapiproxy.h
+++ b/mapiproxy/libmapiproxy/libmapiproxy.h
@@ -190,7 +190,6 @@ TDB_CONTEXT *mapiproxy_server_emsabp_tdb_init(struct loadparm_context *);
 void *mapiproxy_server_openchangedb_init(struct loadparm_context *);
 
 /* definitions from dcesrv_mapiproxy_session. c */
-struct mpm_session *mpm_session_new(struct server_id, uint32_t, const char *, struct GUID *);
 struct mpm_session *mpm_session_init(struct dcesrv_call_state *, struct GUID *);
 bool mpm_session_set_destructor(struct mpm_session *, bool (*destructor)(void *));
 bool mpm_session_set_private_data(struct mpm_session *, void *);

--- a/mapiproxy/libmapiproxy/libmapiproxy.h
+++ b/mapiproxy/libmapiproxy/libmapiproxy.h
@@ -4,6 +4,7 @@
    OpenChange Project
 
    Copyright (C) Julien Kerihuel 2008-2011
+   Copyright (C) Carlos Pérez-Aradros Herce 2015
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -71,7 +72,6 @@ struct mapiproxy_module_list {
 struct mpm_session {
 	struct server_id		server_id;
 	uint32_t			context_id;
-	uint32_t			ref_count;
 	bool				(*destructor)(void *);
 	void				*private_data;
 };
@@ -188,7 +188,6 @@ void *mapiproxy_server_openchangedb_init(struct loadparm_context *);
 /* definitions from dcesrv_mapiproxy_session. c */
 struct mpm_session *mpm_session_new(TALLOC_CTX *, struct server_id, uint32_t);
 struct mpm_session *mpm_session_init(TALLOC_CTX *, struct dcesrv_call_state *);
-bool mpm_session_increment_ref_count(struct mpm_session *);
 bool mpm_session_set_destructor(struct mpm_session *, bool (*destructor)(void *));
 bool mpm_session_set_private_data(struct mpm_session *, void *);
 bool mpm_session_release(struct mpm_session *);

--- a/mapiproxy/modules/mpm_cache.c
+++ b/mapiproxy/modules/mpm_cache.c
@@ -4,6 +4,7 @@
    OpenChange Project
 
    Copyright (C) Julien Kerihuel 2008
+   Copyright (C) Carlos Pérez-Aradros Herce 2015
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -386,14 +387,14 @@ static NTSTATUS cache_pull_OpenMessage(struct dcesrv_call_state *dce_call,
 
 	message = talloc((TALLOC_CTX *)mpm, struct mpm_message);
 	NT_STATUS_HAVE_NO_MEMORY(message);
-	
-	message->session = mpm_session_init((TALLOC_CTX *)mpm, dce_call);
+
+	message->session = mpm_session_init(dce_call, NULL);
 	NT_STATUS_HAVE_NO_MEMORY(message->session);
 
 	message->FolderId = request.FolderId;
 	message->MessageId = request.MessageId;
 	message->handle = 0xFFFFFFFF;
-	
+
 	DLIST_ADD_END(mpm->messages, message, struct mpm_message *);
 
 	return NT_STATUS_OK;
@@ -504,7 +505,7 @@ static NTSTATUS cache_pull_OpenAttach(struct dcesrv_call_state *dce_call,
 	attach = talloc((TALLOC_CTX *)mpm, struct mpm_attachment);
 	NT_STATUS_HAVE_NO_MEMORY(attach);
 
-	attach->session = mpm_session_init((TALLOC_CTX *)mpm, dce_call);
+	attach->session = mpm_session_init(dce_call, NULL);
 	NT_STATUS_HAVE_NO_MEMORY(attach->session);
 
 	attach->AttachmentID = request.AttachmentID;
@@ -635,7 +636,7 @@ static NTSTATUS cache_pull_OpenStream(struct dcesrv_call_state *dce_call,
 			stream = talloc((TALLOC_CTX *)mpm, struct mpm_stream);
 			NT_STATUS_HAVE_NO_MEMORY(stream);
 
-			stream->session = mpm_session_init((TALLOC_CTX *)mpm, dce_call);
+			stream->session = mpm_session_init(dce_call, NULL);
 			NT_STATUS_HAVE_NO_MEMORY(stream->session);
 
 			stream->handle = 0xFFFFFFFF;
@@ -664,7 +665,7 @@ static NTSTATUS cache_pull_OpenStream(struct dcesrv_call_state *dce_call,
 			stream = talloc((TALLOC_CTX *)mpm, struct mpm_stream);
 			NT_STATUS_HAVE_NO_MEMORY(stream);
 
-			stream->session = mpm_session_init((TALLOC_CTX *)mpm, dce_call);
+			stream->session = mpm_session_init(dce_call, NULL);
 			NT_STATUS_HAVE_NO_MEMORY(stream->session);
 
 			stream->handle = 0xFFFFFFFF;

--- a/mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.h
+++ b/mapiproxy/servers/default/asyncemsmdb/dcesrv_asyncemsmdb.h
@@ -4,6 +4,7 @@
    OpenChange Project
 
    Copyright (C) Julien Kerihuel 2015
+   Copyright (C) Carlos Pérez-Aradros Herce 2015
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -34,7 +35,10 @@
 #include <nanomsg/nn.h>
 #include <nanomsg/pipeline.h>
 
-struct asyncemsmdb_private_data {
+
+struct exchange_asyncemsmdb_session {
+	char					*cn;
+	char					*bind_addr;
 	struct dcesrv_call_state		*dce_call;
 	struct EcDoAsyncWaitEx			*r;
 	struct mapistore_context		*mstore_ctx;
@@ -47,15 +51,6 @@ struct asyncemsmdb_private_data {
 	int					lock;
 };
 
-struct exchange_asyncemsmdb_session {
-	struct asyncemsmdb_private_data		*data;
-	struct GUID				uuid;
-	struct mapistore_context		*mstore_ctx;
-	char					*cn;
-	char					*bind_addr;
-	struct exchange_asyncemsmdb_session	*prev;
-	struct exchange_asyncemsmdb_session	*next;
-};
 
 #ifndef __BEGIN_DECLS
 #ifdef __cplusplus

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
@@ -4,6 +4,7 @@
    OpenChange Project
 
    Copyright (C) Julien Kerihuel 2009-2015
+   Copyright (C) Carlos Pérez-Aradros Herce 2015
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -201,14 +202,9 @@ static enum MAPISTATUS dcesrv_EcDoConnect(struct dcesrv_call_state *dce_call,
 
 	r->out.result = MAPI_E_SUCCESS;
 
-	/* Search for an existing session and increment ref_count, otherwise create it */
+	/* Search for an existing session, create if it doesn't exist */
 	session = dcesrv_find_emsmdb_session(&handle->wire_handle.uuid);
-	if (session) {
-		OC_DEBUG(0, "[exchange_emsmdb]: Increment session ref count for %d\n",
-				 session->session->context_id);
-		mpm_session_increment_ref_count(session->session);
-	}
-	else {
+	if (!session) {
 		/* Step 7. Associate this emsmdbp context to the session */
 		session = talloc_zero(emsmdb_session, struct exchange_emsmdb_session);
 		OPENCHANGE_RETVAL_IF(!session, MAPI_E_NOT_ENOUGH_RESOURCES, emsmdbp_ctx);
@@ -1336,14 +1332,9 @@ static enum MAPISTATUS dcesrv_EcDoConnectEx(struct dcesrv_call_state *dce_call,
 		r->out.result = MAPI_E_SUCCESS;
 	}
 
-	/* Search for an existing session and increment ref_count, otherwise create it */
+	/* Search for an existing session, create if it doesn't exist */
 	session = dcesrv_find_emsmdb_session(&handle->wire_handle.uuid);
-	if (session) {
-		OC_DEBUG(0, "[exchange_emsmdb]: Increment session ref count for %d\n",
-				 session->session->context_id);
-		mpm_session_increment_ref_count(session->session);
-	}
-	else {
+	if (!session) {
 		/* Step 7. Associate this emsmdbp context to the session */
 		session = talloc_zero(emsmdb_session, struct exchange_emsmdb_session);
 		OPENCHANGE_RETVAL_IF(!session, MAPI_E_NOT_ENOUGH_RESOURCES, emsmdbp_ctx);

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
@@ -36,34 +36,20 @@
 struct exchange_emsmdb_session		*emsmdb_session = NULL;
 void					*openchange_db_ctx = NULL;
 
-static struct exchange_emsmdb_session *dcesrv_find_emsmdb_session(struct GUID *uuid)
-{
-	struct exchange_emsmdb_session	*session, *found_session = NULL;
 
-	for (session = emsmdb_session; !found_session && session; session = session->next) {
-		if (GUID_equal(uuid, &session->uuid)) {
-			found_session = session;
-		}
+static struct emsmdbp_context *dcesrv_find_emsmdbp_context(struct GUID *uuid)
+{
+	struct mpm_session	*session;
+	struct emsmdbp_context	*emsabp_ctx = NULL;
+
+	session = mpm_session_find_by_uuid(uuid);
+	if (session) {
+		emsabp_ctx = (struct emsmdbp_context *)session->private_data;
 	}
 
-	return found_session;
+	return emsabp_ctx;
 }
 
-/* FIXME: See _unbind below */
-/* static struct exchange_emsmdb_session *dcesrv_find_emsmdb_session_by_server_id(const struct server_id *server_id, uint32_t context_id) */
-/* { */
-/* 	struct exchange_emsmdb_session	*session; */
-
-/* 	for (session = emsmdb_session; session; session = session->next) { */
-/* 		if (session->session */
-/* 		    && session->session->server_id.id == server_id->id && session->session->server_id.id2 == server_id->id2 && session->session->server_id.node == server_id->node */
-/* 		    && session->session->context_id == context_id) { */
-/* 			return session; */
-/* 		} */
-/* 	} */
-
-/* 	return NULL; */
-/* } */
 
 /**
    \details exchange_emsmdb EcDoConnect (0x0) function
@@ -83,7 +69,7 @@ static enum MAPISTATUS dcesrv_EcDoConnect(struct dcesrv_call_state *dce_call,
 	struct emsmdbp_context		*emsmdbp_ctx;
 	struct dcesrv_handle		*handle;
 	struct policy_handle		wire_handle;
-	struct exchange_emsmdb_session	*session;
+	struct mpm_session		*session;
 	struct ldb_message		*msg;
 	const char			*mailNickname;
 	const char			*userDN;
@@ -203,24 +189,16 @@ static enum MAPISTATUS dcesrv_EcDoConnect(struct dcesrv_call_state *dce_call,
 	r->out.result = MAPI_E_SUCCESS;
 
 	/* Search for an existing session, create if it doesn't exist */
-	session = dcesrv_find_emsmdb_session(&handle->wire_handle.uuid);
+	session = mpm_session_find_by_uuid(&handle->wire_handle.uuid);
 	if (!session) {
 		/* Step 7. Associate this emsmdbp context to the session */
-		session = talloc_zero(emsmdb_session, struct exchange_emsmdb_session);
+		session = mpm_session_init(dce_call, &handle->wire_handle.uuid);
 		OPENCHANGE_RETVAL_IF(!session, MAPI_E_NOT_ENOUGH_RESOURCES, emsmdbp_ctx);
 
-		session->pullTimeStamp = *r->out.pullTimeStamp;
-		session->session = mpm_session_init(session, dce_call);
-		OPENCHANGE_RETVAL_IF(!session->session, MAPI_E_NOT_ENOUGH_RESOURCES, emsmdbp_ctx);
+		mpm_session_set_private_data(session, (void *) emsmdbp_ctx);
+		mpm_session_set_destructor(session, emsmdbp_destructor);
 
-		session->uuid = handle->wire_handle.uuid;
-
-		mpm_session_set_private_data(session->session, (void *) emsmdbp_ctx);
-		mpm_session_set_destructor(session->session, emsmdbp_destructor);
-
-		OC_DEBUG(0, "[exchange_emsmdb]: New session added: %d\n", session->session->context_id);
-
-		DLIST_ADD_END(emsmdb_session, session, struct exchange_emsmdb_session *);
+		OC_DEBUG(0, "[exchange_emsmdb]: New session added: %d\n", session->context_id);
 	}
 
 	return MAPI_E_SUCCESS;
@@ -241,8 +219,7 @@ static enum MAPISTATUS dcesrv_EcDoDisconnect(struct dcesrv_call_state *dce_call,
 					     struct EcDoDisconnect *r)
 {
 	struct dcesrv_handle		*h;
-	struct exchange_emsmdb_session	*session;
-	bool				ret;
+	struct mpm_session		*session;
 
 	OC_DEBUG(3, "exchange_emsmdb: EcDoDisconnect (0x1)\n");
 
@@ -255,15 +232,9 @@ static enum MAPISTATUS dcesrv_EcDoDisconnect(struct dcesrv_call_state *dce_call,
 	/* Step 1. Retrieve handle and free if emsmdbp context and session are available */
 	h = dcesrv_handle_fetch(dce_call->context, r->in.handle, DCESRV_HANDLE_ANY);
 	if (h) {
-		session = dcesrv_find_emsmdb_session(&r->in.handle->uuid);
+		session = mpm_session_find_by_uuid(&r->in.handle->uuid);
 		if (session) {
-			ret = mpm_session_release(session->session);
-			if (ret == true) {
-				DLIST_REMOVE(emsmdb_session, session);
-				OC_DEBUG(5, "Session found and released\n");
-			} else {
-				OC_DEBUG(5, "Session found and ref_count decreased\n");
-			}
+			mpm_session_release(session);
 		} else {
 			OC_DEBUG(5, "  emsmdb_session NOT found\n");
 		}
@@ -957,7 +928,6 @@ static enum MAPISTATUS dcesrv_EcDoRpc(struct dcesrv_call_state *dce_call,
 				      TALLOC_CTX *mem_ctx,
 				      struct EcDoRpc *r)
 {
-	struct exchange_emsmdb_session	*session;
 	struct emsmdbp_context		*emsmdbp_ctx = NULL;
 	struct mapi_request		*mapi_request;
 	struct mapi_response		*mapi_response;
@@ -974,11 +944,8 @@ static enum MAPISTATUS dcesrv_EcDoRpc(struct dcesrv_call_state *dce_call,
 	}
 
 	/* Retrieve the emsmdbp_context from the session management system */
-        session = dcesrv_find_emsmdb_session(&r->in.handle->uuid);
-        if (session) {
-                emsmdbp_ctx = (struct emsmdbp_context *)session->session->private_data;
-	}
-	else {
+        emsmdbp_ctx = dcesrv_find_emsmdbp_context(&r->in.handle->uuid);
+        if (!emsmdbp_ctx) {
 		r->out.handle->handle_type = 0;
 		r->out.handle->uuid = GUID_zero();
 		r->out.result = DCERPC_FAULT_CONTEXT_MISMATCH;
@@ -1035,8 +1002,7 @@ static enum MAPISTATUS dcesrv_EcRRegisterPushNotification(struct dcesrv_call_sta
 							  struct EcRRegisterPushNotification *r)
 {
 	int				retval;
-	struct exchange_emsmdb_session	*session;
-	/* struct emsmdbp_context		*emsmdbp_ctx = NULL; */
+	struct emsmdbp_context		*emsmdbp_ctx = NULL;
 
 	OC_DEBUG(3, "exchange_emsmdb: EcRRegisterPushNotification (0x4)\n");
 
@@ -1049,10 +1015,8 @@ static enum MAPISTATUS dcesrv_EcRRegisterPushNotification(struct dcesrv_call_sta
 	}
 
 	/* Retrieve the emsmdbp_context from the session management system */
-	session = dcesrv_find_emsmdb_session(&r->in.handle->uuid);
-	if (session) {
-		/* emsmdbp_ctx = (struct emsmdbp_context *)session->session->private_data; */
-	} else {
+	emsmdbp_ctx = dcesrv_find_emsmdbp_context(&r->in.handle->uuid);
+	if (!emsmdbp_ctx) {
 		r->out.handle->handle_type = 0;
 		r->out.handle->uuid = GUID_zero();
 		r->out.result = DCERPC_FAULT_CONTEXT_MISMATCH;
@@ -1065,7 +1029,7 @@ static enum MAPISTATUS dcesrv_EcRRegisterPushNotification(struct dcesrv_call_sta
 		r->out.handle = r->in.handle;
 		/* FIXME: Create a notification object and return associated handle */
 		*r->out.hNotification = 244;
-	} 
+	}
 
 	return MAPI_E_SUCCESS;
 }
@@ -1184,10 +1148,10 @@ static enum MAPISTATUS dcesrv_EcDoConnectEx(struct dcesrv_call_state *dce_call,
 					    TALLOC_CTX *mem_ctx,
 					    struct EcDoConnectEx *r)
 {
+	struct mpm_session		*session;
 	struct emsmdbp_context		*emsmdbp_ctx;
 	struct dcesrv_handle		*handle;
 	struct policy_handle		wire_handle;
-	struct exchange_emsmdb_session	*session;
 	struct ldb_message		*msg;
 	const char			*mailNickname;
 	const char			*userDN;
@@ -1333,24 +1297,16 @@ static enum MAPISTATUS dcesrv_EcDoConnectEx(struct dcesrv_call_state *dce_call,
 	}
 
 	/* Search for an existing session, create if it doesn't exist */
-	session = dcesrv_find_emsmdb_session(&handle->wire_handle.uuid);
+	session = mpm_session_find_by_uuid(&handle->wire_handle.uuid);
 	if (!session) {
 		/* Step 7. Associate this emsmdbp context to the session */
-		session = talloc_zero(emsmdb_session, struct exchange_emsmdb_session);
+		session = mpm_session_init(dce_call, &handle->wire_handle.uuid);
 		OPENCHANGE_RETVAL_IF(!session, MAPI_E_NOT_ENOUGH_RESOURCES, emsmdbp_ctx);
 
-		session->pullTimeStamp = *r->out.pulTimeStamp;
-		session->session = mpm_session_init(session, dce_call);
-		OPENCHANGE_RETVAL_IF(!session->session, MAPI_E_NOT_ENOUGH_RESOURCES, emsmdbp_ctx);
-		
-		session->uuid = handle->wire_handle.uuid;
+		mpm_session_set_private_data(session, (void *) emsmdbp_ctx);
+		mpm_session_set_destructor(session, emsmdbp_destructor);
 
-		mpm_session_set_private_data(session->session, (void *) emsmdbp_ctx);
-		mpm_session_set_destructor(session->session, emsmdbp_destructor);
-
-		OC_DEBUG(0, "[exchange_emsmdb]: New session added: %d\n", session->session->context_id);
-
-		DLIST_ADD_END(emsmdb_session, session, struct exchange_emsmdb_session *);
+		OC_DEBUG(0, "[exchange_emsmdb]: New session added: %d\n", session->context_id);
 	}
 
 	return MAPI_E_SUCCESS;
@@ -1370,7 +1326,6 @@ static enum MAPISTATUS dcesrv_EcDoRpcExt2(struct dcesrv_call_state *dce_call,
 					  struct EcDoRpcExt2 *r)
 {
 	enum ndr_err_code		ndr_err;
-	struct exchange_emsmdb_session	*session;
 	struct emsmdbp_context		*emsmdbp_ctx = NULL;
 	struct mapi2k7_request		mapi2k7_request;
 	struct mapi_response		*mapi_response;
@@ -1400,14 +1355,13 @@ static enum MAPISTATUS dcesrv_EcDoRpcExt2(struct dcesrv_call_state *dce_call,
 	}
 
 	/* Retrieve the emsmdbp_context from the session management system */
-        session = dcesrv_find_emsmdb_session(&r->in.handle->uuid);
-	if (!session) {
+        emsmdbp_ctx = dcesrv_find_emsmdbp_context(&r->in.handle->uuid);
+	if (!emsmdbp_ctx) {
 		r->out.handle->handle_type = 0;
 		r->out.handle->uuid = GUID_zero();
 		r->out.result = DCERPC_FAULT_CONTEXT_MISMATCH;
 		return MAPI_E_LOGON_FAILED;
 	}
-	emsmdbp_ctx = (struct emsmdbp_context *)session->session->private_data;
 
 	/* Sanity checks on pcbOut input parameter */
 	if (*r->in.pcbOut < 0x00000008) {
@@ -1527,7 +1481,6 @@ static enum MAPISTATUS dcesrv_EcDoAsyncConnectEx(struct dcesrv_call_state *dce_c
 						 TALLOC_CTX *mem_ctx,
 						 struct EcDoAsyncConnectEx *r)
 {
-	struct exchange_emsmdb_session	*session;
 	enum mapistore_error		retval;
 	struct emsmdbp_context		*emsmdbp_ctx;
 	struct dcesrv_handle		*handle;
@@ -1563,10 +1516,8 @@ static enum MAPISTATUS dcesrv_EcDoAsyncConnectEx(struct dcesrv_call_state *dce_c
 	}
 
 	/* Step 1. Retrieve the existing session */
-	session = dcesrv_find_emsmdb_session(&r->in.handle->uuid);
-	if (session) {
-		emsmdbp_ctx = (struct emsmdbp_context *) session->session->private_data;
-	} else {
+	emsmdbp_ctx = dcesrv_find_emsmdbp_context(&r->in.handle->uuid);
+	if (!emsmdbp_ctx) {
 		OC_DEBUG(0, "[EcDoAsyncConnectEx]: emsmdb session not found");
 		r->out.async_handle->handle_type = 0;
 		r->out.async_handle->uuid = GUID_zero();
@@ -1690,11 +1641,6 @@ static NTSTATUS dcesrv_exchange_emsmdb_dispatch(struct dcesrv_call_state *dce_ca
  */
 static NTSTATUS dcesrv_exchange_emsmdb_init(struct dcesrv_context *dce_ctx)
 {
-	/* Initialize exchange_emsmdb session */
-	emsmdb_session = talloc_zero(dce_ctx, struct exchange_emsmdb_session);
-	if (!emsmdb_session) return NT_STATUS_NO_MEMORY;
-	emsmdb_session->session = NULL;
-
 	/* Open read/write context on OpenChange dispatcher database */
 	openchange_db_ctx = emsmdbp_openchangedb_init(dce_ctx->lp_ctx);
 	if (!openchange_db_ctx) {

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
@@ -33,7 +33,6 @@
 #include "mapiproxy/libmapiserver/libmapiserver.h"
 #include "dcesrv_exchange_emsmdb.h"
 
-struct exchange_emsmdb_session		*emsmdb_session = NULL;
 void					*openchange_db_ctx = NULL;
 
 

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.c
@@ -218,26 +218,12 @@ static enum MAPISTATUS dcesrv_EcDoDisconnect(struct dcesrv_call_state *dce_call,
 					     TALLOC_CTX *mem_ctx,
 					     struct EcDoDisconnect *r)
 {
-	struct dcesrv_handle		*h;
-	struct mpm_session		*session;
-
 	OC_DEBUG(3, "exchange_emsmdb: EcDoDisconnect (0x1)\n");
 
 	/* Step 0. Ensure incoming user is authenticated */
 	if (!dcesrv_call_authenticated(dce_call)) {
 		OC_DEBUG(1, "No challenge requested by client, cannot authenticate\n");
 		return MAPI_E_LOGON_FAILED;
-	}
-
-	/* Step 1. Retrieve handle and free if emsmdbp context and session are available */
-	h = dcesrv_handle_fetch(dce_call->context, r->in.handle, DCESRV_HANDLE_ANY);
-	if (h) {
-		session = mpm_session_find_by_uuid(&r->in.handle->uuid);
-		if (session) {
-			mpm_session_release(session);
-		} else {
-			OC_DEBUG(5, "  emsmdb_session NOT found\n");
-		}
 	}
 
 	r->out.handle->handle_type = 0;
@@ -1670,20 +1656,7 @@ static NTSTATUS dcesrv_exchange_emsmdb_unbind(struct server_id server_id, uint32
 	/* bool ret; */
 
 	OC_DEBUG(0, "dcesrv_exchange_emsmdb_unbind: server_id=%d, context_id=0x%x", server_id, context_id);
-
-	/* session = dcesrv_find_emsmdb_session_by_server_id(&server_id, context_id); */
-	/* if (session) { */
-	/* 	ret = mpm_session_release(session->session); */
-	/* 	if (ret == true) { */
-	/* 		DLIST_REMOVE(emsmdb_session, session); */
-	/* 		OC_DEBUG(5, ("[%s:%d]: Session found and released\n",  */
-	/* 			  __FUNCTION__, __LINE__)); */
-	/* 	} else { */
-	/* 		OC_DEBUG(5, ("[%s:%d]: Session found and ref_count decreased\n", */
-	/* 			  __FUNCTION__, __LINE__)); */
-	/* 	} */
-	/* } */
-
+	mpm_session_unbind(&server_id, context_id);
 	return NT_STATUS_OK;
 }
 

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
@@ -4,6 +4,7 @@
    OpenChange Project
 
    Copyright (C) Julien Kerihuel 2009-2010
+   Copyright (C) Carlos Pérez-Aradros Herce 2015
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -58,14 +59,6 @@ struct emsmdbp_context {
 
 	TALLOC_CTX				*mem_ctx;
 	struct GUID				session_uuid;
-};
-
-struct exchange_emsmdb_session {
-	uint32_t			pullTimeStamp;
-	struct mpm_session		*session;
-        struct GUID                     uuid;
-	struct exchange_emsmdb_session	*prev;
-	struct exchange_emsmdb_session	*next;
 };
 
 struct emsmdbp_stream {

--- a/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
+++ b/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
@@ -4,6 +4,7 @@
    OpenChange Project
 
    Copyright (C) Julien Kerihuel 2009-2013
+   Copyright (C) Carlos Pérez-Aradros Herce 2015
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -155,12 +156,9 @@ static void dcesrv_NspiBind(struct dcesrv_call_state *dce_call,
 	*r->out.handle = handle->wire_handle;
 	r->out.mapiuid = guid;
 
-	/* Search for an existing session and increment ref_count, otherwise create it */
+	/* Search for an existing session, create if it doesn't exist */
 	session = dcesrv_find_nsp_session(&handle->wire_handle.uuid);
-	if (session) {
-		mpm_session_increment_ref_count(session->session);
-		OC_DEBUG(5, "  [unexpected]: existing nsp_session: %p; session: %p (ref++)", session, session->session);
-	} else {
+	if (!session) {
 		OC_DEBUG(5, "Creating new session");
 
 		/* Step 6. Associate this emsabp context to the session */

--- a/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
+++ b/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.c
@@ -30,30 +30,17 @@
 #include "mapiproxy/libmapiproxy/fault_util.h"
 #include "dcesrv_exchange_nsp.h"
 
-static struct exchange_nsp_session	*nsp_session = NULL;
 static TDB_CONTEXT			*emsabp_tdb_ctx = NULL;
 
-static struct exchange_nsp_session *dcesrv_find_nsp_session(struct GUID *uuid)
-{
-	struct exchange_nsp_session *session, *found_session = NULL;
-
-	for (session = nsp_session; !found_session && session; session = session->next) {
-		if (GUID_equal(uuid, &session->uuid)) {
-			found_session = session;
-		}
-	}
-
-	return found_session;
-}
 
 static struct emsabp_context *dcesrv_find_emsabp_context(struct GUID *uuid)
 {
-	struct exchange_nsp_session	*session;
-	struct emsabp_context		*emsabp_ctx = NULL;
+	struct mpm_session	*session;
+	struct emsabp_context	*emsabp_ctx = NULL;
 
-	session = dcesrv_find_nsp_session(uuid);
+	session = mpm_session_find_by_uuid(uuid);
 	if (session) {
-		emsabp_ctx = (struct emsabp_context *)session->session->private_data;;
+		emsabp_ctx = (struct emsabp_context *)session->private_data;
 	}
 
 	return emsabp_ctx;
@@ -106,7 +93,7 @@ static void dcesrv_NspiBind(struct dcesrv_call_state *dce_call,
 	struct emsabp_context		*emsabp_ctx;
 	struct dcesrv_handle		*handle;
 	struct policy_handle		wire_handle;
-	struct exchange_nsp_session	*session;
+	struct mpm_session		*session;
 	enum MAPISTATUS			retval = MAPI_E_SUCCESS;
 
 	OC_DEBUG(5, "exchange_nsp: NspiBind (0x0)\n");
@@ -157,23 +144,16 @@ static void dcesrv_NspiBind(struct dcesrv_call_state *dce_call,
 	r->out.mapiuid = guid;
 
 	/* Search for an existing session, create if it doesn't exist */
-	session = dcesrv_find_nsp_session(&handle->wire_handle.uuid);
+	session = mpm_session_find_by_uuid(&handle->wire_handle.uuid);
 	if (!session) {
 		OC_DEBUG(5, "Creating new session");
 
 		/* Step 6. Associate this emsabp context to the session */
-		session = talloc((TALLOC_CTX *)nsp_session, struct exchange_nsp_session);
+		session = mpm_session_init(dce_call, &handle->wire_handle.uuid);
 		DCESRV_NSP_RETURN_IF(!session, r, MAPI_E_NOT_ENOUGH_RESOURCES, emsabp_ctx);
 
-		session->session = mpm_session_init((TALLOC_CTX *)nsp_session, dce_call);
-		DCESRV_NSP_RETURN_IF(!session->session, r, MAPI_E_NOT_ENOUGH_RESOURCES, emsabp_ctx);
-
-		session->uuid = handle->wire_handle.uuid;
-
-		mpm_session_set_private_data(session->session, (void *) emsabp_ctx);
-		mpm_session_set_destructor(session->session, emsabp_destructor);
-
-		DLIST_ADD_END(nsp_session, session, struct exchange_nsp_session *);
+		mpm_session_set_private_data(session, (void *) emsabp_ctx);
+		mpm_session_set_destructor(session, emsabp_destructor);
 	}
 
 	DCESRV_NSP_RETURN(r, MAPI_E_SUCCESS, NULL);
@@ -200,7 +180,7 @@ static void dcesrv_NspiUnbind(struct dcesrv_call_state *dce_call,
 			      TALLOC_CTX *mem_ctx, struct NspiUnbind *r)
 {
 	struct dcesrv_handle		*h;
-	struct exchange_nsp_session	*session;
+	struct mpm_session		*session;
 
 	OC_DEBUG(5, "exchange_nsp: NspiUnbind (0x1)\n");
 
@@ -213,14 +193,9 @@ static void dcesrv_NspiUnbind(struct dcesrv_call_state *dce_call,
 	/* Step 1. Retrieve handle and free if emsabp context and session are available */
 	h = dcesrv_handle_fetch(dce_call->context, r->in.handle, DCESRV_HANDLE_ANY);
 	if (h) {
-		session = dcesrv_find_nsp_session(&r->in.handle->uuid);
+		session = mpm_session_find_by_uuid(&r->in.handle->uuid);
 		if (session) {
-			if (mpm_session_release(session->session)) {
-				DLIST_REMOVE(nsp_session, session);
-				OC_DEBUG(5, "Session found and released\n");
-			} else {
-				OC_DEBUG(5, "Session found and ref_count decreased\n");
-			}
+			mpm_session_release(session);
 		}
 		else {
 			OC_DEBUG(5, "  nsp_session NOT found\n");
@@ -1604,10 +1579,6 @@ static NTSTATUS dcesrv_exchange_nsp_dispatch(struct dcesrv_call_state *dce_call,
 static NTSTATUS dcesrv_exchange_nsp_init(struct dcesrv_context *dce_ctx)
 {
 	OC_DEBUG(0, "dcesrv_exchange_nsp_init");
-	/* Initialize exchange_nsp session */
-	nsp_session = talloc_zero(dce_ctx, struct exchange_nsp_session);
-	if (!nsp_session) return NT_STATUS_NO_MEMORY;
-	nsp_session->session = NULL;
 
 	/* Open a read-write pointer on the EMSABP TDB database */
 	emsabp_tdb_ctx = emsabp_tdb_init((TALLOC_CTX *)dce_ctx, dce_ctx->lp_ctx);

--- a/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.h
+++ b/mapiproxy/servers/default/nspi/dcesrv_exchange_nsp.h
@@ -4,6 +4,7 @@
    OpenChange Project
 
    Copyright (C) Julien Kerihuel 2009
+   Copyright (C) Carlos Pérez-Aradros Herce 2015
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -49,13 +50,6 @@ struct emsabp_context {
 	TDB_CONTEXT		*tdb_ctx;
 	TDB_CONTEXT		*ttdb_ctx;
 	TALLOC_CTX		*mem_ctx;
-};
-
-struct exchange_nsp_session {
-	struct mpm_session		*session;
-	struct GUID			uuid;
-	struct exchange_nsp_session	*prev;
-	struct exchange_nsp_session	*next;
 };
 
 struct emsabp_MId {


### PR DESCRIPTION
This PR unifies session handling (under mpm_session) for nspi, emsmdb and asyncemsmdb.

After researching on RPC sessions, along with @blaxter, we decided to implement session releasing this way:

 * When a session is created, it's assigned to the server_id, context_id it was created on
 * On unbind, server_id, context_id pair is marked as released
 * When all user contexts are marked as released, underlying sessions are released too

This will ensure that we don't free a session that would be reused on a server_id, context_id different from the one it was created on (and that happens on common clients). Delaying session freeing to the last channel close.
