### PR TITLE
Improvements over SyncImportDeletes OXCFXICS ROP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 * File name and correct size in small sized attachments, and submit time are now sent
   by OpenChange client against OpenChange server
 * Avoid race condition uploading changes which made new objects be missed
+* Folder deletion using cached mode
 
 ### Performances
 * Optimize the download of contents when you were in the middle of the first synchronization process in a business size mailbox.

--- a/libmapi/FXICS.c
+++ b/libmapi/FXICS.c
@@ -1597,3 +1597,115 @@ _PUBLIC_ enum MAPISTATUS ICSSyncGetTransferState(mapi_object_t *obj, mapi_object
 
 	return MAPI_E_SUCCESS;
 }
+
+/**
+   \details Import message or folder deletions.
+
+   \param collector the ICS collector to use to upload changes
+   \param flags the sync import delete flags. Accepted values are in SyncImportDeletesFlags enum type
+   \param source_keys the GID array from which we import their deletions
+
+   \return MAPI_E_SUCCESS on success, otherwise MAPI error.
+
+   \note Developers may also call GetLastError() to retrieve the last
+   MAPI error code. Possible MAPI error codes are:
+   - MAPI_E_NOT_INITIALIZED: MAPI subsystem has not been initialized
+   - MAPI_E_INVALID_PARAMETER: one of the function parameters is
+     invalid
+   - MAPI_E_CALL_FAILED: A network problem was encountered during the
+   transaction
+   - MAPI_E_NOT_ENOUGH_MEMORY: If any dynamic memory allocated
+   did not succeed
+ */
+_PUBLIC_ enum MAPISTATUS SyncImportDeletes(mapi_object_t *collector,
+					   uint8_t flags,
+					   struct BinaryArray_r *source_keys)
+{
+	bool				       ret;
+	struct EcDoRpc_MAPI_REQ		       *mapi_req;
+	enum MAPISTATUS			       retval;
+	struct mapi_request		       *mapi_request;
+	struct mapi_response		       *mapi_response;
+	struct mapi_session		       *session;
+	struct mapi_SBinaryArray	       property_values;
+	struct mapi_SPropValue		       *lp_prop;
+	NTSTATUS			       status;
+	size_t				       i;
+	struct SyncImportDeletes_req	       request;
+	TALLOC_CTX			       *local_mem_ctx;
+	uint8_t				       logon_id = 0;
+	uint32_t			       size = 0;
+
+	/* Sanity checks */
+	OPENCHANGE_RETVAL_IF(!collector, MAPI_E_INVALID_PARAMETER, NULL);
+	OPENCHANGE_RETVAL_IF(!source_keys, MAPI_E_INVALID_PARAMETER, NULL);
+	OPENCHANGE_RETVAL_IF(source_keys->cValues < 1, MAPI_E_INVALID_PARAMETER, NULL);
+
+	session = mapi_object_get_session(collector);
+	OPENCHANGE_RETVAL_IF(!session, MAPI_E_INVALID_PARAMETER, NULL);
+
+	if ((retval = mapi_object_get_logon_id(collector, &logon_id)) != MAPI_E_SUCCESS) {
+		return retval;
+	}
+
+	local_mem_ctx = talloc_new(session);
+	OPENCHANGE_RETVAL_IF(!local_mem_ctx, MAPI_E_NOT_ENOUGH_MEMORY, NULL);
+
+	/* Fill the SyncImportDeletes operation */
+	request.Flags = flags;
+	size += sizeof(uint8_t);
+	request.PropertyValues.cValues = 1;
+	size += sizeof(uint16_t);
+
+	property_values.cValues = source_keys->cValues;
+	size += sizeof(uint32_t);
+	property_values.bin = talloc_zero_array(local_mem_ctx, struct SBinary_short, source_keys->cValues);
+	OPENCHANGE_RETVAL_IF(!property_values.bin, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+
+	for (i = 0; i < property_values.cValues; i++) {
+		property_values.bin[i].cb = (uint16_t)source_keys->lpbin[i].cb;
+		size += sizeof(uint16_t);
+		property_values.bin[i].lpb = source_keys->lpbin[i].lpb;
+		size += source_keys->lpbin[i].cb;
+	}
+
+	lp_prop = talloc_zero(local_mem_ctx, struct mapi_SPropValue);
+	OPENCHANGE_RETVAL_IF(!lp_prop, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+	size += sizeof(uint32_t);
+
+	ret = set_mapi_SPropValue_proptag(local_mem_ctx, lp_prop,
+					  PT_MV_BINARY, (const void*)&property_values);
+	OPENCHANGE_RETVAL_IF(!ret, MAPI_E_CALL_FAILED, local_mem_ctx);
+	request.PropertyValues.lpProps = lp_prop;
+
+	/* Fill the MAPI_REQ structure */
+	mapi_req = talloc_zero(local_mem_ctx, struct EcDoRpc_MAPI_REQ);
+	OPENCHANGE_RETVAL_IF(!mapi_req, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+	mapi_req->opnum = op_MAPI_SyncImportDeletes;
+	mapi_req->logon_id = logon_id;
+	mapi_req->handle_idx = 0;
+	mapi_req->u.mapi_SyncImportDeletes = request;
+	size += 5;
+
+	/* Fill the mapi_request structure */
+	mapi_request = talloc_zero(local_mem_ctx, struct mapi_request);
+	OPENCHANGE_RETVAL_IF(!mapi_request, MAPI_E_NOT_ENOUGH_MEMORY, local_mem_ctx);
+	mapi_request->mapi_len = size + sizeof (uint32_t) * 2;
+	mapi_request->length = (uint16_t)size;
+	mapi_request->mapi_req = mapi_req;
+	mapi_request->handles = talloc_array(local_mem_ctx, uint32_t, 2);
+	OPENCHANGE_RETVAL_IF(!mapi_request->handles, MAPI_E_NOT_ENOUGH_MEMORY,
+			     local_mem_ctx);
+	mapi_request->handles[0] = mapi_object_get_handle(collector);
+	mapi_request->handles[1] = 0xFFFFFFFF;
+
+	status = emsmdb_transaction_wrapper(session, local_mem_ctx, mapi_request, &mapi_response);
+	OPENCHANGE_RETVAL_IF(!NT_STATUS_IS_OK(status), MAPI_E_CALL_FAILED, local_mem_ctx);
+	OPENCHANGE_RETVAL_IF(!mapi_response->mapi_repl, MAPI_E_CALL_FAILED, local_mem_ctx);
+	retval = mapi_response->mapi_repl->error_code;
+
+	talloc_free(mapi_response);
+	talloc_free(local_mem_ctx);
+
+	return retval;
+}

--- a/libmapi/libmapi.h
+++ b/libmapi/libmapi.h
@@ -494,6 +494,7 @@ enum MAPISTATUS		ICSSyncUploadStateEnd(mapi_object_t *);
 enum MAPISTATUS		SetLocalReplicaMidsetDeleted(mapi_object_t *, const struct GUID, const uint8_t GlobalCountLow[6], const uint8_t GlobalCountHigh[6]);
 enum MAPISTATUS		ICSSyncOpenCollector(mapi_object_t *, bool, mapi_object_t *);
 enum MAPISTATUS		ICSSyncGetTransferState(mapi_object_t *, mapi_object_t *);
+enum MAPISTATUS		SyncImportDeletes(mapi_object_t *, uint8_t, struct BinaryArray_r *);
 
 /* The following public definitions come from libmapi/freebusy.c */
 enum MAPISTATUS		GetUserFreeBusyData(mapi_object_t *, const char *, struct SRow *);

--- a/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
+++ b/mapiproxy/servers/default/emsmdb/dcesrv_exchange_emsmdb.h
@@ -338,6 +338,7 @@ enum mapistore_error  emsmdbp_object_get_fid_by_name(struct emsmdbp_context *, s
 enum MAPISTATUS       emsmdbp_object_create_folder(struct emsmdbp_context *, struct emsmdbp_object *, TALLOC_CTX *, uint64_t, struct SRow *, bool, struct emsmdbp_object **);
 enum mapistore_error  emsmdbp_object_open_folder(TALLOC_CTX *, struct emsmdbp_context *, struct emsmdbp_object *, uint64_t, struct emsmdbp_object **);
 enum MAPISTATUS       emsmdbp_object_open_folder_by_fid(TALLOC_CTX *, struct emsmdbp_context *, struct emsmdbp_object *, uint64_t, struct emsmdbp_object **);
+enum MAPISTATUS       emsmdbp_object_open_folder_by_child_fid(TALLOC_CTX *, struct emsmdbp_context *, struct emsmdbp_object *, uint64_t, struct emsmdbp_object **);
 
 struct emsmdbp_object *emsmdbp_object_init(TALLOC_CTX *, struct emsmdbp_context *, struct emsmdbp_object *parent_object);
 int emsmdbp_object_copy_properties(struct emsmdbp_context *, struct emsmdbp_object *, struct emsmdbp_object *, struct SPropTagArray *, bool);

--- a/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
+++ b/mapiproxy/servers/default/emsmdb/emsmdbp_object.c
@@ -596,7 +596,7 @@ end:
 }
 
 /**
-   \details Return the folder object associated to specified folder identified
+   \details Return the folder object associated to specified folder identifier
 
    \param mem_ctx pointer to the memory context
    \param emsmdbp_ctx pointer to the emsmdbp context
@@ -652,6 +652,45 @@ _PUBLIC_ enum MAPISTATUS emsmdbp_object_open_folder_by_fid(TALLOC_CTX *mem_ctx,
 			*folder_object_p = emsmdbp_object_folder_init(mem_ctx, emsmdbp_ctx, fid, NULL);
 			return MAPI_E_SUCCESS;
 		}
+	}
+
+	return retval;
+}
+
+/**
+   \details Return the folder object associated to the parent of the
+   specified folder identifier
+
+   \param mem_ctx pointer to the memory context where parent_folder_object_p will be allocated
+   \param emsmdbp_ctx pointer to the emsmdbp context
+   \param context_object pointer to current context object
+   \param fid pointer to the Folder Identifier to lookup its parent
+   \param [out] parent_folder_object_p location to store emsmdbp object on success
+
+   \return MAPISTATUS error code
+ */
+
+_PUBLIC_ enum MAPISTATUS emsmdbp_object_open_folder_by_child_fid(TALLOC_CTX *mem_ctx,
+								 struct emsmdbp_context *emsmdbp_ctx,
+								 struct emsmdbp_object *context_object,
+								 uint64_t fid,
+								 struct emsmdbp_object **parent_folder_object_p)
+{
+	uint64_t		parent_fid;
+	enum MAPISTATUS		retval;
+	struct emsmdbp_object	*mailbox_object;
+
+	/* Sanity checks */
+	OPENCHANGE_RETVAL_IF(!mem_ctx, MAPI_E_INVALID_PARAMETER, NULL);
+	OPENCHANGE_RETVAL_IF(!emsmdbp_ctx, MAPI_E_INVALID_PARAMETER, NULL);
+	OPENCHANGE_RETVAL_IF(!context_object, MAPI_E_INVALID_PARAMETER, NULL);
+	OPENCHANGE_RETVAL_IF(!parent_folder_object_p, MAPI_E_INVALID_PARAMETER, NULL);
+
+	mailbox_object = emsmdbp_get_mailbox(context_object);
+	retval = emsmdbp_get_parent_fid(emsmdbp_ctx, mailbox_object, fid, &parent_fid);
+	if (retval == MAPI_E_SUCCESS) {
+		retval = emsmdbp_object_open_folder_by_fid(mem_ctx, emsmdbp_ctx, context_object, parent_fid,
+							   parent_folder_object_p);
 	}
 
 	return retval;

--- a/mapiproxy/servers/default/emsmdb/oxcfxics.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfxics.c
@@ -2525,6 +2525,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncImportDeletes(TALLOC_CTX *mem_ctx,
 	enum MAPISTATUS				retval;
 	struct mapi_handles			*synccontext_object_handle = NULL;
 	struct emsmdbp_object			*synccontext_object = NULL;
+	struct emsmdbp_object			*parent_folder = NULL;
 	uint32_t				synccontext_handle_id;
 	void					*data;
 	struct SyncImportDeletes_req		*request;
@@ -2538,6 +2539,7 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncImportDeletes(TALLOC_CTX *mem_ctx,
 	uint8_t					delete_type;
 	uint32_t				i;
 	int						ret;
+	TALLOC_CTX				*local_mem_ctx;
 
 	OC_DEBUG(4, "exchange_emsmdb: [OXCFXICS] SyncImportDeletes (0x74)\n");
 
@@ -2583,7 +2585,13 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncImportDeletes(TALLOC_CTX *mem_ctx,
 
 	object_array = &request->PropertyValues.lpProps[0].value.MVbin;
 
-	object_ids = talloc_zero_array(synccontext_object, uint64_t, object_array->cValues);
+	local_mem_ctx = talloc_new(NULL);
+	if (!local_mem_ctx) {
+		mapi_repl->error_code = MAPI_E_NOT_ENOUGH_MEMORY;
+		goto end;
+	}
+
+	object_ids = talloc_zero_array(local_mem_ctx, uint64_t, object_array->cValues);
 	if (!object_ids) {
 		mapi_repl->error_code = MAPI_E_NOT_ENOUGH_MEMORY;
 		goto end;
@@ -2593,8 +2601,22 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncImportDeletes(TALLOC_CTX *mem_ctx,
 		for (i = 0; i < object_array->cValues; i++) {
 			ret = oxcfxics_fmid_from_source_key(emsmdbp_ctx, owner, object_array->bin + i, &objectID);
 			if (ret == MAPISTORE_SUCCESS) {
-				emsmdbp_folder_delete(emsmdbp_ctx, synccontext_object->parent_object, objectID, 0xff);
-				object_ids[i] = objectID;
+				retval = emsmdbp_object_open_folder_by_child_fid(local_mem_ctx, emsmdbp_ctx,
+										 synccontext_object->parent_object, objectID,
+										 &parent_folder);
+				if (retval == MAPI_E_SUCCESS) {
+					/* HARD-DELETE is not managed by emsmdbp layer yet */
+					ret = emsmdbp_folder_delete(emsmdbp_ctx, parent_folder, objectID, DEL_MESSAGES | DEL_FOLDERS);
+					if (ret == MAPISTORE_SUCCESS) {
+						object_ids[i] = objectID;
+					} else {
+						OC_DEBUG(5, "folder deletion failed for fid: 0x%.16"PRIx64" %s",
+							 objectID, mapistore_errstr(ret));
+					}
+				} else {
+					OC_DEBUG(5, "open parent folder for delete fid 0x%.16"PRIx64" : %s",
+						 objectID, mapi_get_errstr(retval));
+				}
 			}
 		}
 	}
@@ -2634,8 +2656,8 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncImportDeletes(TALLOC_CTX *mem_ctx,
 	}
 
 end:
-	if (object_ids) {
-		talloc_free(object_ids);
+	if (local_mem_ctx) {
+		talloc_free(local_mem_ctx);
 	}
 
 	*size += libmapiserver_RopSyncImportDeletes_size(mapi_repl);

--- a/mapiproxy/servers/default/emsmdb/oxcfxics.c
+++ b/mapiproxy/servers/default/emsmdb/oxcfxics.c
@@ -2583,7 +2583,20 @@ _PUBLIC_ enum MAPISTATUS EcDoRpc_RopSyncImportDeletes(TALLOC_CTX *mem_ctx,
 	owner = emsmdbp_get_owner(synccontext_object);
 	openchangedb_get_MailboxReplica(emsmdbp_ctx->oc_ctx, owner, &repl_id, &replica_guid);
 
-	object_array = &request->PropertyValues.lpProps[0].value.MVbin;
+	/* Check PropertyValues is not NULL */
+	if (request->PropertyValues.cValues == 0) {
+		OC_DEBUG(1, "PropertyValues MUST be NOT null");
+		mapi_repl->error_code = MAPI_E_INVALID_PARAMETER;
+		goto end;
+	}
+
+	/* The object array is available at fixed 0 position */
+	object_array = (struct mapi_SBinaryArray *)get_mapi_SPropValue_data(&request->PropertyValues.lpProps[0]);
+	if (!object_array) {
+		OC_DEBUG(1, "The object array to delete must be in a MultipleBinary property");
+		mapi_repl->error_code = MAPI_E_INVALID_PARAMETER;
+		goto end;
+	}
 
 	local_mem_ctx = talloc_new(NULL);
 	if (!local_mem_ctx) {

--- a/utils/mapitest/module.c
+++ b/utils/mapitest/module.c
@@ -389,6 +389,8 @@ _PUBLIC_ uint32_t module_oxcfxics_init(struct mapitest *mt)
 	mapitest_suite_add_test(suite, "SYNC-CONFIGURE-CONTENTS", "Configure ICS contents context for download", mapitest_oxcfxics_SyncConfigureContents);
 	mapitest_suite_add_test(suite, "SET-LOCAL-REPLICA-MIDSET-DELETED", "Reserve a range of local replica IDs", mapitest_oxcfxics_SetLocalReplicaMidsetDeleted);
 	mapitest_suite_add_test(suite, "SYNC-OPEN-COLLECTOR", "Test opening ICS upload collector", mapitest_oxcfxics_SyncOpenCollector);
+	mapitest_suite_add_test(suite, "SYNC-IMPORT-MSG-DELETES", "Test import message deletions", mapitest_oxcfxics_SyncImportDeletesMsg);
+	mapitest_suite_add_test(suite, "SYNC-IMPORT-FOLDER-DELETES", "Test import folder deletions", mapitest_oxcfxics_SyncImportDeletesFolder);
 
 	mapitest_suite_register(mt, suite);
 


### PR DESCRIPTION
- Implement SyncImportDeletes operation in client side
  - Along with mapitest to test it
- Folder deletion on cached mode now works
  - It was only working if the folder was at INBOX's level
- Added additional checks on SyncImportDeletes
  - As suggested in #391 comment

It is based #391 to avoid later conflict resolution.
