### PR TITLE
Out of office messages with non-ascii characters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 
 ### Fixes
 
+* Out of office message supports non-ascii characters
 * Support notifications when the username is a mail address (e.g. Zentyal Cloud)
 * Open a shared calendar from address list in Outlook 2013
 * Send event invitation mails to several attendees, mixing internal and external recipients

--- a/mapiproxy/services/ocsmanager/ocsmanager/controllers/oof.py
+++ b/mapiproxy/services/ocsmanager/ocsmanager/controllers/oof.py
@@ -351,7 +351,7 @@ class OofHandler(object):
         try:
             self.check_mailbox(mailbox)
         except Exception as e:
-            log.error(e)
+            log.exception(e)
             fault_element = self._fault_element_from_exception(e)
             body_element.append(fault_element)
             return self._response_string(envelope_element)
@@ -398,6 +398,7 @@ class OofHandler(object):
         try:
             self.check_mailbox(mailbox)
         except Exception as e:
+            log.exception(e)
             fault_element = self._fault_element_from_exception(e)
             body_element.append(fault_element)
             return self._response_string(envelope_element)
@@ -423,6 +424,7 @@ class OofHandler(object):
             oof.from_xml(settings_element)
             oof.to_sieve(mailbox)
         except Exception as e:
+            log.exception(e)
             response_message_element.set('ResponseClass', 'Error')
             response_code_element.text = 'ErrorInvalidParameter'
             message_text = Element('MessageText')

--- a/mapiproxy/services/ocsmanager/ocsmanager/controllers/oof.py
+++ b/mapiproxy/services/ocsmanager/ocsmanager/controllers/oof.py
@@ -683,7 +683,7 @@ class OofSettings(object):
         if self._config['internal_reply_message'] is not None:
             MessageInternal = Element("Message")
             MessageInternal.text = base64.b64decode(
-                self._config['internal_reply_message'])
+                self._config['internal_reply_message']).decode('utf8')
             InternalReply.append(MessageInternal)
 
         ExternalReply = Element("ExternalReply")
@@ -692,7 +692,7 @@ class OofSettings(object):
         if self._config['external_reply_message'] is not None:
             MessageExternal = Element("Message")
             MessageExternal.text = base64.b64decode(
-                self._config['external_reply_message'])
+                self._config['external_reply_message']).decode('utf8')
             ExternalReply.append(MessageExternal)
 
         AllowExternalOof = Element("AllowExternalOof")
@@ -817,8 +817,10 @@ class OofFileBackend(object):
         log.debug("SIEVE_PATH_SCRIPT %s" % sieve_script_path)
         (head, tail) = os.path.split(sieve_script_path)
         sinfo = os.stat(head)
+        if isinstance(script, unicode):
+            script = script.encode('utf8')
         with open(sieve_script_path, 'w') as f:
-            f.write(script.encode('utf8'))
+            f.write(script)
             os.chmod(sieve_script_path, 0755)
             os.chown(sieve_script_path, sinfo.st_uid, sinfo.st_gid)
 


### PR DESCRIPTION
Avoid encoding errors when settings and getting out of office state.