### PR TITLE
Log failure opening the backend store path

### DIFF
--- a/mapiproxy/libmapistore/mapistore_backend.c
+++ b/mapiproxy/libmapistore/mapistore_backend.c
@@ -181,6 +181,7 @@ static init_backend_fn *load_backends(TALLOC_CTX *mem_ctx, const char *path)
 
 	dir = opendir(path);
 	if (dir == NULL) {
+		OC_DEBUG(3, "Cannot open backend store path '%s': %s", path, strerror(errno));
 		talloc_free(ret);
 		return NULL;
 	}


### PR DESCRIPTION
Log a message if the backend store path cannot be opened. If the default
backend path is used, and it does not exist, you currently only get the
messages:

  (mapistore_backend_init): No mapistore backends available (using backend path '(null)'
  (mapistore_init): mapistore_backend_init: Storage backend initialization failed
  (emsmdbp_init): MAPISTORE initialization failed

It seems helpful to log exactly what goes wrong.
This would have saved me some time debugging.
