### PR TITLE
OpenChangeDB logger backend minor improvements + fixing compilation warnings

### DIFF
--- a/mapiproxy/libmapiproxy/backends/openchangedb_logger.c
+++ b/mapiproxy/libmapiproxy/backends/openchangedb_logger.c
@@ -330,8 +330,9 @@ static enum MAPISTATUS get_new_changeNumber(struct openchangedb_context *self,
 	OC_DEBUG(priv_data->log_level, "%s[in]: username=[%s]",
 					priv_data->log_prefix, username);
 	retval = priv_data->backend->get_new_changeNumber(priv_data->backend, username, cn);
-	OC_DEBUG(priv_data->log_level, "%s[out]: retval=[%s]",
-					priv_data->log_prefix, mapi_get_errstr(retval));
+	OC_DEBUG(priv_data->log_level, "%s[out]: retval=[%s] cn=[0x%016"PRIx64"]",
+		 priv_data->log_prefix, mapi_get_errstr(retval),
+		 (retval == MAPI_E_SUCCESS) ? *cn : 0);
 
 	return retval;
 }
@@ -348,8 +349,9 @@ static enum MAPISTATUS get_new_changeNumbers(struct openchangedb_context *self,
 	OC_DEBUG(priv_data->log_level, "%s[in]: username=[%s], max=[0x%016"PRIx64"]",
 				     priv_data->log_prefix, username, max);
 	retval = priv_data->backend->get_new_changeNumbers(priv_data->backend, mem_ctx, username, max, cns_p);
-	OC_DEBUG(priv_data->log_level, "%s[out]: retval=[%s]",
-				     priv_data->log_prefix, mapi_get_errstr(retval));
+	OC_DEBUG(priv_data->log_level, "%s[out]: retval=[%s] last_cn=[0x%016"PRIx64"]",
+		 priv_data->log_prefix, mapi_get_errstr(retval),
+		 (retval == MAPI_E_SUCCESS) ? (*cns_p)->lpui8[max - 1] : 0);
 
 	return retval;
 }

--- a/testsuite/libmapiproxy/openchangedb_multitenancy.c
+++ b/testsuite/libmapiproxy/openchangedb_multitenancy.c
@@ -1,3 +1,24 @@
+/*
+   OpenChange Unit Testing
+
+   OpenChange Project
+
+   Copyright (C) Jesus García 2013-2014
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "testsuite.h"
 #include "testsuite_common.h"
 #include "mapiproxy/libmapiproxy/libmapiproxy.h"
@@ -1410,8 +1431,8 @@ START_TEST (test_build_table_folders_live_filtering) {
 	enum MAPITAGS prop;
 	uint32_t i;
 	struct mapi_SRestriction res;
-	int ok = 0, bad = 0, idx;
-	int ok_2 = 0, bad_2 = 0, idx_2;
+	int ok = 0, bad = 0, idx = 0;
+	int ok_2 = 0, bad_2 = 0, idx_2 = 0;
 
 	fid = 17438782182108692481ul;
 	ret = openchangedb_table_init(g_mem_ctx, g_oc_ctx, USER1, 1, fid, &table);


### PR DESCRIPTION
* Implement missing unit tests for openchangedb_logger unittest.
* Avoid compilation warnings in openchangedb_multitenancy unittest + COPYRIGHT note
* Print out the change number returned value for `get_new_changeNumber` and `get_new_changeNumbers` for easing debugging purposes.