### PR TITLE
nspi: added missing attributes mappings for telephone and location

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Unreleased changes refer to our current [master branch](https://github.com/openc
 
 ### Fixes
 
+* Telephone and location fields are now shown in the Global Address List
 * Rpcproxy handles client disconnections better
 * Out of office message supports non-ascii characters
 * Support notifications when the username is a mail address (e.g. Zentyal Cloud)

--- a/mapiproxy/servers/default/nspi/emsabp_property.c
+++ b/mapiproxy/servers/default/nspi/emsabp_property.c
@@ -9,12 +9,12 @@
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -57,6 +57,8 @@ static const struct emsabp_property emsabp_property[] = {
 	{ PidTagAddressBookObjectGuid,		"objectGUID",		false,	NULL			},
 	{ PidTagObjectType,			"msExchRecipientTypeDetails",		false,	NULL			},
 	{ PidTagDisplayType,			"msExchRecipientDisplayType",		false,	NULL			},
+	{ PidTagBusinessTelephoneNumber,	"telephoneNumber",	false,	NULL			},
+	{ PidTagOfficeLocation,			"physicalDeliveryOfficeName",	false,	NULL			},
 	{ 0,					NULL,			false,	NULL			}
 };
 
@@ -106,12 +108,12 @@ _PUBLIC_ const char *emsabp_property_get_attribute(uint32_t ulPropTag)
 	_map_proptag_to_unicode_ansi(ulPropTag, &ansiPropTag, &uniPropTag);
 
 	for (i = 0; emsabp_property[i].attribute; i++) {
-		if ((uniPropTag == emsabp_property[i].ulPropTag) || 
+		if ((uniPropTag == emsabp_property[i].ulPropTag) ||
 		    (ansiPropTag == emsabp_property[i].ulPropTag)) {
 			return emsabp_property[i].attribute;
 		}
 	}
-	
+
 	return NULL;
 }
 


### PR DESCRIPTION
With this change the relephone and location field are shown in the
global address list.