### PR TITLE
configure.ac: Include <string.h> for the strcmp function

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -142,6 +142,7 @@ fi[]
 AC_DEFUN([OC_CHECK_SAMBA_VERSION], [
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <samba/version.h>
+#include <string.h>
 int main() { if (!strcmp(SAMBA_VERSION_STRING, "$1") || !strcmp(SAMBA_VERSION_STRING, "$2")) {return 0; } else { return -1;} }
 ]])],[$3],[
 	ifelse([$4],[],[AC_MSG_WARN([The Samba4 version installed on your system doesn't meet OpenChange requirements ($1 or $2).])],[$4])],[$5])


### PR DESCRIPTION
Without this change, the OC_CHECK_SAMBA_VERSION configure check fails to compile with compilers which do not support implicit function declarations by default (a C language feature that was removed in 1999).

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
